### PR TITLE
fix: desktop widget updates on automatic track changes

### DIFF
--- a/electron/platform/systemMedia.js
+++ b/electron/platform/systemMedia.js
@@ -109,26 +109,54 @@ function configureMprisInterfaces(dbus) {
     }
 
     update(nextState = {}) {
-      const previous = this.state;
-      this.state = { ...previous, ...nextState };
-
-      const changed = {};
-      for (const property of [
+      const properties = [
         'PlaybackStatus',
         'LoopStatus',
         'Shuffle',
-        'Metadata',
         'Volume',
         'CanGoNext',
         'CanGoPrevious',
         'CanPlay',
         'CanPause',
         'CanSeek'
-      ]) {
-        if (this[property] !== undefined) changed[property] = this[property];
+      ];
+
+      const oldValues = {};
+      for (const property of properties) {
+        oldValues[property] = this[property];
       }
 
-      Interface.emitPropertiesChanged(this, changed);
+      const prevTrack = this.state.track || {};
+      const prevDuration = this.state.durationSeconds;
+
+      this.state = { ...this.state, ...nextState };
+
+      const changed = {};
+      for (const property of properties) {
+        if (this[property] !== undefined && this[property] !== oldValues[property]) {
+          changed[property] = this[property];
+        }
+      }
+
+      const newTrack = this.state.track || {};
+      const newDuration = this.state.durationSeconds;
+
+      const metadataChanged =
+        prevTrack.id !== newTrack.id ||
+        prevTrack.title !== newTrack.title ||
+        prevTrack.album !== newTrack.album ||
+        prevTrack.thumbnail !== newTrack.thumbnail ||
+        String(prevTrack.artist) !== String(newTrack.artist) ||
+        String(prevTrack.artists) !== String(newTrack.artists) ||
+        prevDuration !== newDuration;
+
+      if (metadataChanged) {
+        changed.Metadata = this.Metadata;
+      }
+
+      if (Object.keys(changed).length > 0) {
+        Interface.emitPropertiesChanged(this, changed);
+      }
     }
 
     Next() { this.emitCommand({ type: 'next' }); }

--- a/src/app/platform/systemMediaActions.js
+++ b/src/app/platform/systemMediaActions.js
@@ -54,9 +54,15 @@ export function installSystemMediaActions(ctx) {
     }
   };
 
+  let lastSyncAt = 0;
   ctx.queueSystemMediaSync = function queueSystemMediaSync() {
-    window.clearTimeout(ctx.systemMediaSyncTimer);
-    ctx.systemMediaSyncTimer = window.setTimeout(ctx.syncSystemMediaState, 180);
+    if (ctx.systemMediaSyncTimer) return;
+    const delay = Math.max(0, 180 - (Date.now() - lastSyncAt));
+    ctx.systemMediaSyncTimer = window.setTimeout(() => {
+      ctx.systemMediaSyncTimer = 0;
+      lastSyncAt = Date.now();
+      ctx.syncSystemMediaState();
+    }, delay);
   };
 
   ctx.handleSystemMediaCommand = function handleSystemMediaCommand(command = {}) {


### PR DESCRIPTION
## Description
This PR fixes a bug where desktop media widgets would fail to update when a track changed automatically in the playlist, but would correctly update when playback was paused or manually sought.

## Cause
1. The frontend used a debounced timer to send state updates to the backend. During crossfades or frequent <audio> timeupdate events, that timer kept getting reset before it could fire, so the IPC sync never actually happened.
2. Once the sync timer was fixed, a second problem showed up. Every time the backend received an IPC update, the MPRIS handler broadcast a D-Bus PropertiesChanged signal for every property, including track metadata, even when nothing had actually changed. Because these updates were happening multiple times per second, the desktop environment was flooded with unnecessary metadata updates, causing media widgets to become sluggish or freeze.