### PR TITLE
fix(auth): Fix YouTube Brand account switch window

### DIFF
--- a/electron/auth/authService.js
+++ b/electron/auth/authService.js
@@ -4,7 +4,16 @@ import path from 'node:path';
 import { Innertube, UniversalCache } from 'youtubei.js';
 import { createAccountProfileProbe } from './accountProfileProbe.js';
 import { createBrowserMusicFetch } from './browserMusicApi.js';
-import { collectYouTubeAuthCookie, hasYouTubeLoginCookie } from './youtubeAuthCookies.js';
+import {
+  isAuthSwitchDestinationUrl,
+  loadAuthWindowUrl,
+  observeAuthSwitchIdentity
+} from './authWindowNavigation.js';
+import {
+  collectYouTubeAuthCookie,
+  hasYouTubeLoginCookie,
+  youtubeAccountIdentity
+} from './youtubeAuthCookies.js';
 
 const require = createRequire(import.meta.url);
 const { app, BrowserWindow, session: electronSession } = require('electron');
@@ -48,7 +57,7 @@ export function createAuthService({
   let authEventsBound = false;
   let browserAuthWindow;
   let browserAuthMode = '';
-  let identityBeforeSwitch = '';
+  let authSwitchIdentity = {};
   let authRefreshTimer;
   const authState = {
     status: 'signed_out',
@@ -206,6 +215,22 @@ export function createAuthService({
     return `${authState.browser.cookie}\n${authState.browser.dataSyncId}\n${authState.browser.poToken}`;
   }
 
+  function browserSwitchIdentity() {
+    return youtubeAccountIdentity(authState.browser.cookie, authState.browser.dataSyncId);
+  }
+
+  function refreshSwitchedBrowserAccount() {
+    browserInnertubePromise = null;
+    browserInnertubeIdentity = '';
+    authState.user = { name: 'Signed in', byline: 'YouTube Music', thumbnail: null };
+    publishAuthState();
+
+    const identity = browserIdentity();
+    void Promise.resolve(getBrowserInnertube())
+      .then((yt) => refreshBrowserAccountSummary(yt, identity))
+      .catch((error) => console.warn(`Could not refresh switched browser account: ${error.message}`));
+  }
+
   function usefulAccountProfile(profile) {
     return Boolean(profile?.thumbnail || profile?.channelId || (profile?.name && profile.name !== 'Signed in'));
   }
@@ -253,7 +278,14 @@ export function createAuthService({
           const legacy = window.yt && window.yt.config_ ? window.yt.config_ : {};
           return {
             visitorData: (cfg && cfg.get('VISITOR_DATA')) || legacy.VISITOR_DATA || findScriptValue('VISITOR_DATA') || '',
-            dataSyncId: (cfg && cfg.get('DATASYNC_ID')) || legacy.DATASYNC_ID || findScriptValue('DATASYNC_ID') || '',
+            dataSyncId:
+              (cfg && cfg.get('DELEGATED_SESSION_ID')) ||
+              legacy.DELEGATED_SESSION_ID ||
+              findScriptValue('DELEGATED_SESSION_ID') ||
+              (cfg && cfg.get('DATASYNC_ID')) ||
+              legacy.DATASYNC_ID ||
+              findScriptValue('DATASYNC_ID') ||
+              '',
             poToken: (cfg && cfg.get('PO_TOKEN')) || findScriptValue('PO_TOKEN') || ''
           };
         })()
@@ -298,14 +330,14 @@ export function createAuthService({
   async function openBrowserAuthWindow({ mode, title, url }) {
     if (browserAuthWindow && !browserAuthWindow.isDestroyed()) {
       browserAuthMode = mode;
-      if (mode === 'switch') identityBeforeSwitch = browserIdentity();
-      await browserAuthWindow.loadURL(url);
+      authSwitchIdentity = {};
+      await loadAuthWindowUrl(browserAuthWindow, url);
       browserAuthWindow.focus();
       return publicAuthState();
     }
 
     browserAuthMode = mode;
-    if (mode === 'switch') identityBeforeSwitch = browserIdentity();
+    authSwitchIdentity = {};
 
     browserAuthWindow = new BrowserWindow({
       width: 1120,
@@ -321,7 +353,11 @@ export function createAuthService({
     });
 
     browserAuthWindow.webContents.setWindowOpenHandler(({ url }) => {
-      browserAuthWindow?.loadURL(url);
+      const window = browserAuthWindow;
+      if (window && !window.isDestroyed()) {
+        void loadAuthWindowUrl(window, url)
+          .catch((error) => console.warn(`Could not open browser auth page: ${error.message}`));
+      }
       return { action: 'deny' };
     });
 
@@ -329,19 +365,28 @@ export function createAuthService({
       const url = browserAuthWindow?.webContents.getURL() || '';
       if (/https?:\/\/([^/]+\.)?(youtube|google)\.com/i.test(url)) {
         await refreshBrowserAuth(browserAuthWindow.webContents);
-        if (browserAuthMode === 'switch' && browserIdentity() !== identityBeforeSwitch) {
-          browserAuthMode = '';
-          browserAuthWindow?.close();
-          scheduleAuthRefresh();
+        if (browserAuthMode === 'switch') {
+          const chooserWasLoaded = Boolean(authSwitchIdentity.ready);
+          authSwitchIdentity = observeAuthSwitchIdentity(authSwitchIdentity, browserSwitchIdentity());
+          if (authSwitchIdentity.completed || (chooserWasLoaded && isAuthSwitchDestinationUrl(url))) {
+            browserAuthMode = '';
+            refreshSwitchedBrowserAccount();
+            browserAuthWindow?.close();
+            scheduleAuthRefresh();
+          }
         }
       }
     });
 
     browserAuthWindow.on('closed', async () => {
-      const completedSwitch = browserAuthMode === 'switch' && browserIdentity() !== identityBeforeSwitch;
+      const closedMode = browserAuthMode;
       browserAuthWindow = null;
       browserAuthMode = '';
       await refreshBrowserAuth();
+      const completedSwitch = closedMode === 'switch' &&
+        authSwitchIdentity.ready &&
+        browserSwitchIdentity() !== authSwitchIdentity.baseline;
+      authSwitchIdentity = {};
       if (!hasBrowserLoginCookie() && authState.status === 'starting') {
         authState.status = 'signed_out';
         authState.error = 'Browser sign-in was closed before YouTube cookies were captured.';
@@ -350,7 +395,7 @@ export function createAuthService({
       if (completedSwitch) scheduleAuthRefresh();
     });
 
-    await browserAuthWindow.loadURL(url);
+    await loadAuthWindowUrl(browserAuthWindow, url);
     return publicAuthState();
   }
 

--- a/electron/auth/authWindowNavigation.js
+++ b/electron/auth/authWindowNavigation.js
@@ -1,0 +1,64 @@
+// Keeps browser-auth navigation failures distinct from navigations that YouTube
+// intentionally supersedes with a redirect or client-side URL replacement.
+
+export function isTrustedAuthUrl(value = '') {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' && (
+      url.hostname === 'youtube.com' ||
+      url.hostname.endsWith('.youtube.com') ||
+      url.hostname === 'google.com' ||
+      url.hostname.endsWith('.google.com')
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isAuthSwitchDestinationUrl(value = '') {
+  try {
+    const url = new URL(value);
+    const youtubeHost = url.hostname === 'youtube.com' || url.hostname.endsWith('.youtube.com');
+    return url.protocol === 'https:' &&
+      youtubeHost &&
+      !/^\/channel_switcher\/?$/.test(url.pathname);
+  } catch {
+    return false;
+  }
+}
+
+export function isSupersededAuthNavigation(error, attemptedUrl, currentUrl = '') {
+  const aborted = error?.code === 'ERR_ABORTED' || error?.errno === -3;
+  if (!aborted || !isTrustedAuthUrl(attemptedUrl)) return false;
+  return !currentUrl || isTrustedAuthUrl(currentUrl);
+}
+
+export function observeAuthSwitchIdentity(state = {}, identity = '') {
+  const currentIdentity = String(identity || '');
+  if (!state.ready) {
+    return {
+      baseline: currentIdentity,
+      ready: true,
+      completed: false
+    };
+  }
+
+  return {
+    baseline: state.baseline,
+    ready: true,
+    completed: currentIdentity !== state.baseline
+  };
+}
+
+export async function loadAuthWindowUrl(browserWindow, url) {
+  try {
+    await browserWindow.loadURL(url);
+    return true;
+  } catch (error) {
+    const currentUrl = browserWindow.isDestroyed()
+      ? ''
+      : browserWindow.webContents.getURL();
+    if (isSupersededAuthNavigation(error, url, currentUrl)) return false;
+    throw error;
+  }
+}

--- a/electron/auth/youtubeAuthCookies.js
+++ b/electron/auth/youtubeAuthCookies.js
@@ -17,6 +17,12 @@ export function hasYouTubeLoginCookie(cookie = '') {
   return Boolean(cookies.SAPISID || cookies['__Secure-3PAPISID']);
 }
 
+export function youtubeAccountIdentity(cookie = '', dataSyncId = '') {
+  const cookies = parseCookieString(cookie);
+  const signingCookie = cookies.SAPISID || cookies['__Secure-3PAPISID'] || '';
+  return `${String(dataSyncId || '').trim()}\n${signingCookie}`;
+}
+
 export function normalizeYouTubeAuthCookie(cookie = '') {
   const normalized = String(cookie || '').trim();
   const cookies = parseCookieString(normalized);

--- a/test/authWindowNavigation.test.js
+++ b/test/authWindowNavigation.test.js
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  isAuthSwitchDestinationUrl,
+  isSupersededAuthNavigation,
+  isTrustedAuthUrl,
+  loadAuthWindowUrl,
+  observeAuthSwitchIdentity
+} from '../electron/auth/authWindowNavigation.js';
+
+function fakeWindow({ currentUrl = '', error } = {}) {
+  return {
+    isDestroyed: () => false,
+    loadURL: async () => {
+      if (error) throw error;
+    },
+    webContents: {
+      getURL: () => currentUrl
+    }
+  };
+}
+
+test('auth navigation accepts only HTTPS YouTube and Google pages', () => {
+  assert.equal(isTrustedAuthUrl('https://www.youtube.com/channel_switcher'), true);
+  assert.equal(isTrustedAuthUrl('https://accounts.google.com/AccountChooser'), true);
+  assert.equal(isTrustedAuthUrl('http://www.youtube.com/channel_switcher'), false);
+  assert.equal(isTrustedAuthUrl('https://youtube.com.example.test/channel_switcher'), false);
+});
+
+test('regular YouTube is recognized as the post-switch destination', () => {
+  assert.equal(isAuthSwitchDestinationUrl('https://www.youtube.com/'), true);
+  assert.equal(isAuthSwitchDestinationUrl('https://www.youtube.com/feed/you'), true);
+  assert.equal(isAuthSwitchDestinationUrl('https://www.youtube.com/channel_switcher'), false);
+  assert.equal(isAuthSwitchDestinationUrl('https://accounts.google.com/AccountChooser'), false);
+});
+
+test('superseded YouTube auth navigation is recognized as benign', () => {
+  const error = { code: 'ERR_ABORTED', errno: -3 };
+  assert.equal(
+    isSupersededAuthNavigation(
+      error,
+      'https://www.youtube.com/channel_switcher',
+      'https://www.youtube.com/channel_switcher?themeRefresh=1'
+    ),
+    true
+  );
+});
+
+test('the account chooser load establishes the switch baseline without closing', () => {
+  const observed = observeAuthSwitchIdentity({}, 'chooser-page-identity');
+
+  assert.deepEqual(observed, {
+    baseline: 'chooser-page-identity',
+    ready: true,
+    completed: false
+  });
+});
+
+test('only an identity change after the chooser load completes the switch', () => {
+  const baseline = observeAuthSwitchIdentity({}, 'chooser-page-identity');
+  const unchanged = observeAuthSwitchIdentity(baseline, 'chooser-page-identity');
+  const switched = observeAuthSwitchIdentity(unchanged, 'brand-account-identity');
+
+  assert.equal(unchanged.completed, false);
+  assert.equal(switched.completed, true);
+  assert.equal(switched.baseline, 'chooser-page-identity');
+});
+
+test('loadAuthWindowUrl ignores a trusted ERR_ABORTED redirect', async () => {
+  const loaded = await loadAuthWindowUrl(fakeWindow({
+    currentUrl: 'https://www.youtube.com/channel_switcher?themeRefresh=1',
+    error: { code: 'ERR_ABORTED', errno: -3 }
+  }), 'https://www.youtube.com/channel_switcher');
+
+  assert.equal(loaded, false);
+});
+
+test('loadAuthWindowUrl preserves real navigation failures', async () => {
+  await assert.rejects(
+    loadAuthWindowUrl(fakeWindow({
+      currentUrl: 'https://www.youtube.com/channel_switcher',
+      error: { code: 'ERR_CONNECTION_REFUSED', errno: -102 }
+    }), 'https://www.youtube.com/channel_switcher'),
+    { code: 'ERR_CONNECTION_REFUSED' }
+  );
+});
+
+test('loadAuthWindowUrl does not hide an abort into an untrusted page', async () => {
+  await assert.rejects(
+    loadAuthWindowUrl(fakeWindow({
+      currentUrl: 'https://example.test/phishing',
+      error: { code: 'ERR_ABORTED', errno: -3 }
+    }), 'https://www.youtube.com/channel_switcher'),
+    { code: 'ERR_ABORTED' }
+  );
+});

--- a/test/youtubeAuthCookies.test.js
+++ b/test/youtubeAuthCookies.test.js
@@ -4,7 +4,8 @@ import {
   collectYouTubeAuthCookie,
   hasYouTubeLoginCookie,
   normalizeYouTubeAuthCookie,
-  parseCookieString
+  parseCookieString,
+  youtubeAccountIdentity
 } from '../electron/auth/youtubeAuthCookies.js';
 
 test('parseCookieString preserves cookie values containing equals signs', () => {
@@ -19,6 +20,17 @@ test('hasYouTubeLoginCookie accepts either supported signing cookie', () => {
   assert.equal(hasYouTubeLoginCookie('__Secure-3PAPISID=fallback'), true);
   assert.equal(hasYouTubeLoginCookie('SID=unrelated'), false);
   assert.equal(hasYouTubeLoginCookie('NOTSAPISID=substring'), false);
+});
+
+test('youtubeAccountIdentity ignores unrelated cookie changes', () => {
+  assert.equal(
+    youtubeAccountIdentity('SAPISID=primary; PREF=first', 'brand-channel'),
+    youtubeAccountIdentity('PREF=second; SAPISID=primary', 'brand-channel')
+  );
+  assert.notEqual(
+    youtubeAccountIdentity('SAPISID=primary; PREF=first', 'brand-channel'),
+    youtubeAccountIdentity('SAPISID=primary; PREF=first', 'personal-channel')
+  );
 });
 
 test('normalizeYouTubeAuthCookie aliases the secure signing cookie for youtubei.js', () => {


### PR DESCRIPTION
## Summary

- Fix YouTube Brand Account switching in the authentication window.
- Handle expected YouTube/Google redirect navigation aborts without hiding genuine failures.
- Detect account changes using the delegated session ID and signing cookie.
- Refresh the InnerTube client and account profile immediately after switching.
- Add coverage for trusted navigation, redirect handling, and account identity detection.