### PR TITLE
fix: prevent system media discovery race on kde systems

### DIFF
--- a/electron/platform/systemMedia.js
+++ b/electron/platform/systemMedia.js
@@ -101,10 +101,10 @@ function configureMprisInterfaces(dbus) {
   });
 
   class PlayerInterface extends Interface {
-    constructor(emitCommand) {
+    constructor(emitCommand, initialState = {}) {
       super('org.mpris.MediaPlayer2.Player');
       this.emitCommand = emitCommand;
-      this.state = {};
+      this.state = { ...initialState };
       this.Variant = dbus.Variant;
     }
 
@@ -257,7 +257,7 @@ export function createSystemMediaService({
   let player = null;
   let startPromise = null;
 
-  async function start() {
+  async function start(initialState = {}) {
     if (platform !== 'linux') return false;
     if (startPromise) return startPromise;
 
@@ -265,12 +265,14 @@ export function createSystemMediaService({
       const dbus = loadDbus();
       const { MediaPlayerInterface, PlayerInterface } = configureMprisInterfaces(dbus);
       bus = dbus.sessionBus();
-      player = new PlayerInterface(emitCommand);
+      player = new PlayerInterface(emitCommand, initialState);
       bus.export(OBJECT_PATH, new MediaPlayerInterface(emitCommand));
       bus.export(OBJECT_PATH, player);
-      // Export the complete MPRIS object before announcing the well-known name.
-      // Consumers such as Plasma introspect as soon as NameOwnerChanged fires and
-      // may permanently discard a player whose interfaces are not ready yet.
+      // Export the complete MPRIS object with its initial playback state before
+      // announcing the well-known name. Consumers such as Plasma can read the
+      // player immediately when NameOwnerChanged fires; publishing the initial
+      // state afterward creates a window where they can cache an empty player
+      // and miss the first PropertiesChanged signal.
       await bus.requestName(SERVICE_NAME);
       return true;
     })().catch((error) => {
@@ -285,7 +287,7 @@ export function createSystemMediaService({
 
   return {
     async publish(state) {
-      if (!await start()) return false;
+      if (!await start(state)) return false;
       player?.update(state);
       return Boolean(player);
     },

--- a/electron/platform/systemMedia.js
+++ b/electron/platform/systemMedia.js
@@ -248,23 +248,30 @@ function configureMprisInterfaces(dbus) {
   return { MediaPlayerInterface, PlayerInterface };
 }
 
-export function createSystemMediaService({ emitCommand }) {
+export function createSystemMediaService({
+  emitCommand,
+  loadDbus = () => require('@particle/dbus-next'),
+  platform = process.platform
+}) {
   let bus = null;
   let player = null;
   let startPromise = null;
 
   async function start() {
-    if (process.platform !== 'linux') return false;
+    if (platform !== 'linux') return false;
     if (startPromise) return startPromise;
 
     startPromise = (async () => {
-      const dbus = require('@particle/dbus-next');
+      const dbus = loadDbus();
       const { MediaPlayerInterface, PlayerInterface } = configureMprisInterfaces(dbus);
       bus = dbus.sessionBus();
       player = new PlayerInterface(emitCommand);
-      await bus.requestName(SERVICE_NAME);
       bus.export(OBJECT_PATH, new MediaPlayerInterface(emitCommand));
       bus.export(OBJECT_PATH, player);
+      // Export the complete MPRIS object before announcing the well-known name.
+      // Consumers such as Plasma introspect as soon as NameOwnerChanged fires and
+      // may permanently discard a player whose interfaces are not ready yet.
+      await bus.requestName(SERVICE_NAME);
       return true;
     })().catch((error) => {
       console.warn(`System media integration disabled: ${error.message}`);

--- a/test/systemMedia.test.js
+++ b/test/systemMedia.test.js
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createSystemMediaService } from '../electron/platform/systemMedia.js';
+
+class FakeInterface {
+  constructor(name) {
+    this.name = name;
+  }
+
+  static configureMembers() {}
+  static emitPropertiesChanged() {}
+}
+
+function fakeDbus(events) {
+  const bus = {
+    disconnect() {},
+    export(path, playerInterface) {
+      events.push(`export:${path}:${playerInterface.name}`);
+    },
+    requestName(name) {
+      events.push(`request-name:${name}`);
+      return Promise.resolve();
+    },
+    unexport() {}
+  };
+
+  return {
+    interface: {
+      Interface: FakeInterface,
+      ACCESS_READ: Symbol('read'),
+      ACCESS_READWRITE: Symbol('readwrite')
+    },
+    sessionBus: () => bus,
+    Variant: class FakeVariant {
+      constructor(signature, value) {
+        this.signature = signature;
+        this.value = value;
+      }
+    }
+  };
+}
+
+test('MPRIS interfaces are exported before the service name is announced', async () => {
+  const events = [];
+  const service = createSystemMediaService({
+    emitCommand: () => {},
+    loadDbus: () => fakeDbus(events),
+    platform: 'linux'
+  });
+
+  await service.publish({
+    track: { id: 'track-1', title: 'Track' },
+    isPlaying: true
+  });
+
+  assert.deepEqual(events, [
+    'export:/org/mpris/MediaPlayer2:org.mpris.MediaPlayer2',
+    'export:/org/mpris/MediaPlayer2:org.mpris.MediaPlayer2.Player',
+    'request-name:org.mpris.MediaPlayer2.Orchard'
+  ]);
+});

--- a/test/systemMedia.test.js
+++ b/test/systemMedia.test.js
@@ -12,13 +12,14 @@ class FakeInterface {
   static emitPropertiesChanged() {}
 }
 
-function fakeDbus(events) {
+function fakeDbus(events, { onRequestName } = {}) {
   const bus = {
     disconnect() {},
     export(path, playerInterface) {
       events.push(`export:${path}:${playerInterface.name}`);
     },
     requestName(name) {
+      onRequestName?.();
       events.push(`request-name:${name}`);
       return Promise.resolve();
     },
@@ -59,4 +60,33 @@ test('MPRIS interfaces are exported before the service name is announced', async
     'export:/org/mpris/MediaPlayer2:org.mpris.MediaPlayer2.Player',
     'request-name:org.mpris.MediaPlayer2.Orchard'
   ]);
+});
+
+test('initial playback state is available before the MPRIS service name is announced', async () => {
+  const events = [];
+  let player;
+  const dbus = fakeDbus(events, {
+    onRequestName: () => {
+      assert.equal(player.PlaybackStatus, 'Playing');
+      assert.equal(player.Metadata['xesam:title'].value, 'Track');
+      assert.equal(player.CanPlay, true);
+    }
+  });
+  const originalExport = dbus.sessionBus().export;
+  dbus.sessionBus().export = (path, playerInterface) => {
+    if (playerInterface.name === 'org.mpris.MediaPlayer2.Player') player = playerInterface;
+    originalExport(path, playerInterface);
+  };
+  const service = createSystemMediaService({
+    emitCommand: () => {},
+    loadDbus: () => dbus,
+    platform: 'linux'
+  });
+
+  await service.publish({
+    track: { id: 'track-1', title: 'Track' },
+    isPlaying: true
+  });
+
+  assert.ok(player);
 });


### PR DESCRIPTION
## Summary

Fixes system media controls failing to detect active playback on KDE Plasma.

## Changes

- Keep system media metadata synchronized with the currently playing track
- Correct playback state updates exposed through the system media interface
- Ensure media controls detect Orchard while audio is playing

## Testing

- Verified system media detects active playback
- Confirmed track metadata and playback state update correctly