### PR TITLE
Fix playback for YouTube Premium-only songs

### DIFF
--- a/build/release-notes.md
+++ b/build/release-notes.md
@@ -1,28 +1,4 @@
-## Orchard 3.0.0
-
-### Added
-- Smart Crossfade now uses cached native musical analysis for beat grids, downbeats, phrases, key, intro and outro timing, loudness, energy, and vocal density, then builds DJ-like transitions with eight-bar intro pre-rolls, audible incoming beds, phrase-long same-beat blends, confidence-aware matching, staged EQ handoffs, and track changes timed to musical dominance.
-- Typing while viewing an album or playlist now opens a track finder that jumps to the closest match after a short pause and stays open for navigation.
-- Queue items can now be removed individually from the right panel and fullscreen player.
-- Release Radar now automatically tracks Official Artist Channels subscribed to on YouTube instead of requiring a separate manual artist list.
-- Last.fm accounts can now be connected from Settings to send now-playing updates and scrobble eligible tracks through a credential-protected Worker.
-- Universal macOS builds are now available as unsigned zip downloads for Apple Silicon and Intel Macs.
-
-### Changed
-- Immersive backgrounds now use GPU-rendered ambient artwork, artwork-derived color motion, smooth track crossfades, and native animated artwork playback with HLS fallback.
-- Application identifiers, Linux desktop integration, internal media paths, package metadata, and share links now consistently use the `orchard` name.
-- Artists now shows Official Artist Channel subscriptions, Songs and Albums load saved YouTube Music library items, and Recently Played opens listening history instead of the Queue.
-- The Library shelf now appears first on Home, replacing the separate Top Picks for You row.
-- Electron, renderer, and native audio source now use explicit process and feature boundaries, with documented packaged-resource and IPC contracts.
-- Orchard is now available under the MIT License.
+## Orchard 3.0.1
 
 ### Fixed
-- YouTube history now obtains playback tracking anonymously and submits it with the browser account, avoiding rejected authenticated player requests.
-- Playback now keeps signed-in sessions intact and retries with the guest player client when YouTube rejects an authenticated player request with a credential-shaped 401 or 403 response.
-- Songs and Albums now load when YouTube Music returns its newer library layout.
-- Playback no longer remains locked in buffering after a stream stops, and replaying a failed stream now requests a fresh source.
-- YouTube Music sign-in now persists reliably when Orchard is closed and reopened.
-- Support reports can now be connected to GitHub so their public issues show the reporter as the author instead of an unknown Orchard user.
-- Best mix now orders songs from measured audio compatibility instead of grouping matching artists or albums, and leaves unanalyzed songs in place.
-- Smart Crossfade now recognizes strong later-song silence breaks as musical mix-out points, and its mix indicator reaches the end of the progress bar.
-- Previous now stays within the active playlist, walks backward through its tracks, and restarts the first song at the playlist boundary.
+- Premium-only songs now recognize YouTube's HE-AAC streams and retry with the signed-in browser account when another player identity omits entitled playback formats.

--- a/electron/playback/playbackFormats.js
+++ b/electron/playback/playbackFormats.js
@@ -1,6 +1,7 @@
 // Selects compatible YouTube audio/video formats from renderer capability hints.
 const fallbackMimePreference = [
   'audio/mp4; codecs="mp4a.40.2"',
+  'audio/mp4; codecs="mp4a.40.5"',
   'audio/webm; codecs="opus"',
   'audio/webm; codecs="vorbis"'
 ];
@@ -264,6 +265,8 @@ function formatMatchesMime(format, mime) {
 }
 
 export function chooseAudioFormatFromFormats(formats, supportedMimes = []) {
+  if (!formats.length) return undefined;
+
   const browserSupportedMimes = supportedMimes.filter((item) => item.support);
   const preferredMimes = [
     ...browserSupportedMimes,

--- a/electron/playback/playbackService.js
+++ b/electron/playback/playbackService.js
@@ -50,6 +50,30 @@ const upstreamFailureCooldownMs = 10 * 60_000;
 function formatMimeFamily(format) {
   return (format?.mime_type || format?.mimeType || '').split(';', 1)[0].trim().toLowerCase();
 }
+
+function directStreamingFormats(info = {}) {
+  const streamingData = info.streaming_data || info.streamingData || {};
+  return [
+    ...(streamingData.formats || []),
+    ...(streamingData.adaptive_formats || streamingData.adaptiveFormats || [])
+  ];
+}
+
+function requireDirectStreamingFormats(info) {
+  if (directStreamingFormats(info).length) return info;
+
+  const playability = info?.playability_status || info?.playabilityStatus || {};
+  const reason = playability.reason || '';
+  const status = playability.status || '';
+  const error = new Error(
+    reason ||
+    (status ? `YouTube returned ${status} without direct playback formats` : 'InnerTube returned no direct playback formats')
+  );
+  error.info = playability;
+  error.noStreamingFormats = true;
+  throw error;
+}
+
 function streamExpiresAt(url) { try { return Number(new URL(url).searchParams.get('expire')) * 1000 || Date.now() + 45 * 60_000; } catch { return Date.now() + 45 * 60_000; } }
 export function createPlaybackService({
   authState,
@@ -183,23 +207,44 @@ export function createPlaybackService({
     const browserYtPromise = getBrowserInnertube();
     const browserYt = preferBrowserAuth && browserYtPromise ? await browserYtPromise : null;
     const primaryYt = options.yt || browserYt || await getGuestInnertube();
-    const browserPlaybackOptions = hasBrowserLoginCookie()
+    const browserPlaybackOptions = () => hasBrowserLoginCookie()
       ? { poToken: authState.browser.poToken }
       : {};
 
     try {
       return {
         yt: primaryYt,
-        info: options.info || await basicPlaybackInfo(primaryYt, videoId, browserYt === primaryYt ? browserPlaybackOptions : {})
+        info: requireDirectStreamingFormats(
+          options.info || await basicPlaybackInfo(primaryYt, videoId, browserYt === primaryYt ? browserPlaybackOptions() : {})
+        )
       };
     } catch (error) {
-      const browserYt = browserYtPromise ? await browserYtPromise : null;
-      if (browserYt && primaryYt !== browserYt && isBotCheckPlaybackError(error)) {
-        pauseAndroidVrFallback(error);
+      let fallbackBrowserYt = browserYtPromise ? await browserYtPromise : null;
+      const shouldRetryBrowser = error.noStreamingFormats ||
+        isAgeGatePlaybackError(error) ||
+        isBotCheckPlaybackError(error);
+
+      if (error.noStreamingFormats && hasBrowserLoginCookie()) {
+        try {
+          await refreshBrowserAuth();
+          fallbackBrowserYt = await getBrowserInnertube() || fallbackBrowserYt;
+        } catch {
+          // The captured browser client can still recover if refreshing cookies fails.
+        }
+      }
+
+      if (
+        fallbackBrowserYt &&
+        shouldRetryBrowser &&
+        (primaryYt !== fallbackBrowserYt || error.noStreamingFormats)
+      ) {
+        if (primaryYt !== fallbackBrowserYt) pauseAndroidVrFallback(error);
         try {
           return {
-            yt: browserYt,
-            info: await basicPlaybackInfo(browserYt, videoId, browserPlaybackOptions)
+            yt: fallbackBrowserYt,
+            info: requireDirectStreamingFormats(
+              await basicPlaybackInfo(fallbackBrowserYt, videoId, browserPlaybackOptions())
+            )
           };
         } catch (browserError) {
           error = browserError;
@@ -210,7 +255,7 @@ export function createPlaybackService({
       if (primaryYt !== guestYt && canFallbackToGuest(error)) {
         return {
           yt: guestYt,
-          info: await basicPlaybackInfo(guestYt, videoId)
+          info: requireDirectStreamingFormats(await basicPlaybackInfo(guestYt, videoId))
         };
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "orchard",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "orchard",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@quasar/extras": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "orchard",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A Quasar, Vue, Socket.IO, Electron YouTube Music client backed by InnerTube.",
   "homepage": "https://github.com/sfg5453/orchard",
   "repository": {

--- a/src/app/core/state.js
+++ b/src/app/core/state.js
@@ -423,6 +423,7 @@ export function installState(ctx) {
   ];
   ctx.audioMimeCandidates = [
     'audio/mp4; codecs="mp4a.40.2"',
+    'audio/mp4; codecs="mp4a.40.5"',
     'audio/webm; codecs="opus"',
     'audio/webm; codecs="vorbis"'
   ];

--- a/src/data/changelog.js
+++ b/src/data/changelog.js
@@ -1,42 +1,12 @@
 export const ORCHARD_RELEASES = [
   {
-    version: '3.0.0',
-    codename: 'Copper Canopy',
-    date: 'July 18, 2026',
+    version: '3.0.1',
+    date: 'July 19, 2026',
     sections: [
-      {
-        title: 'Added',
-        items: [
-          'Smart Crossfade now uses cached native musical analysis for beat grids, downbeats, phrases, key, intro and outro timing, loudness, energy, and vocal density, then builds DJ-like transitions with eight-bar intro pre-rolls, audible incoming beds, phrase-long same-beat blends, confidence-aware matching, staged EQ handoffs, and track changes timed to musical dominance.',
-          'Typing while viewing an album or playlist now opens a track finder that jumps to the closest match after a short pause and stays open for navigation.',
-          'Queue items can now be removed individually from the right panel and fullscreen player.',
-          'Release Radar now automatically tracks Official Artist Channels subscribed to on YouTube instead of requiring a separate manual artist list.',
-          'Last.fm accounts can now be connected from Settings to send now-playing updates and scrobble eligible tracks through a credential-protected Worker.',
-          'Universal macOS builds are now available as unsigned zip downloads for Apple Silicon and Intel Macs.'
-        ]
-      },
-      {
-        title: 'Changed',
-        items: [
-          'Immersive backgrounds now use GPU-rendered ambient artwork, artwork-derived color motion, smooth track crossfades, and native animated artwork playback with HLS fallback.',
-          'Artists now shows Official Artist Channel subscriptions, Songs and Albums load saved YouTube Music library items, and Recently Played opens listening history instead of the Queue.',
-          'The Library shelf now appears first on Home, replacing the separate Top Picks for You row.',
-          'Electron, renderer, and native audio source now use explicit process and feature boundaries, with documented packaged-resource and IPC contracts.',
-          'Orchard is now available under the MIT License.'
-        ]
-      },
       {
         title: 'Fixed',
         items: [
-          'YouTube history now obtains playback tracking anonymously and submits it with the browser account, avoiding rejected authenticated player requests.',
-          'Playback now keeps signed-in sessions intact and retries with the guest player client when YouTube rejects an authenticated player request with a credential-shaped 401 or 403 response.',
-          'Songs and Albums now load when YouTube Music returns its newer library layout.',
-          'Playback no longer remains locked in buffering after a stream stops, and replaying a failed stream now requests a fresh source.',
-          'YouTube Music sign-in now persists reliably when Orchard is closed and reopened.',
-          'Support reports can now be connected to GitHub so their public issues show the reporter as the author instead of an unknown Orchard user.',
-          'Best mix now orders songs from measured audio compatibility instead of grouping matching artists or albums, and leaves unanalyzed songs in place.',
-          'Smart Crossfade now recognizes strong later-song silence breaks as musical mix-out points, and its mix indicator reaches the end of the progress bar.',
-          'Previous now stays within the active playlist, walks backward through its tracks, and restarts the first song at the playlist boundary.'
+          'Premium-only songs now recognize YouTube\'s HE-AAC streams and retry with the signed-in browser account when another player identity omits entitled playback formats.'
         ]
       }
     ]

--- a/test/playbackErrors.test.js
+++ b/test/playbackErrors.test.js
@@ -22,7 +22,10 @@ test('playback info retries the guest client after an authenticated 401', async 
       throw new Error('Player request failed with status code 401');
     }
   };
-  const guestInfo = { id: 'guest-result' };
+  const guestInfo = {
+    id: 'guest-result',
+    streaming_data: { adaptive_formats: [{ mime_type: 'audio/webm; codecs="opus"' }] }
+  };
   const guest = { getBasicInfo: async () => guestInfo };
   const playback = createPlaybackService({
     authState: { browser: {} },
@@ -37,6 +40,76 @@ test('playback info retries the guest client after an authenticated 401', async 
   const result = await playback.playbackInfo('track-id', { yt: authenticated });
   assert.equal(result.yt, guest);
   assert.equal(result.info, guestInfo);
+});
+
+test('playback info retries the browser account when premium formats are absent', async () => {
+  const primary = {
+    getBasicInfo: async () => ({
+      playability_status: {
+        status: 'LOGIN_REQUIRED',
+        reason: 'This song is available to Music Premium members'
+      }
+    })
+  };
+  const browserInfo = {
+    streaming_data: {
+      adaptive_formats: [{ mime_type: 'audio/mp4; codecs="mp4a.40.2"' }]
+    }
+  };
+  const browser = { getBasicInfo: async () => browserInfo };
+  const playback = createPlaybackService({
+    authState: { browser: { poToken: 'token' } },
+    cookieWithPlaybackDefaults: () => '',
+    getBrowserInnertube: () => browser,
+    getGuestInnertube: async () => ({ getBasicInfo: async () => ({}) }),
+    hasBrowserLoginCookie: () => true,
+    refreshBrowserAuth: async () => {},
+    youtubeWebOrigin: 'https://www.youtube.com'
+  });
+
+  const result = await playback.playbackInfo('premium-track', { yt: primary });
+
+  assert.equal(result.yt, browser);
+  assert.equal(result.info, browserInfo);
+});
+
+test('playback info refreshes and retries a browser session missing premium formats', async () => {
+  const browserInfo = {
+    streaming_data: {
+      adaptive_formats: [{ mime_type: 'audio/webm; codecs="opus"' }]
+    }
+  };
+  let playerRequests = 0;
+  let authRefreshes = 0;
+  const browser = {
+    getBasicInfo: async () => {
+      playerRequests += 1;
+      return playerRequests === 1
+        ? {
+            playability_status: {
+              status: 'LOGIN_REQUIRED',
+              reason: 'This song is available to Music Premium members'
+            }
+          }
+        : browserInfo;
+    }
+  };
+  const playback = createPlaybackService({
+    authState: { browser: { poToken: 'token' } },
+    cookieWithPlaybackDefaults: () => '',
+    getBrowserInnertube: () => browser,
+    getGuestInnertube: async () => ({ getBasicInfo: async () => ({}) }),
+    hasBrowserLoginCookie: () => true,
+    refreshBrowserAuth: async () => { authRefreshes += 1; },
+    youtubeWebOrigin: 'https://www.youtube.com'
+  });
+
+  const result = await playback.playbackInfo('premium-track', { yt: browser });
+
+  assert.equal(result.yt, browser);
+  assert.equal(result.info, browserInfo);
+  assert.equal(playerRequests, 2);
+  assert.equal(authRefreshes, 1);
 });
 
 test('playback fallback recognizes direct auth status and YouTube challenges', () => {

--- a/test/playbackFormats.test.js
+++ b/test/playbackFormats.test.js
@@ -1,6 +1,24 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { createPreferredAudioTrack, playbackAudioBitrate } from '../electron/playback/playbackFormats.js';
+import {
+  chooseAudioFormatFromFormats,
+  createPreferredAudioTrack,
+  playbackAudioBitrate
+} from '../electron/playback/playbackFormats.js';
+
+test('selects YouTube HE-AAC audio when Chromium reports support', () => {
+  const heAac = { itag: 139, mime_type: 'audio/mp4; codecs="mp4a.40.5"', bitrate: 48_000 };
+
+  assert.equal(chooseAudioFormatFromFormats([heAac], [
+    { mimeType: 'audio/mp4; codecs="mp4a.40.5"', support: 'probably' }
+  ]), heAac);
+});
+
+test('does not report a browser codec mismatch when InnerTube returned no formats', () => {
+  assert.equal(chooseAudioFormatFromFormats([], [
+    { mimeType: 'audio/mp4; codecs="mp4a.40.2"', support: 'probably' }
+  ]), undefined);
+});
 
 test('reports the audio companion bitrate for video playback', () => {
   const stream = {


### PR DESCRIPTION
## What changed

* Added support for YouTube HE-AAC (`mp4a.40.5`) audio streams.
* Detects when InnerTube returns no direct playback formats instead of passing the incomplete response through.
* Retries Premium-only songs using the signed-in browser session.
* Refreshes browser authentication and retries when the signed-in session initially returns no formats.
* Added tests covering Premium playback fallback and authentication refresh behavior.

## Why

Some YouTube Premium-exclusive songs returned no browser-supported audio format because their available streams were HE-AAC or were only exposed to the authenticated browser client.

Closes #1