### PR TITLE
fix(graphics): reduce GPU contention and add integrated GPU mode

### DIFF
--- a/electron/main/graphicsMode.js
+++ b/electron/main/graphicsMode.js
@@ -22,6 +22,10 @@ const LINUX_GPU_OFFLOAD_ENVIRONMENT = Object.freeze([
   '__NV_PRIME_RENDER_OFFLOAD_PROVIDER',
   '__VK_LAYER_NV_optimus'
 ]);
+const LINUX_GPU_ENVIRONMENT = Object.freeze([
+  'DRI_PRIME',
+  ...LINUX_GPU_OFFLOAD_ENVIRONMENT
+]);
 
 function readText(filePath) {
   try {
@@ -148,6 +152,23 @@ export function configureLinuxIntegratedGpuEnvironment(device, environment = pro
   return selector;
 }
 
+function captureLinuxGpuEnvironment(environment) {
+  return new Map(LINUX_GPU_ENVIRONMENT.map((name) => [
+    name,
+    {
+      present: Object.hasOwn(environment, name),
+      value: environment[name]
+    }
+  ]));
+}
+
+function restoreLinuxGpuEnvironment(environment, snapshot) {
+  for (const [name, original] of snapshot) {
+    if (original.present) environment[name] = original.value;
+    else delete environment[name];
+  }
+}
+
 export function applyStartupGraphicsMode({
   app,
   environment = process.env,
@@ -187,6 +208,9 @@ export function createGraphicsModeController({
   linuxGraphicsDevices,
   platform = process.platform
 }) {
+  const originalLinuxGpuEnvironment = platform === 'linux'
+    ? captureLinuxGpuEnvironment(environment)
+    : null;
   const linuxIntegratedGpu = platform === 'linux'
     ? selectLinuxIntegratedGpu(linuxGraphicsDevices || readLinuxGraphicsDevices())
     : null;
@@ -231,6 +255,11 @@ export function createGraphicsModeController({
       return state();
     },
     restart() {
+      if (platform === 'linux' &&
+          selectedMode === GRAPHICS_MODES.AUTOMATIC &&
+          originalLinuxGpuEnvironment) {
+        restoreLinuxGpuEnvironment(environment, originalLinuxGpuEnvironment);
+      }
       app.relaunch();
       app.quit();
     }

--- a/electron/main/graphicsMode.js
+++ b/electron/main/graphicsMode.js
@@ -1,0 +1,238 @@
+import {
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs';
+import path from 'node:path';
+import {
+  GRAPHICS_MODES,
+  integratedGpuSelectionSupported,
+  normalizeGraphicsMode
+} from '../../shared/graphicsMode.js';
+
+export const GRAPHICS_MODE_FILENAME = 'graphics-mode.json';
+
+const LINUX_GPU_OFFLOAD_ENVIRONMENT = Object.freeze([
+  '__GLX_VENDOR_LIBRARY_NAME',
+  '__NV_PRIME_RENDER_OFFLOAD',
+  '__NV_PRIME_RENDER_OFFLOAD_PROVIDER',
+  '__VK_LAYER_NV_optimus'
+]);
+
+function readText(filePath) {
+  try {
+    return readFileSync(filePath, 'utf8').trim().toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+function pciAddresses(value) {
+  return [...String(value).matchAll(/\b[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-7]\b/gi)]
+    .map((match) => match[0].toLowerCase());
+}
+
+export function readLinuxGraphicsDevices(drmPath = '/sys/class/drm') {
+  try {
+    return readdirSync(drmPath, { withFileTypes: true })
+      .filter((entry) => /^card\d+$/.test(entry.name))
+      .flatMap((entry) => {
+        const sysfsPath = path.join(drmPath, entry.name, 'device');
+        try {
+          const devicePath = realpathSync(sysfsPath);
+          const addresses = pciAddresses(devicePath);
+          const pciAddress = addresses.at(-1) || '';
+          if (!pciAddress) return [];
+          const renderNode = readdirSync(path.join(sysfsPath, 'drm'))
+            .find((name) => /^renderD\d+$/.test(name));
+
+          return [{
+            bootVga: readText(path.join(sysfsPath, 'boot_vga')) === '1',
+            card: entry.name,
+            deviceId: readText(path.join(sysfsPath, 'device')),
+            devicePath,
+            pciAddress,
+            renderNodePath: renderNode ? path.join('/dev/dri', renderNode) : '',
+            subsystemVendorId: readText(path.join(sysfsPath, 'subsystem_vendor')),
+            topology: addresses,
+            vendorId: readText(path.join(sysfsPath, 'vendor'))
+          }];
+        } catch {
+          return [];
+        }
+      });
+  } catch {
+    return [];
+  }
+}
+
+export function selectLinuxIntegratedGpu(devices = []) {
+  const candidates = devices
+    .map((device) => {
+      const address = String(device.pciAddress || '').toLowerCase();
+      const topology = Array.isArray(device.topology) ? device.topology : [];
+      const intelIntegrated = device.vendorId === '0x8086' && /:00:02\.[0-7]$/.test(address);
+      const amdApu = device.vendorId === '0x1002' &&
+        topology.slice(0, -1).some((ancestor) => /:00:08\.[0-7]$/.test(ancestor));
+      if (!intelIntegrated && !amdApu) return null;
+
+      return {
+        ...device,
+        score: 100 +
+          (device.subsystemVendorId && device.subsystemVendorId !== device.vendorId ? 4 : 0) +
+          (device.bootVga ? 0 : 2) -
+          topology.length
+      };
+    })
+    .filter(Boolean)
+    .sort((left, right) => right.score - left.score);
+
+  return candidates[0] || null;
+}
+
+export function linuxDriPrimeSelector(device) {
+  const address = String(device?.pciAddress || '').toLowerCase();
+  return /^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-7]$/.test(address)
+    ? `pci-${address.replace(/[.:]/g, '_')}`
+    : '';
+}
+
+export function linuxRenderNodePath(device) {
+  const renderNodePath = String(device?.renderNodePath || '');
+  return /^\/dev\/dri\/renderD\d+$/.test(renderNodePath) ? renderNodePath : '';
+}
+
+export function readStoredGraphicsMode(filePath) {
+  try {
+    const stored = JSON.parse(readFileSync(filePath, 'utf8'));
+    return normalizeGraphicsMode(stored?.graphicsMode);
+  } catch {
+    return GRAPHICS_MODES.AUTOMATIC;
+  }
+}
+
+export function writeStoredGraphicsMode(filePath, graphicsMode) {
+  const normalized = normalizeGraphicsMode(graphicsMode);
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  try {
+    writeFileSync(temporaryPath, `${JSON.stringify({ graphicsMode: normalized }, null, 2)}\n`, {
+      encoding: 'utf8',
+      mode: 0o600
+    });
+    renameSync(temporaryPath, filePath);
+  } catch (error) {
+    try {
+      unlinkSync(temporaryPath);
+    } catch {
+      // The temporary file may not have been created.
+    }
+    throw error;
+  }
+
+  return normalized;
+}
+
+export function configureLinuxIntegratedGpuEnvironment(device, environment = process.env) {
+  for (const name of LINUX_GPU_OFFLOAD_ENVIRONMENT) {
+    delete environment[name];
+  }
+  const selector = linuxDriPrimeSelector(device);
+  if (selector) environment.DRI_PRIME = selector;
+  else delete environment.DRI_PRIME;
+  return selector;
+}
+
+export function applyStartupGraphicsMode({
+  app,
+  environment = process.env,
+  graphicsMode,
+  linuxIntegratedGpu = null,
+  platform = process.platform
+}) {
+  const normalized = normalizeGraphicsMode(graphicsMode);
+
+  if (normalized === GRAPHICS_MODES.INTEGRATED) {
+    const supported = platform === 'linux'
+      ? Boolean(
+          linuxDriPrimeSelector(linuxIntegratedGpu) &&
+          linuxRenderNodePath(linuxIntegratedGpu)
+        )
+      : integratedGpuSelectionSupported(platform);
+    if (!supported) return GRAPHICS_MODES.AUTOMATIC;
+
+    if (platform === 'linux') {
+      configureLinuxIntegratedGpuEnvironment(linuxIntegratedGpu, environment);
+      app.commandLine.appendSwitch(
+        'render-node-override',
+        linuxRenderNodePath(linuxIntegratedGpu)
+      );
+    }
+    app.commandLine.appendSwitch('force_low_power_gpu');
+    return GRAPHICS_MODES.INTEGRATED;
+  }
+
+  return GRAPHICS_MODES.AUTOMATIC;
+}
+
+export function createGraphicsModeController({
+  app,
+  filePath,
+  environment = process.env,
+  linuxGraphicsDevices,
+  platform = process.platform
+}) {
+  const linuxIntegratedGpu = platform === 'linux'
+    ? selectLinuxIntegratedGpu(linuxGraphicsDevices || readLinuxGraphicsDevices())
+    : null;
+  const integratedGpuSupported = platform === 'linux'
+    ? Boolean(
+        linuxDriPrimeSelector(linuxIntegratedGpu) &&
+        linuxRenderNodePath(linuxIntegratedGpu)
+      )
+    : integratedGpuSelectionSupported(platform);
+  let selectedMode = readStoredGraphicsMode(filePath);
+  const appliedMode = applyStartupGraphicsMode({
+    app,
+    environment,
+    graphicsMode: selectedMode,
+    linuxIntegratedGpu,
+    platform
+  });
+
+  function state() {
+    return {
+      appliedMode,
+      integratedGpuDevice: linuxIntegratedGpu
+        ? `${linuxIntegratedGpu.vendorId.replace(/^0x/, '')}:${linuxIntegratedGpu.deviceId.replace(/^0x/, '')}@${linuxIntegratedGpu.pciAddress}`
+        : '',
+      integratedGpuSupported,
+      platform,
+      restartRequired: selectedMode !== appliedMode,
+      selectedMode
+    };
+  }
+
+  return {
+    state,
+    setMode(value) {
+      const normalized = normalizeGraphicsMode(value);
+      const nextMode = integratedGpuSupported ||
+        normalized !== GRAPHICS_MODES.INTEGRATED
+        ? normalized
+        : GRAPHICS_MODES.AUTOMATIC;
+      writeStoredGraphicsMode(filePath, nextMode);
+      selectedMode = nextMode;
+      return state();
+    },
+    restart() {
+      app.relaunch();
+      app.quit();
+    }
+  };
+}

--- a/electron/main/index.js
+++ b/electron/main/index.js
@@ -56,6 +56,7 @@ import { registerScreenshotCapture } from '../platform/screenshotCapture.js';
 import { setupSystemMediaHandlers } from '../platform/systemMedia.js';
 import { welcomeRequiredAtLaunch } from '../platform/welcomeState.js';
 import { configureWindowOpenHandler, registerDevToolsShortcut, registerWindowControls } from '../platform/windowControls.js';
+import { createGraphicsModeController, GRAPHICS_MODE_FILENAME } from './graphicsMode.js';
 import { resolveRuntimePaths } from './runtimePaths.js';
 
 const require = createRequire(import.meta.url);
@@ -63,6 +64,10 @@ const { app, BrowserWindow, Menu, Tray, clipboard, globalShortcut, ipcMain, nati
 const isDev = !app.isPackaged && Boolean(process.env.VITE_DEV_SERVER_URL);
 const allowDevTools = !app.isPackaged;
 const runtimePaths = resolveRuntimePaths({ app, isDev });
+const graphicsMode = createGraphicsModeController({
+  app,
+  filePath: path.join(app.getPath('userData'), GRAPHICS_MODE_FILENAME)
+});
 
 app.commandLine.appendSwitch('autoplay-policy', 'no-user-gesture-required');
 if (process.platform === 'linux') {
@@ -458,6 +463,7 @@ app.whenReady().then(async () => {
     clearDiscordPresence,
     ipcMain,
     isDev,
+    graphicsMode,
     resolveDiscordSongLink,
     resolveDiscordSongLinkDetails,
     setDiscordPresence,

--- a/electron/platform/appHandlers.js
+++ b/electron/platform/appHandlers.js
@@ -6,6 +6,7 @@ const { APP, DISCORD, SONG_LINKS } = IPC_CHANNELS;
 export function registerAppHandlers({
   app,
   clearDiscordPresence,
+  graphicsMode,
   ipcMain,
   isDev,
   resolveDiscordSongLink,
@@ -32,6 +33,12 @@ export function registerAppHandlers({
     node: process.versions.node,
     dev: isDev
   }));
+  ipcMain.handle(APP.GRAPHICS_MODE, (_event, value) => {
+    return value === undefined ? graphicsMode.state() : graphicsMode.setMode(value);
+  });
+  ipcMain.handle(APP.RESTART, () => {
+    graphicsMode.restart();
+  });
   ipcMain.handle(APP.FINISH_WELCOME, () => {
     showMainWindow();
   });

--- a/electron/preload/index.cjs
+++ b/electron/preload/index.cjs
@@ -35,6 +35,10 @@ contextBridge.exposeInMainWorld('orchardApp', {
   captureScreenshot: () => ipcRenderer.invoke('app:capture-screenshot'),
   diagnostics: () => ipcRenderer.invoke('app:diagnostics'),
   finishWelcome: () => ipcRenderer.invoke('app:finish-welcome'),
+  graphicsMode: (value) => value === undefined
+    ? ipcRenderer.invoke('app:graphics-mode')
+    : ipcRenderer.invoke('app:graphics-mode', value),
+  restart: () => ipcRenderer.invoke('app:restart'),
   showWelcome: () => ipcRenderer.invoke('app:show-welcome')
 });
 

--- a/shared/graphicsMode.js
+++ b/shared/graphicsMode.js
@@ -1,0 +1,19 @@
+export const GRAPHICS_MODES = Object.freeze({
+  AUTOMATIC: 'automatic',
+  INTEGRATED: 'integrated'
+});
+
+export const GRAPHICS_MODE_OPTIONS = Object.freeze([
+  Object.freeze({ label: 'Automatic', value: GRAPHICS_MODES.AUTOMATIC }),
+  Object.freeze({ label: 'Integrated GPU', value: GRAPHICS_MODES.INTEGRATED })
+]);
+
+export function normalizeGraphicsMode(value) {
+  return GRAPHICS_MODE_OPTIONS.some((option) => option.value === value)
+    ? value
+    : GRAPHICS_MODES.AUTOMATIC;
+}
+
+export function integratedGpuSelectionSupported(platform = process.platform) {
+  return ['darwin', 'win32'].includes(platform);
+}

--- a/shared/ipcChannels.js
+++ b/shared/ipcChannels.js
@@ -10,6 +10,8 @@ export const IPC_CHANNELS = Object.freeze({
     CAPTURE_SCREENSHOT: 'app:capture-screenshot',
     DIAGNOSTICS: 'app:diagnostics',
     FINISH_WELCOME: 'app:finish-welcome',
+    GRAPHICS_MODE: 'app:graphics-mode',
+    RESTART: 'app:restart',
     SHOW_WELCOME: 'app:show-welcome'
   }),
   AUDIO_ANALYSIS: Object.freeze({

--- a/src/app/appearance/appearancePreferences.js
+++ b/src/app/appearance/appearancePreferences.js
@@ -1,10 +1,19 @@
+import {
+  GRAPHICS_MODES,
+  GRAPHICS_MODE_OPTIONS,
+  normalizeGraphicsMode
+} from '../../../shared/graphicsMode.js';
+
 export const APPEARANCE_DEFAULTS = {
   accentColorSource: 'artwork',
   customAccentColor: '#2fdf93',
+  graphicsMode: GRAPHICS_MODES.AUTOMATIC,
   immersiveBackgroundIntensity: 'balanced',
   immersiveBackgroundMotion: 'animated',
   themePreference: 'dark'
 };
+
+export { GRAPHICS_MODE_OPTIONS, normalizeGraphicsMode };
 
 export const ACCENT_COLOR_SOURCE_OPTIONS = [
   { label: 'Artwork', value: 'artwork' },

--- a/src/app/core/lifecycle.js
+++ b/src/app/core/lifecycle.js
@@ -108,6 +108,7 @@ export function installLifecycle(ctx) {
     ctx.youtubeHistoryEnabled,
     ctx.discordRpcEnabled,
     ctx.discordRpcActivityName,
+    ctx.graphicsMode,
     ctx.immersiveBackgroundsEnabled,
     ctx.immersiveBackgroundIntensity,
     ctx.immersiveBackgroundMotion,
@@ -150,6 +151,7 @@ export function installLifecycle(ctx) {
       youtubeHistoryEnabled: ctx.youtubeHistoryEnabled.value,
       discordRpcEnabled: ctx.discordRpcEnabled.value,
       discordRpcActivityName: ctx.discordRpcActivityName.value,
+      graphicsMode: ctx.graphicsMode.value,
       immersiveBackgroundsEnabled: ctx.immersiveBackgroundsEnabled.value,
       immersiveBackgroundIntensity: ctx.immersiveBackgroundIntensity.value,
       immersiveBackgroundMotion: ctx.immersiveBackgroundMotion.value,
@@ -248,6 +250,41 @@ export function installLifecycle(ctx) {
   watch(ctx.discordRpcActivityName, () => {
     ctx.queueDiscordPresenceSync();
   });
+
+  watch(ctx.graphicsMode, async (value) => {
+    const normalized = ctx.normalizeUserPreferences({ graphicsMode: value }).graphicsMode;
+    if (normalized !== value) {
+      ctx.graphicsMode.value = normalized;
+      return;
+    }
+
+    try {
+      const state = await window.orchardApp?.graphicsMode?.(normalized);
+      if (!state) {
+        ctx.graphicsModeApplied.value = normalized;
+        ctx.graphicsModeStatusReady.value = true;
+        return;
+      }
+
+      ctx.graphicsModeApplied.value = state.appliedMode;
+      ctx.graphicsModeIntegratedSupported.value = Boolean(state.integratedGpuSupported);
+      ctx.graphicsModePlatform.value = state.platform || '';
+      ctx.graphicsModeStatusReady.value = true;
+      ctx.graphicsModeMessage.value = '';
+      if (state.selectedMode !== normalized) ctx.graphicsMode.value = state.selectedMode;
+    } catch (error) {
+      ctx.graphicsModeStatusReady.value = true;
+      ctx.graphicsModeMessage.value = error.message || 'Could not save the graphics mode.';
+    }
+  }, { immediate: true });
+
+  ctx.restartOrchard = async function restartOrchard() {
+    try {
+      await window.orchardApp?.restart?.();
+    } catch (error) {
+      ctx.graphicsModeMessage.value = error.message || 'Could not restart Orchard.';
+    }
+  };
 
   watch([ctx.songCacheEnabled, ctx.songCacheMaxSizeMb], () => {
     ctx.syncSongCacheSettings();

--- a/src/app/core/readinessActions.js
+++ b/src/app/core/readinessActions.js
@@ -397,6 +397,7 @@ export function installReadinessActions(ctx) {
     ctx.customAccentColor.value = preferences.customAccentColor;
     ctx.discordRpcEnabled.value = preferences.discordRpcEnabled;
     ctx.discordRpcActivityName.value = preferences.discordRpcActivityName;
+    ctx.graphicsMode.value = preferences.graphicsMode;
     ctx.immersiveBackgroundsEnabled.value = preferences.immersiveBackgroundsEnabled;
     ctx.immersiveBackgroundIntensity.value = preferences.immersiveBackgroundIntensity;
     ctx.immersiveBackgroundMotion.value = preferences.immersiveBackgroundMotion;

--- a/src/app/core/state.js
+++ b/src/app/core/state.js
@@ -10,12 +10,14 @@ import orchardLogoUrl from '../../assets/orchard-logo.png';
 import {
   ACCENT_COLOR_SOURCE_OPTIONS,
   APPEARANCE_DEFAULTS,
+  GRAPHICS_MODE_OPTIONS,
   IMMERSIVE_BACKGROUND_INTENSITY_OPTIONS,
   IMMERSIVE_BACKGROUND_MOTION_OPTIONS,
   THEME_PREFERENCE_OPTIONS,
   immersiveBackgroundOpacity,
   normalizeAccentColorSource,
   normalizeCustomAccentColor,
+  normalizeGraphicsMode,
   normalizeImmersiveBackgroundIntensity,
   normalizeImmersiveBackgroundMotion,
   normalizeThemePreference
@@ -54,6 +56,7 @@ export function installState(ctx) {
     volume: 0.85
   };
   ctx.accentColorSourceOptions = ACCENT_COLOR_SOURCE_OPTIONS;
+  ctx.graphicsModeOptions = GRAPHICS_MODE_OPTIONS;
   ctx.immersiveBackgroundIntensityOptions = IMMERSIVE_BACKGROUND_INTENSITY_OPTIONS;
   ctx.immersiveBackgroundMotionOptions = IMMERSIVE_BACKGROUND_MOTION_OPTIONS;
   ctx.themePreferenceOptions = THEME_PREFERENCE_OPTIONS;
@@ -90,6 +93,7 @@ export function installState(ctx) {
         ? preferences.discordRpcEnabled
         : ctx.DEFAULT_USER_PREFERENCES.discordRpcEnabled,
       discordRpcActivityName: ctx.normalizeDiscordRpcActivityName(preferences.discordRpcActivityName),
+      graphicsMode: normalizeGraphicsMode(preferences.graphicsMode),
       immersiveBackgroundsEnabled: typeof preferences.immersiveBackgroundsEnabled === 'boolean'
         ? preferences.immersiveBackgroundsEnabled
         : ctx.DEFAULT_USER_PREFERENCES.immersiveBackgroundsEnabled,
@@ -341,6 +345,16 @@ export function installState(ctx) {
   ctx.youtubeHistoryEnabled = ref(ctx.initialUserPreferences.youtubeHistoryEnabled);
   ctx.discordRpcEnabled = ref(ctx.initialUserPreferences.discordRpcEnabled);
   ctx.discordRpcActivityName = ref(ctx.initialUserPreferences.discordRpcActivityName);
+  ctx.graphicsMode = ref(ctx.initialUserPreferences.graphicsMode);
+  ctx.graphicsModeApplied = ref(ctx.initialUserPreferences.graphicsMode);
+  ctx.graphicsModeIntegratedSupported = ref(false);
+  ctx.graphicsModePlatform = ref('');
+  ctx.graphicsModeStatusReady = ref(false);
+  ctx.graphicsModeMessage = ref('');
+  ctx.graphicsModeRestartRequired = computed(() => (
+    ctx.graphicsModeStatusReady.value &&
+    ctx.graphicsMode.value !== ctx.graphicsModeApplied.value
+  ));
   ctx.immersiveBackgroundsEnabled = ref(ctx.initialUserPreferences.immersiveBackgroundsEnabled);
   ctx.immersiveBackgroundIntensity = ref(ctx.initialUserPreferences.immersiveBackgroundIntensity);
   ctx.immersiveBackgroundMotion = ref(ctx.initialUserPreferences.immersiveBackgroundMotion);
@@ -372,6 +386,7 @@ export function installState(ctx) {
     ctx.customAccentColor.value = defaults.customAccentColor;
     ctx.discordRpcEnabled.value = defaults.discordRpcEnabled;
     ctx.discordRpcActivityName.value = defaults.discordRpcActivityName;
+    ctx.graphicsMode.value = defaults.graphicsMode;
     ctx.immersiveBackgroundsEnabled.value = defaults.immersiveBackgroundsEnabled;
     ctx.immersiveBackgroundIntensity.value = defaults.immersiveBackgroundIntensity;
     ctx.immersiveBackgroundMotion.value = defaults.immersiveBackgroundMotion;

--- a/src/components/animated-background/KawarpArtworkBackground.js
+++ b/src/components/animated-background/KawarpArtworkBackground.js
@@ -107,11 +107,8 @@ export class KawarpArtworkBackground {
   }
 
   shouldAnimate() {
-    // A static artwork source still benefits from Kawarp's ambient domain warp.
-    // The Static setting disables the separate artwork-video layer, not the
-    // canvas effect; Animated retains the previous playback-gated behavior.
     return this.enabled && this.visible && !this.reducedMotion &&
-      (!this.motionEnabled || this.playing);
+      this.motionEnabled && this.playing;
   }
 
   renderStill() {

--- a/src/components/chrome/AppFrame.vue
+++ b/src/components/chrome/AppFrame.vue
@@ -99,6 +99,7 @@ export default {
     }"
   >
     <AnimatedBackground
+      v-if="immersiveBackgroundsEnabled"
       :artwork-url="immersiveArtworkImage"
       :animated-artwork-url="immersiveArtworkVideo"
       :enabled="immersiveBackgroundsEnabled"

--- a/src/components/settings/SettingsView.vue
+++ b/src/components/settings/SettingsView.vue
@@ -186,6 +186,52 @@ export default {
           <p>Choose how artwork shapes the listening view.</p>
         </div>
 
+        <div class="settings-row settings-row--options">
+          <div class="settings-row__copy">
+            <label id="settings-graphics-mode-label">Graphics mode</label>
+            <p id="settings-graphics-mode-description">
+              Automatic uses Electron defaults. Integrated GPU prefers lower-power graphics. Changes require a restart.
+            </p>
+            <p v-if="graphicsModePlatform === 'linux' && graphicsModeIntegratedSupported">
+              On Linux, Orchard selects the detected integrated adapter directly.
+            </p>
+            <p v-else-if="graphicsModeStatusReady && !graphicsModeIntegratedSupported">
+              Integrated GPU selection is unavailable on this platform.
+            </p>
+            <p v-if="graphicsModeMessage" aria-live="polite">{{ graphicsModeMessage }}</p>
+          </div>
+          <div
+            class="settings-option-group"
+            role="group"
+            aria-labelledby="settings-graphics-mode-label"
+            aria-describedby="settings-graphics-mode-description"
+          >
+            <button
+              v-for="option in graphicsModeOptions"
+              :key="option.value"
+              type="button"
+              class="settings-option"
+              :class="{ 'settings-option--active': graphicsMode === option.value }"
+              :aria-pressed="graphicsMode === option.value"
+              :disabled="option.value === 'integrated' && graphicsModeStatusReady && !graphicsModeIntegratedSupported"
+              @click="graphicsMode = option.value"
+            >
+              {{ option.label }}
+            </button>
+          </div>
+        </div>
+
+        <div v-if="graphicsModeRestartRequired" class="settings-action-row">
+          <div class="settings-row__copy">
+            <span>Restart required</span>
+            <p>Restart Orchard to apply {{ graphicsModeOptions.find((option) => option.value === graphicsMode)?.label || 'the selected graphics mode' }}.</p>
+          </div>
+          <button type="button" class="settings-button" @click="restartOrchard">
+            <q-icon name="restart_alt" />
+            Restart Orchard
+          </button>
+        </div>
+
         <div class="settings-row">
           <div class="settings-row__copy">
             <label for="settings-immersive">Immersive backgrounds</label>

--- a/test/animatedBackground.test.js
+++ b/test/animatedBackground.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import { KawarpArtworkBackground } from '../src/components/animated-background/KawarpArtworkBackground.js';
 import { VideoArtworkBackground } from '../src/components/animated-background/VideoArtworkBackground.js';
 import {
   interpolateRgb,
@@ -20,6 +21,45 @@ test('palette interpolation clamps progress', () => {
   assert.equal(normalizeBackgroundUrl('  cover.jpg  '), 'cover.jpg');
 });
 
+test('static artwork renders one frame without starting the WebGL animation loop', () => {
+  let renderCount = 0;
+  let startCount = 0;
+  let stopCount = 0;
+  const background = new KawarpArtworkBackground({});
+  background.renderer = {
+    renderFrame() { renderCount += 1; },
+    start() { startCount += 1; },
+    stop() { stopCount += 1; }
+  };
+  background.source = 'cover.jpg';
+  background.motionEnabled = false;
+  background.playing = true;
+
+  background.syncPlayback();
+
+  assert.equal(startCount, 0);
+  assert.equal(stopCount, 1);
+  assert.equal(renderCount, 1);
+});
+
+test('animated artwork only runs while playback is active', () => {
+  let startCount = 0;
+  const background = new KawarpArtworkBackground({});
+  background.renderer = {
+    renderFrame() {},
+    start() { startCount += 1; },
+    stop() {}
+  };
+  background.source = 'cover.jpg';
+  background.motionEnabled = true;
+
+  background.syncPlayback();
+  assert.equal(startCount, 0);
+
+  background.playing = true;
+  background.syncPlayback();
+  assert.equal(startCount, 1);
+});
 
 test('animated artwork reuses one video and releases superseded sources', async () => {
   const listeners = new Map();

--- a/test/graphicsMode.test.js
+++ b/test/graphicsMode.test.js
@@ -244,3 +244,47 @@ test('graphics controller tracks restart state and uses Electron relaunch', (t) 
   controller.restart();
   assert.deepEqual(app.calls, [['relaunch'], ['quit']]);
 });
+
+test('Linux graphics controller restores the inherited GPU environment before restarting into Automatic', (t) => {
+  const filePath = temporaryPreferencesPath(t);
+  writeStoredGraphicsMode(filePath, GRAPHICS_MODES.INTEGRATED);
+  const environment = {
+    DRI_PRIME: '1',
+    KEEP_ME: 'yes',
+    __GLX_VENDOR_LIBRARY_NAME: 'nvidia',
+    __NV_PRIME_RENDER_OFFLOAD: '1',
+    __NV_PRIME_RENDER_OFFLOAD_PROVIDER: 'NVIDIA-G0',
+    __VK_LAYER_NV_optimus: 'NVIDIA_only'
+  };
+  const inheritedEnvironment = { ...environment };
+  const app = fakeApp();
+  const controller = createGraphicsModeController({
+    app,
+    environment,
+    filePath,
+    linuxGraphicsDevices: [{
+      bootVga: false,
+      deviceId: '0x1638',
+      pciAddress: '0000:09:00.0',
+      renderNodePath: '/dev/dri/renderD129',
+      subsystemVendorId: '0x1458',
+      topology: ['0000:00:08.1', '0000:09:00.0'],
+      vendorId: '0x1002'
+    }],
+    platform: 'linux'
+  });
+
+  assert.equal(environment.DRI_PRIME, 'pci-0000_09_00_0');
+  assert.equal(environment.__NV_PRIME_RENDER_OFFLOAD, undefined);
+
+  controller.setMode(GRAPHICS_MODES.AUTOMATIC);
+  controller.restart();
+
+  assert.deepEqual(environment, inheritedEnvironment);
+  assert.deepEqual(app.calls, [
+    ['appendSwitch', 'render-node-override', '/dev/dri/renderD129'],
+    ['appendSwitch', 'force_low_power_gpu'],
+    ['relaunch'],
+    ['quit']
+  ]);
+});

--- a/test/graphicsMode.test.js
+++ b/test/graphicsMode.test.js
@@ -1,0 +1,246 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  GRAPHICS_MODES,
+  integratedGpuSelectionSupported,
+  normalizeGraphicsMode
+} from '../shared/graphicsMode.js';
+import {
+  applyStartupGraphicsMode,
+  configureLinuxIntegratedGpuEnvironment,
+  createGraphicsModeController,
+  linuxDriPrimeSelector,
+  linuxRenderNodePath,
+  readStoredGraphicsMode,
+  selectLinuxIntegratedGpu,
+  writeStoredGraphicsMode
+} from '../electron/main/graphicsMode.js';
+
+function temporaryPreferencesPath(t) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), 'orchard-graphics-mode-'));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  return path.join(directory, 'preferences', 'graphics-mode.json');
+}
+
+function fakeApp() {
+  const calls = [];
+  return {
+    calls,
+    commandLine: {
+      appendSwitch: (name, value) => calls.push(
+        value === undefined ? ['appendSwitch', name] : ['appendSwitch', name, value]
+      )
+    },
+    quit: () => calls.push(['quit']),
+    relaunch: () => calls.push(['relaunch'])
+  };
+}
+
+test('graphics mode normalization defaults unknown values to Automatic', () => {
+  assert.equal(normalizeGraphicsMode('automatic'), GRAPHICS_MODES.AUTOMATIC);
+  assert.equal(normalizeGraphicsMode('integrated'), GRAPHICS_MODES.INTEGRATED);
+  assert.equal(normalizeGraphicsMode('software'), GRAPHICS_MODES.AUTOMATIC);
+  assert.equal(normalizeGraphicsMode('disable-gpu'), GRAPHICS_MODES.AUTOMATIC);
+  assert.equal(normalizeGraphicsMode(null), GRAPHICS_MODES.AUTOMATIC);
+});
+
+test('integrated GPU selection reports only implemented desktop platforms', () => {
+  assert.equal(integratedGpuSelectionSupported('win32'), true);
+  assert.equal(integratedGpuSelectionSupported('darwin'), true);
+  assert.equal(integratedGpuSelectionSupported('linux'), false);
+  assert.equal(integratedGpuSelectionSupported('freebsd'), false);
+});
+
+test('graphics mode storage defaults missing or corrupt files to Automatic', (t) => {
+  const filePath = temporaryPreferencesPath(t);
+  assert.equal(readStoredGraphicsMode(filePath), GRAPHICS_MODES.AUTOMATIC);
+
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, '{broken json');
+  assert.equal(readStoredGraphicsMode(filePath), GRAPHICS_MODES.AUTOMATIC);
+});
+
+test('graphics mode storage writes normalized state', (t) => {
+  const filePath = temporaryPreferencesPath(t);
+  assert.equal(writeStoredGraphicsMode(filePath, 'integrated'), GRAPHICS_MODES.INTEGRATED);
+  assert.deepEqual(JSON.parse(readFileSync(filePath, 'utf8')), { graphicsMode: 'integrated' });
+  assert.equal(readStoredGraphicsMode(filePath), GRAPHICS_MODES.INTEGRATED);
+
+  assert.equal(writeStoredGraphicsMode(filePath, 'software'), GRAPHICS_MODES.AUTOMATIC);
+  assert.equal(readStoredGraphicsMode(filePath), GRAPHICS_MODES.AUTOMATIC);
+});
+
+test('integrated mode applies Electron low-power selection on Windows and macOS', () => {
+  for (const platform of ['win32', 'darwin']) {
+    const app = fakeApp();
+    const applied = applyStartupGraphicsMode({
+      app,
+      graphicsMode: GRAPHICS_MODES.INTEGRATED,
+      platform
+    });
+
+    assert.equal(applied, GRAPHICS_MODES.INTEGRATED);
+    assert.deepEqual(app.calls, [['appendSwitch', 'force_low_power_gpu']]);
+  }
+});
+
+test('Linux integrated detection identifies AMD APUs and Intel processor graphics', () => {
+  const amdApu = {
+    bootVga: false,
+    deviceId: '0x1638',
+    pciAddress: '0000:09:00.0',
+    renderNodePath: '/dev/dri/renderD129',
+    subsystemVendorId: '0x1458',
+    topology: ['0000:00:08.1', '0000:09:00.0'],
+    vendorId: '0x1002'
+  };
+  const amdDiscrete = {
+    bootVga: true,
+    deviceId: '0x731f',
+    pciAddress: '0000:03:00.0',
+    renderNodePath: '/dev/dri/renderD128',
+    subsystemVendorId: '0x1002',
+    topology: ['0000:00:01.1', '0000:01:00.0', '0000:02:00.0', '0000:03:00.0'],
+    vendorId: '0x1002'
+  };
+  const intelIntegrated = {
+    bootVga: true,
+    deviceId: '0x46a6',
+    pciAddress: '0000:00:02.0',
+    renderNodePath: '/dev/dri/renderD128',
+    subsystemVendorId: '0x17aa',
+    topology: ['0000:00:02.0'],
+    vendorId: '0x8086'
+  };
+
+  assert.equal(selectLinuxIntegratedGpu([amdDiscrete, amdApu])?.pciAddress, '0000:09:00.0');
+  assert.equal(selectLinuxIntegratedGpu([intelIntegrated])?.pciAddress, '0000:00:02.0');
+  assert.equal(selectLinuxIntegratedGpu([amdDiscrete]), null);
+  assert.equal(linuxDriPrimeSelector(amdApu), 'pci-0000_09_00_0');
+  assert.equal(linuxRenderNodePath(amdApu), '/dev/dri/renderD129');
+});
+
+test('Linux integrated mode explicitly selects the detected PCI device', () => {
+  const integratedGpu = {
+    pciAddress: '0000:09:00.0',
+    renderNodePath: '/dev/dri/renderD129'
+  };
+  const environment = {
+    DRI_PRIME: '1',
+    KEEP_ME: 'yes',
+    __GLX_VENDOR_LIBRARY_NAME: 'nvidia',
+    __NV_PRIME_RENDER_OFFLOAD: '1',
+    __NV_PRIME_RENDER_OFFLOAD_PROVIDER: 'NVIDIA-G0',
+    __VK_LAYER_NV_optimus: 'NVIDIA_only'
+  };
+  const app = fakeApp();
+
+  assert.equal(
+    configureLinuxIntegratedGpuEnvironment(integratedGpu, environment),
+    'pci-0000_09_00_0'
+  );
+  assert.deepEqual(environment, {
+    DRI_PRIME: 'pci-0000_09_00_0',
+    KEEP_ME: 'yes'
+  });
+  assert.equal(applyStartupGraphicsMode({
+    app,
+    environment,
+    graphicsMode: GRAPHICS_MODES.INTEGRATED,
+    linuxIntegratedGpu: integratedGpu,
+    platform: 'linux'
+  }), GRAPHICS_MODES.INTEGRATED);
+  assert.equal(environment.DRI_PRIME, 'pci-0000_09_00_0');
+  assert.deepEqual(app.calls, [
+    ['appendSwitch', 'render-node-override', '/dev/dri/renderD129'],
+    ['appendSwitch', 'force_low_power_gpu']
+  ]);
+});
+
+test('Linux graphics controller applies a detected AMD APU instead of the boot GPU', (t) => {
+  const filePath = temporaryPreferencesPath(t);
+  writeStoredGraphicsMode(filePath, GRAPHICS_MODES.INTEGRATED);
+  const environment = {};
+  const app = fakeApp();
+  const controller = createGraphicsModeController({
+    app,
+    environment,
+    filePath,
+    linuxGraphicsDevices: [
+      {
+        bootVga: true,
+        deviceId: '0x731f',
+        pciAddress: '0000:03:00.0',
+        renderNodePath: '/dev/dri/renderD128',
+        subsystemVendorId: '0x1002',
+        topology: ['0000:00:01.1', '0000:01:00.0', '0000:02:00.0', '0000:03:00.0'],
+        vendorId: '0x1002'
+      },
+      {
+        bootVga: false,
+        deviceId: '0x1638',
+        pciAddress: '0000:09:00.0',
+        renderNodePath: '/dev/dri/renderD129',
+        subsystemVendorId: '0x1458',
+        topology: ['0000:00:08.1', '0000:09:00.0'],
+        vendorId: '0x1002'
+      }
+    ],
+    platform: 'linux'
+  });
+
+  assert.deepEqual(controller.state(), {
+    appliedMode: GRAPHICS_MODES.INTEGRATED,
+    integratedGpuDevice: '1002:1638@0000:09:00.0',
+    integratedGpuSupported: true,
+    platform: 'linux',
+    restartRequired: false,
+    selectedMode: GRAPHICS_MODES.INTEGRATED
+  });
+  assert.equal(environment.DRI_PRIME, 'pci-0000_09_00_0');
+  assert.deepEqual(app.calls, [
+    ['appendSwitch', 'render-node-override', '/dev/dri/renderD129'],
+    ['appendSwitch', 'force_low_power_gpu']
+  ]);
+});
+
+test('unsupported integrated selection falls back to Automatic when persisted', (t) => {
+  const filePath = temporaryPreferencesPath(t);
+  writeStoredGraphicsMode(filePath, GRAPHICS_MODES.INTEGRATED);
+  const app = fakeApp();
+  const controller = createGraphicsModeController({
+    app,
+    filePath,
+    platform: 'freebsd'
+  });
+
+  assert.deepEqual(controller.state(), {
+    appliedMode: GRAPHICS_MODES.AUTOMATIC,
+    integratedGpuDevice: '',
+    integratedGpuSupported: false,
+    platform: 'freebsd',
+    restartRequired: true,
+    selectedMode: GRAPHICS_MODES.INTEGRATED
+  });
+  assert.equal(controller.setMode(GRAPHICS_MODES.INTEGRATED).selectedMode, GRAPHICS_MODES.AUTOMATIC);
+  assert.equal(readStoredGraphicsMode(filePath), GRAPHICS_MODES.AUTOMATIC);
+});
+
+test('graphics controller tracks restart state and uses Electron relaunch', (t) => {
+  const filePath = temporaryPreferencesPath(t);
+  const app = fakeApp();
+  const controller = createGraphicsModeController({
+    app,
+    filePath,
+    platform: 'win32'
+  });
+
+  assert.equal(controller.state().restartRequired, false);
+  assert.equal(controller.setMode(GRAPHICS_MODES.INTEGRATED).restartRequired, true);
+  controller.restart();
+  assert.deepEqual(app.calls, [['relaunch'], ['quit']]);
+});


### PR DESCRIPTION
## Summary

Addresses GPU instability and contention when Orchard is open alongside GPU-intensive applications.

This keeps hardware acceleration enabled while allowing Orchard to use an integrated GPU when available. It also reduces unnecessary immersive-background rendering when animation is disabled, playback is paused, or Orchard is not visible.

## Changes

- Add **Automatic** and **Integrated GPU** graphics modes
- Apply Electron’s low-power GPU preference on Windows and macOS
- Detect and directly select supported Intel and AMD integrated GPUs on Linux
- Persist graphics mode before Electron initializes
- Prompt for and support restarting Orchard after changing modes
- Restore the original Linux GPU environment when switching back to Automatic
- Stop WebGL animation for static backgrounds and paused playback
- Fully release immersive-background rendering resources when backgrounds are disabled
- Add coverage for GPU detection, persistence, relaunch behavior, and background rendering

Closes #17