### PR TITLE
fix: harden song cache streaming

### DIFF
--- a/electron/playback/songCache.js
+++ b/electron/playback/songCache.js
@@ -8,6 +8,7 @@ const cacheDirectoryName = 'song-cache';
 const minCacheSizeMb = 128;
 const maxCacheSizeMb = 4096;
 const defaultCacheSizeMb = 512;
+const defaultMaxWriteLagBytes = 8 * 1024 * 1024;
 
 export function normalizeSongCacheSettings(settings = {}) {
   const rawSize = Number(settings.maxSizeMb);
@@ -26,6 +27,10 @@ export function createSongCache(options = {}) {
   let settings = normalizeSongCacheSettings(options);
   const directory = options.directory || defaultSongCacheDirectory();
   const createCacheWriteStream = options.createWriteStream || fs.createWriteStream;
+  const configuredMaxWriteLagBytes = Number(options.maxWriteLagBytes);
+  const maxWriteLagBytes = Number.isFinite(configuredMaxWriteLagBytes) && configuredMaxWriteLagBytes > 0
+    ? Math.floor(configuredMaxWriteLagBytes)
+    : defaultMaxWriteLagBytes;
   const activeWrites = new Set();
   let directoryReady = null;
 
@@ -141,11 +146,23 @@ export function createSongCache(options = {}) {
     const tempPath = `${filePath}.${process.pid}.${Date.now()}.part`;
     const [playbackBody, cacheBody] = upstream.body.tee();
     const cacheController = new AbortController();
-    const cacheTask = storeBody(cacheBody, tempPath, filePath, totalLength, cacheController.signal)
+    let cachedBytes = 0;
+    let playbackBytes = 0;
+    const cacheTask = storeBody(
+      cacheBody,
+      tempPath,
+      filePath,
+      totalLength,
+      cacheController.signal,
+      (written) => { cachedBytes = written; }
+    )
       .finally(() => activeWrites.delete(filePath));
 
     try {
-      const playbackComplete = await pipeResponseBody(playbackBody, res);
+      const playbackComplete = await pipeResponseBody(playbackBody, res, (length) => {
+        playbackBytes += length;
+        if (playbackBytes - cachedBytes > maxWriteLagBytes) cacheController.abort();
+      });
       if (!playbackComplete) cacheController.abort();
     } catch (error) {
       cacheController.abort();
@@ -155,28 +172,30 @@ export function createSongCache(options = {}) {
 
     return true;
 
-    async function storeBody(body, temporaryPath, destinationPath, expectedLength, signal) {
+    async function storeBody(body, temporaryPath, destinationPath, expectedLength, signal, onProgress) {
       let writer;
       let reader;
       let written = 0;
       const cancel = () => void reader?.cancel().catch(() => {});
       try {
         if (signal.aborted) throw new Error('Song cache write was cancelled');
+        reader = body.getReader();
+        signal.addEventListener('abort', cancel, { once: true });
         writer = createCacheWriteStream(temporaryPath);
         // Write callbacks carry failures to this task; this listener also keeps
         // a late stream error from becoming an uncaught process error.
         writer.on('error', () => {});
-        reader = body.getReader();
-        signal.addEventListener('abort', cancel, { once: true });
         while (true) {
           const chunk = await reader.read();
           if (chunk.done) break;
           if (!chunk.value?.byteLength) continue;
           written += chunk.value.byteLength;
           await writeChunk(writer, chunk.value);
+          onProgress(written);
         }
         await finishWriter(writer);
 
+        if (signal.aborted) throw new Error('Song cache write was cancelled');
         if (written !== expectedLength) throw new Error('Song cache received an incomplete stream');
         await fs.promises.rename(temporaryPath, destinationPath);
         await writeMetadata(destinationPath, videoId, stream).catch(() => {});
@@ -358,7 +377,7 @@ function onceDrain(stream) {
   return new Promise((resolve) => stream.once('drain', resolve));
 }
 
-async function pipeResponseBody(body, res) {
+async function pipeResponseBody(body, res, onChunk) {
   const reader = body.getReader();
   let complete = false;
   try {
@@ -368,7 +387,10 @@ async function pipeResponseBody(body, res) {
         complete = true;
         break;
       }
-      if (chunk.value?.byteLength && !res.write(chunk.value)) await onceDrain(res);
+      if (chunk.value?.byteLength) {
+        onChunk(chunk.value.byteLength);
+        if (!res.write(chunk.value)) await onceDrain(res);
+      }
     }
   } finally {
     if (!complete) await reader.cancel().catch(() => {});

--- a/electron/playback/songCache.js
+++ b/electron/playback/songCache.js
@@ -25,9 +25,27 @@ export function normalizeSongCacheSettings(settings = {}) {
 export function createSongCache(options = {}) {
   let settings = normalizeSongCacheSettings(options);
   const directory = options.directory || defaultSongCacheDirectory();
+  const createCacheWriteStream = options.createWriteStream || fs.createWriteStream;
+  const activeWrites = new Set();
+  let directoryReady = null;
 
   async function ensureDirectory() {
-    await fs.promises.mkdir(directory, { recursive: true });
+    if (!directoryReady) {
+      directoryReady = fs.promises.mkdir(directory, { recursive: true })
+        .then(() => removePartialFiles())
+        .catch((error) => {
+          directoryReady = null;
+          throw error;
+        });
+    }
+    await directoryReady;
+  }
+
+  async function removePartialFiles() {
+    const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+    await Promise.all(entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.part'))
+      .map((entry) => fs.promises.unlink(path.join(directory, entry.name)).catch(() => {})));
   }
 
   function cachePath(videoId, stream) {
@@ -108,42 +126,70 @@ export function createSongCache(options = {}) {
       return false;
     }
 
-    await ensureDirectory();
     const totalLength = Number(stream.format.contentLength || 0);
     const filePath = cachePath(videoId, stream);
-    const tempPath = `${filePath}.${process.pid}.${Date.now()}.part`;
-    const writer = fs.createWriteStream(tempPath);
-    let written = 0;
+    if (activeWrites.has(filePath)) return false;
+    activeWrites.add(filePath);
 
     try {
-      const reader = upstream.body.getReader();
-      while (!res.destroyed) {
-        const chunk = await reader.read();
-        if (chunk.done) break;
-        if (!chunk.value?.byteLength) continue;
-        written += chunk.value.byteLength;
-        if (!res.write(chunk.value)) await onceDrain(res);
-        if (!writer.write(chunk.value)) await onceDrain(writer);
-      }
-      writer.end();
-      await new Promise((resolve, reject) => writer.once('finish', resolve).once('error', reject));
-
-      if (written === totalLength && !res.destroyed) {
-        await fs.promises.rename(tempPath, filePath);
-        await writeMetadata(filePath, videoId, stream).catch(() => {});
-        await prune();
-      } else {
-        await fs.promises.unlink(tempPath).catch(() => {});
-      }
-    } catch (error) {
-      writer.destroy();
-      await fs.promises.unlink(tempPath).catch(() => {});
-      if (!res.destroyed) res.destroy(error);
-    } finally {
-      if (!res.destroyed) res.end();
+      await ensureDirectory();
+    } catch {
+      activeWrites.delete(filePath);
+      return false;
     }
 
+    const tempPath = `${filePath}.${process.pid}.${Date.now()}.part`;
+    const [playbackBody, cacheBody] = upstream.body.tee();
+    const cacheController = new AbortController();
+    const cacheTask = storeBody(cacheBody, tempPath, filePath, totalLength, cacheController.signal)
+      .finally(() => activeWrites.delete(filePath));
+
+    try {
+      const playbackComplete = await pipeResponseBody(playbackBody, res);
+      if (!playbackComplete) cacheController.abort();
+    } catch (error) {
+      cacheController.abort();
+      if (!res.destroyed) res.destroy(error);
+    }
+    await cacheTask;
+
     return true;
+
+    async function storeBody(body, temporaryPath, destinationPath, expectedLength, signal) {
+      let writer;
+      let reader;
+      let written = 0;
+      const cancel = () => void reader?.cancel().catch(() => {});
+      try {
+        if (signal.aborted) throw new Error('Song cache write was cancelled');
+        writer = createCacheWriteStream(temporaryPath);
+        // Write callbacks carry failures to this task; this listener also keeps
+        // a late stream error from becoming an uncaught process error.
+        writer.on('error', () => {});
+        reader = body.getReader();
+        signal.addEventListener('abort', cancel, { once: true });
+        while (true) {
+          const chunk = await reader.read();
+          if (chunk.done) break;
+          if (!chunk.value?.byteLength) continue;
+          written += chunk.value.byteLength;
+          await writeChunk(writer, chunk.value);
+        }
+        await finishWriter(writer);
+
+        if (written !== expectedLength) throw new Error('Song cache received an incomplete stream');
+        await fs.promises.rename(temporaryPath, destinationPath);
+        await writeMetadata(destinationPath, videoId, stream).catch(() => {});
+        await prune();
+      } catch {
+        writer?.destroy();
+        await reader?.cancel().catch(() => {});
+        await fs.promises.unlink(temporaryPath).catch(() => {});
+      } finally {
+        signal.removeEventListener('abort', cancel);
+        reader?.releaseLock();
+      }
+    }
   }
 
   async function prune() {
@@ -310,4 +356,41 @@ function defaultSongCacheDirectory() {
 
 function onceDrain(stream) {
   return new Promise((resolve) => stream.once('drain', resolve));
+}
+
+async function pipeResponseBody(body, res) {
+  const reader = body.getReader();
+  let complete = false;
+  try {
+    while (!res.destroyed) {
+      const chunk = await reader.read();
+      if (chunk.done) {
+        complete = true;
+        break;
+      }
+      if (chunk.value?.byteLength && !res.write(chunk.value)) await onceDrain(res);
+    }
+  } finally {
+    if (!complete) await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+  if (!res.destroyed) res.end();
+  return complete;
+}
+
+function writeChunk(writer, chunk) {
+  return new Promise((resolve, reject) => {
+    writer.write(chunk, (error) => error ? reject(error) : resolve());
+  });
+}
+
+function finishWriter(writer) {
+  return new Promise((resolve, reject) => {
+    const onError = (error) => reject(error);
+    writer.once('error', onError);
+    writer.end(() => {
+      writer.removeListener('error', onError);
+      resolve();
+    });
+  });
 }

--- a/test/songCache.test.js
+++ b/test/songCache.test.js
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { access, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Writable } from 'node:stream';
+import test from 'node:test';
+
+import { createSongCache } from '../electron/playback/songCache.js';
+
+function responseBody(bytes) {
+  return new Response(Uint8Array.from(bytes)).body;
+}
+
+function fakeResponse() {
+  const response = new EventEmitter();
+  response.chunks = [];
+  response.destroyed = false;
+  response.ended = false;
+  response.write = (chunk) => {
+    response.chunks.push(Buffer.from(chunk));
+    return true;
+  };
+  response.end = () => {
+    response.ended = true;
+  };
+  response.destroy = () => {
+    response.destroyed = true;
+  };
+  return response;
+}
+
+function cacheRequest(bytes = [1, 2, 3, 4]) {
+  return {
+    videoId: 'cache-track',
+    stream: {
+      format: {
+        contentLength: bytes.length,
+        itag: 140,
+        mimeType: 'audio/mp4'
+      },
+      mediaKind: 'audio'
+    },
+    range: { ok: true, wantsRange: false, start: 0 },
+    upstream: { body: responseBody(bytes) },
+    res: fakeResponse()
+  };
+}
+
+test('song cache removes abandoned partial files before serving entries', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'orchard-song-cache-parts-'));
+  const partialPath = path.join(directory, 'stale.bin.123.456.part');
+  await writeFile(partialPath, 'partial');
+  const cache = createSongCache({ directory });
+
+  try {
+    await cache.list();
+    await assert.rejects(access(partialPath));
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('song cache allows only one writer for the same complete stream', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'orchard-song-cache-writer-'));
+  const cache = createSongCache({ directory });
+  const first = cacheRequest();
+  const duplicate = cacheRequest();
+
+  try {
+    const firstWrite = cache.pipeAndStore(first);
+    assert.equal(await cache.pipeAndStore(duplicate), false);
+    assert.equal(await firstWrite, true);
+    assert.equal(first.res.ended, true);
+    assert.deepEqual(Buffer.concat(first.res.chunks), Buffer.from([1, 2, 3, 4]));
+
+    const inventory = await cache.list();
+    assert.equal(inventory.entries.length, 1);
+    assert.equal(inventory.entries[0].size, 4);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('song cache write failures never interrupt the playback response', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'orchard-song-cache-failure-'));
+  const cache = createSongCache({
+    directory,
+    createWriteStream() {
+      return new Writable({
+        write(_chunk, _encoding, callback) {
+          callback(new Error('disk write failed'));
+        }
+      });
+    }
+  });
+  const request = cacheRequest([9, 8, 7, 6]);
+
+  try {
+    assert.equal(await cache.pipeAndStore(request), true);
+    assert.equal(request.res.destroyed, false);
+    assert.equal(request.res.ended, true);
+    assert.deepEqual(Buffer.concat(request.res.chunks), Buffer.from([9, 8, 7, 6]));
+    assert.equal((await cache.list()).entries.length, 0);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/test/songCache.test.js
+++ b/test/songCache.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
-import { access, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { access, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { Writable } from 'node:stream';
@@ -10,6 +10,20 @@ import { createSongCache } from '../electron/playback/songCache.js';
 
 function responseBody(bytes) {
   return new Response(Uint8Array.from(bytes)).body;
+}
+
+function chunkedResponseBody(chunks) {
+  let index = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (index >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(Uint8Array.from(chunks[index]));
+      index += 1;
+    }
+  });
 }
 
 function fakeResponse() {
@@ -102,6 +116,42 @@ test('song cache write failures never interrupt the playback response', async ()
     assert.equal(request.res.ended, true);
     assert.deepEqual(Buffer.concat(request.res.chunks), Buffer.from([9, 8, 7, 6]));
     assert.equal((await cache.list()).entries.length, 0);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test('song cache abandons a write that falls too far behind playback', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'orchard-song-cache-lag-'));
+  let writes = 0;
+  const cache = createSongCache({
+    directory,
+    maxWriteLagBytes: 4,
+    createWriteStream() {
+      return new Writable({
+        write(_chunk, _encoding, callback) {
+          writes += 1;
+          setTimeout(callback, 20);
+        }
+      });
+    }
+  });
+  const bytes = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
+  const request = cacheRequest(bytes);
+  request.upstream.body = chunkedResponseBody([
+    bytes.slice(0, 4),
+    bytes.slice(4, 8),
+    bytes.slice(8)
+  ]);
+
+  try {
+    assert.equal(await cache.pipeAndStore(request), true);
+    assert.equal(request.res.destroyed, false);
+    assert.equal(request.res.ended, true);
+    assert.deepEqual(Buffer.concat(request.res.chunks), Buffer.from(bytes));
+    assert.equal(writes, 1);
+    assert.equal((await cache.list()).entries.length, 0);
+    assert.deepEqual(await readdir(directory), []);
   } finally {
     await rm(directory, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Description

Hardens song-cache streaming so cache failures do not interrupt playback.

## Changes

- Streams playback and cache writes independently.
- Prevents concurrent writes for the same cached track.
- Removes abandoned `.part` files during cache initialization.
- Cleans up incomplete cache files after interrupted downloads.
- Handles disk write failures without terminating the playback response.
- Adds tests for partial-file cleanup, duplicate writes, and cache write failures.
