### PR TITLE
Add native WSOLA engine for beat-matched transitions

### DIFF
--- a/electron/audio/audioAnalysisService.js
+++ b/electron/audio/audioAnalysisService.js
@@ -226,7 +226,7 @@ export function setupAudioAnalysisService({
     // Only forward keys that are real numbers: the N-API binding treats a
     // present-but-undefined key as a type error, not an omission.
     const renderOptions = { sampleRate };
-    ['beats', 'bassSwap', 'bassCrossoverHz', 'bassSwapSeconds', 'tempoGlide'].forEach((key) => {
+    ['beats', 'bassSwap', 'handoff', 'bed', 'bassCrossoverHz', 'bassSwapSeconds', 'tempoGlide'].forEach((key) => {
       const value = Number(options[key]);
       if (Number.isFinite(value)) renderOptions[key] = value;
     });

--- a/electron/audio/audioAnalysisService.js
+++ b/electron/audio/audioAnalysisService.js
@@ -181,6 +181,72 @@ export function setupAudioAnalysisService({
     return true;
   });
 
+  // Stereo transition rendering shares the addon but not the analysis cache:
+  // a rendered overlap is bound to one exact pairing and playback position, so
+  // the renderer owns any reuse and this handler stays stateless.
+  ipcMain.handle(AUDIO_ANALYSIS.RENDER_TRANSITION, async (_event, payload = {}) => {
+    const native = addon();
+    if (!native || typeof native.renderTransition !== 'function') {
+      log('transition-render-unavailable', { loadAttempts: nativeLoadAttempts });
+      throw new Error('Native transition rendering is unavailable.');
+    }
+
+    function transitionSource(value, label) {
+      const channels = Array.isArray(value?.channels)
+        ? value.channels.map(floatSamples)
+        : [];
+      const anchor = Number(value?.anchor);
+      const bpm = Number(value?.bpm);
+      if (!channels.length || channels.some((channel) => !channel?.length) ||
+          !Number.isFinite(anchor) || anchor < 0 || !Number.isFinite(bpm)) {
+        throw new Error(`Invalid ${label} PCM for transition rendering.`);
+      }
+      // Overlap slices are bounded by design; refuse anything whole-track sized.
+      const maxSamples = 48000 * 90 * channels.length;
+      const total = channels.reduce((sum, channel) => sum + channel.length, 0);
+      if (total > maxSamples) throw new Error(`Oversized ${label} PCM for transition rendering.`);
+      return { channels, anchor, bpm };
+    }
+
+    const outgoing = transitionSource(payload.outgoing, 'outgoing');
+    const incoming = transitionSource(payload.incoming, 'incoming');
+    const options = payload.options && typeof payload.options === 'object' ? payload.options : {};
+    const sampleRate = Number(options.sampleRate);
+    if (!Number.isFinite(sampleRate) || sampleRate < 1000) {
+      throw new Error('A valid sample rate is required for transition rendering.');
+    }
+
+    const startedAt = Date.now();
+    log('transition-render-start', {
+      sampleRate,
+      beats: Number(options.beats) || 0,
+      outgoingBpm: outgoing.bpm,
+      incomingBpm: incoming.bpm
+    });
+    // Only forward keys that are real numbers: the N-API binding treats a
+    // present-but-undefined key as a type error, not an omission.
+    const renderOptions = { sampleRate };
+    ['beats', 'bassSwap', 'bassCrossoverHz', 'bassSwapSeconds', 'tempoGlide'].forEach((key) => {
+      const value = Number(options[key]);
+      if (Number.isFinite(value)) renderOptions[key] = value;
+    });
+    const result = await native.renderTransition(outgoing, incoming, renderOptions);
+    log(result.rendered ? 'transition-render-ready' : 'transition-render-refused', {
+      elapsedMs: Date.now() - startedAt,
+      rejected: String(result.rejected || ''),
+      stretchRatio: Number(result.stretchRatio) || 0,
+      overlapSamples: result.channels?.[0]?.length || 0
+    });
+    return {
+      rendered: Boolean(result.rendered),
+      rejected: String(result.rejected || ''),
+      stretchRatio: Number(result.stretchRatio) || 1,
+      bpm: Number(result.bpm) || 0,
+      sampleRate,
+      channels: result.channels || []
+    };
+  });
+
   ipcMain.handle(AUDIO_ANALYSIS.STORE, async (_event, payload = {}) => {
     await cacheReady;
     const trackId = cleanTrackId(payload.trackId);
@@ -285,6 +351,7 @@ export function setupAudioAnalysisService({
       ipcMain.removeHandler(AUDIO_ANALYSIS.DEBUG);
       ipcMain.removeHandler(AUDIO_ANALYSIS.STORE);
       ipcMain.removeHandler(AUDIO_ANALYSIS.ANALYZE);
+      ipcMain.removeHandler(AUDIO_ANALYSIS.RENDER_TRANSITION);
       if (cache.size) await persist().catch(() => {});
     }
   };

--- a/electron/preload/index.cjs
+++ b/electron/preload/index.cjs
@@ -81,6 +81,11 @@ contextBridge.exposeInMainWorld('orchardAudioAnalysis', {
     samples,
     sampleRate,
     duration
+  }),
+  renderTransition: (outgoing, incoming, options) => ipcRenderer.invoke('audio-analysis:render-transition', {
+    outgoing,
+    incoming,
+    options
   })
 });
 

--- a/native/binding.gyp
+++ b/native/binding.gyp
@@ -5,7 +5,8 @@
       "sources": [
         "binding/addon.cpp",
         "analyzer/audio_analysis.cpp",
-        "analyzer/tempo_analysis.cpp"
+        "analyzer/tempo_analysis.cpp",
+        "transition/wsola.cpp"
       ],
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")"

--- a/native/binding.gyp
+++ b/native/binding.gyp
@@ -6,7 +6,8 @@
         "binding/addon.cpp",
         "analyzer/audio_analysis.cpp",
         "analyzer/tempo_analysis.cpp",
-        "transition/wsola.cpp"
+        "transition/wsola.cpp",
+        "transition/transition_render.cpp"
       ],
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include\")"

--- a/native/binding/addon.cpp
+++ b/native/binding/addon.cpp
@@ -187,8 +187,6 @@ Napi::Value Analyze(const Napi::CallbackInfo& info) {
   return promise;
 }
 
-// Owns the planar PCM snapshot and stretched result for the worker's lifetime.
-// Mirrors AnalysisWorker: no shared mutable DSP state, no cancellation hook.
 class StretchWorker final : public Napi::AsyncWorker {
  public:
   StretchWorker(
@@ -207,12 +205,10 @@ class StretchWorker final : public Napi::AsyncWorker {
   }
 
   void Execute() override {
-    // libuv worker-pool thread: do not create or retain JavaScript/Napi values.
     result_ = orchard::WsolaStretch(channels_, sample_rate_, config_);
   }
 
   void OnOK() override {
-    // Environment thread: each channel is copied into its own Float32Array.
     const auto env = Env();
     auto output = Napi::Array::New(env, result_.size());
     for (size_t channel = 0; channel < result_.size(); ++channel) {
@@ -333,7 +329,6 @@ bool ReadSource(Napi::Env env, const Napi::Value& value, orchard::TransitionSour
   return true;
 }
 
-// Owns the PCM snapshots and rendered overlap for the worker's lifetime.
 class TransitionWorker final : public Napi::AsyncWorker {
  public:
   TransitionWorker(
@@ -352,7 +347,6 @@ class TransitionWorker final : public Napi::AsyncWorker {
   }
 
   void Execute() override {
-    // libuv worker-pool thread: do not create or retain JavaScript/Napi values.
     result_ = orchard::RenderTransition(outgoing_, incoming_, config_);
   }
 
@@ -421,7 +415,6 @@ Napi::Value RenderTransition(const Napi::CallbackInfo& info) {
   return promise;
 }
 
-// Exposes the version marker, analysis, time-stretch, and transition renderer.
 Napi::Object Initialize(Napi::Env env, Napi::Object exports) {
   exports.Set("analysisVersion", kAnalysisVersion);
   exports.Set("analyze", Napi::Function::New(env, Analyze));

--- a/native/binding/addon.cpp
+++ b/native/binding/addon.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "../analyzer/audio_analysis.h"
+#include "../transition/wsola.h"
 
 namespace {
 
@@ -185,10 +186,123 @@ Napi::Value Analyze(const Napi::CallbackInfo& info) {
   return promise;
 }
 
-// Exposes only the version marker and Promise-returning analysis entry point.
+// Owns the planar PCM snapshot and stretched result for the worker's lifetime.
+// Mirrors AnalysisWorker: no shared mutable DSP state, no cancellation hook.
+class StretchWorker final : public Napi::AsyncWorker {
+ public:
+  StretchWorker(
+    Napi::Env env,
+    std::vector<std::vector<float>> channels,
+    double sample_rate,
+    orchard::WsolaConfig config
+  ) : Napi::AsyncWorker(env),
+      deferred_(Napi::Promise::Deferred::New(env)),
+      channels_(std::move(channels)),
+      sample_rate_(sample_rate),
+      config_(config) {}
+
+  Napi::Promise Promise() const {
+    return deferred_.Promise();
+  }
+
+  void Execute() override {
+    // libuv worker-pool thread: do not create or retain JavaScript/Napi values.
+    result_ = orchard::WsolaStretch(channels_, sample_rate_, config_);
+  }
+
+  void OnOK() override {
+    // Environment thread: each channel is copied into its own Float32Array.
+    const auto env = Env();
+    auto output = Napi::Array::New(env, result_.size());
+    for (size_t channel = 0; channel < result_.size(); ++channel) {
+      auto typed = Napi::Float32Array::New(env, result_[channel].size());
+      std::copy(result_[channel].begin(), result_[channel].end(), typed.Data());
+      output.Set(channel, typed);
+    }
+    deferred_.Resolve(output);
+  }
+
+  void OnError(const Napi::Error& error) override {
+    deferred_.Reject(error.Value());
+  }
+
+ private:
+  Napi::Promise::Deferred deferred_;
+  std::vector<std::vector<float>> channels_;
+  double sample_rate_;
+  orchard::WsolaConfig config_;
+  std::vector<std::vector<float>> result_;
+};
+
+// Time-scales planar PCM without changing pitch. Accepts an array of
+// Float32Array channels so the caller can hand over AudioBuffer planes
+// directly; the copy is required because that storage stays owned by
+// JavaScript and cannot be read later from the worker-pool thread.
+Napi::Value TimeStretch(const Napi::CallbackInfo& info) {
+  const auto env = info.Env();
+  if (info.Length() < 3 || !info[0].IsArray() || !info[1].IsNumber() || !info[2].IsNumber()) {
+    Napi::TypeError::New(env, "timeStretch expects channel Float32Arrays, sampleRate, and ratio")
+      .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  const auto planes = info[0].As<Napi::Array>();
+  const double sample_rate = info[1].As<Napi::Number>().DoubleValue();
+  const double ratio = info[2].As<Napi::Number>().DoubleValue();
+  if (planes.Length() == 0 || !std::isfinite(sample_rate) || sample_rate < 1000 ||
+      !std::isfinite(ratio) || ratio <= 0) {
+    Napi::RangeError::New(env, "channels, sample rate, and ratio must be valid")
+      .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  std::vector<std::vector<float>> channels(planes.Length());
+  size_t expected = 0;
+  for (uint32_t index = 0; index < planes.Length(); ++index) {
+    const auto plane = planes.Get(index);
+    if (!plane.IsTypedArray() ||
+        plane.As<Napi::TypedArray>().TypedArrayType() != napi_float32_array) {
+      Napi::TypeError::New(env, "every channel must be a Float32Array")
+        .ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+    const auto typed = plane.As<Napi::Float32Array>();
+    if (index == 0) expected = typed.ElementLength();
+    if (typed.ElementLength() != expected || typed.ElementLength() == 0) {
+      Napi::RangeError::New(env, "channels must be non-empty and the same length")
+        .ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+    channels[index].assign(typed.Data(), typed.Data() + typed.ElementLength());
+  }
+
+  orchard::WsolaConfig config;
+  config.ratio = ratio;
+  if (info.Length() > 3 && info[3].IsObject()) {
+    const auto options = info[3].As<Napi::Object>();
+    if (options.Has("frameSize")) {
+      config.frame_size = options.Get("frameSize").As<Napi::Number>().Int32Value();
+    }
+    if (options.Has("searchRadius")) {
+      config.search_radius = options.Get("searchRadius").As<Napi::Number>().Int32Value();
+    }
+  }
+
+  auto* worker = new StretchWorker(env, std::move(channels), sample_rate, config);
+  auto promise = worker->Promise();
+  worker->Queue();
+  return promise;
+}
+
+// Exposes the version marker, analysis, and time-stretch entry points.
 Napi::Object Initialize(Napi::Env env, Napi::Object exports) {
   exports.Set("analysisVersion", kAnalysisVersion);
   exports.Set("analyze", Napi::Function::New(env, Analyze));
+  exports.Set("timeStretch", Napi::Function::New(env, TimeStretch));
+  exports.Set(
+    "maxTransparentRatioDeviation",
+    Napi::Number::New(env, orchard::kMaxTransparentRatioDeviation)
+  );
   return exports;
 }
 

--- a/native/binding/addon.cpp
+++ b/native/binding/addon.cpp
@@ -405,6 +405,8 @@ Napi::Value RenderTransition(const Napi::CallbackInfo& info) {
   config.sample_rate = number("sampleRate", config.sample_rate);
   config.beats = number("beats", config.beats);
   config.bass_swap = number("bassSwap", config.bass_swap);
+  config.handoff = number("handoff", config.handoff);
+  config.bed = number("bed", config.bed);
   config.bass_crossover_hz = number("bassCrossoverHz", config.bass_crossover_hz);
   config.bass_swap_seconds = number("bassSwapSeconds", config.bass_swap_seconds);
   config.tempo_glide = number("tempoGlide", config.tempo_glide);

--- a/native/binding/addon.cpp
+++ b/native/binding/addon.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "../analyzer/audio_analysis.h"
+#include "../transition/transition_render.h"
 #include "../transition/wsola.h"
 
 namespace {
@@ -286,6 +287,12 @@ Napi::Value TimeStretch(const Napi::CallbackInfo& info) {
     if (options.Has("searchRadius")) {
       config.search_radius = options.Get("searchRadius").As<Napi::Number>().Int32Value();
     }
+    if (options.Has("startRatio")) {
+      config.start_ratio = options.Get("startRatio").As<Napi::Number>().DoubleValue();
+    }
+    if (options.Has("glide")) {
+      config.glide = options.Get("glide").As<Napi::Number>().DoubleValue();
+    }
   }
 
   auto* worker = new StretchWorker(env, std::move(channels), sample_rate, config);
@@ -294,11 +301,132 @@ Napi::Value TimeStretch(const Napi::CallbackInfo& info) {
   return promise;
 }
 
-// Exposes the version marker, analysis, and time-stretch entry points.
+// Reads one `{ channels, anchor, bpm }` source. Returns false and leaves the
+// exception pending when the shape is wrong.
+bool ReadSource(Napi::Env env, const Napi::Value& value, orchard::TransitionSource& source) {
+  if (!value.IsObject()) {
+    Napi::TypeError::New(env, "each transition source must be an object")
+      .ThrowAsJavaScriptException();
+    return false;
+  }
+  const auto object = value.As<Napi::Object>();
+  if (!object.Get("channels").IsArray()) {
+    Napi::TypeError::New(env, "each transition source needs a channels array")
+      .ThrowAsJavaScriptException();
+    return false;
+  }
+  const auto planes = object.Get("channels").As<Napi::Array>();
+  source.channels.resize(planes.Length());
+  for (uint32_t index = 0; index < planes.Length(); ++index) {
+    const auto plane = planes.Get(index);
+    if (!plane.IsTypedArray() ||
+        plane.As<Napi::TypedArray>().TypedArrayType() != napi_float32_array) {
+      Napi::TypeError::New(env, "every channel must be a Float32Array")
+        .ThrowAsJavaScriptException();
+      return false;
+    }
+    const auto typed = plane.As<Napi::Float32Array>();
+    source.channels[index].assign(typed.Data(), typed.Data() + typed.ElementLength());
+  }
+  source.anchor = object.Has("anchor") ? object.Get("anchor").As<Napi::Number>().DoubleValue() : 0;
+  source.bpm = object.Has("bpm") ? object.Get("bpm").As<Napi::Number>().DoubleValue() : 0;
+  return true;
+}
+
+// Owns the PCM snapshots and rendered overlap for the worker's lifetime.
+class TransitionWorker final : public Napi::AsyncWorker {
+ public:
+  TransitionWorker(
+    Napi::Env env,
+    orchard::TransitionSource outgoing,
+    orchard::TransitionSource incoming,
+    orchard::TransitionConfig config
+  ) : Napi::AsyncWorker(env),
+      deferred_(Napi::Promise::Deferred::New(env)),
+      outgoing_(std::move(outgoing)),
+      incoming_(std::move(incoming)),
+      config_(config) {}
+
+  Napi::Promise Promise() const {
+    return deferred_.Promise();
+  }
+
+  void Execute() override {
+    // libuv worker-pool thread: do not create or retain JavaScript/Napi values.
+    result_ = orchard::RenderTransition(outgoing_, incoming_, config_);
+  }
+
+  void OnOK() override {
+    // Environment thread: a refusal resolves normally so callers can branch on
+    // `rendered` instead of wrapping every transition in a try/catch.
+    const auto env = Env();
+    auto output = Napi::Object::New(env);
+    output.Set("rendered", result_.rendered);
+    output.Set("rejected", result_.rejected);
+    output.Set("stretchRatio", Compact(result_.stretch_ratio));
+    output.Set("bpm", Compact(result_.bpm));
+    auto planes = Napi::Array::New(env, result_.channels.size());
+    for (size_t channel = 0; channel < result_.channels.size(); ++channel) {
+      auto typed = Napi::Float32Array::New(env, result_.channels[channel].size());
+      std::copy(result_.channels[channel].begin(), result_.channels[channel].end(), typed.Data());
+      planes.Set(channel, typed);
+    }
+    output.Set("channels", planes);
+    deferred_.Resolve(output);
+  }
+
+  void OnError(const Napi::Error& error) override {
+    deferred_.Reject(error.Value());
+  }
+
+ private:
+  Napi::Promise::Deferred deferred_;
+  orchard::TransitionSource outgoing_;
+  orchard::TransitionSource incoming_;
+  orchard::TransitionConfig config_;
+  orchard::TransitionResult result_;
+};
+
+// Renders a beat-matched overlap between two tracks into one buffer. The
+// synchronous copies are required because TypedArray storage stays owned by
+// JavaScript and cannot be read later from the worker-pool thread.
+Napi::Value RenderTransition(const Napi::CallbackInfo& info) {
+  const auto env = info.Env();
+  if (info.Length() < 3 || !info[2].IsObject()) {
+    Napi::TypeError::New(env, "renderTransition expects outgoing, incoming, and options")
+      .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  orchard::TransitionSource outgoing;
+  orchard::TransitionSource incoming;
+  if (!ReadSource(env, info[0], outgoing)) return env.Undefined();
+  if (!ReadSource(env, info[1], incoming)) return env.Undefined();
+
+  const auto options = info[2].As<Napi::Object>();
+  orchard::TransitionConfig config;
+  const auto number = [&options](const char* key, double fallback) {
+    return options.Has(key) ? options.Get(key).As<Napi::Number>().DoubleValue() : fallback;
+  };
+  config.sample_rate = number("sampleRate", config.sample_rate);
+  config.beats = number("beats", config.beats);
+  config.bass_swap = number("bassSwap", config.bass_swap);
+  config.bass_crossover_hz = number("bassCrossoverHz", config.bass_crossover_hz);
+  config.bass_swap_seconds = number("bassSwapSeconds", config.bass_swap_seconds);
+  config.tempo_glide = number("tempoGlide", config.tempo_glide);
+
+  auto* worker = new TransitionWorker(env, std::move(outgoing), std::move(incoming), config);
+  auto promise = worker->Promise();
+  worker->Queue();
+  return promise;
+}
+
+// Exposes the version marker, analysis, time-stretch, and transition renderer.
 Napi::Object Initialize(Napi::Env env, Napi::Object exports) {
   exports.Set("analysisVersion", kAnalysisVersion);
   exports.Set("analyze", Napi::Function::New(env, Analyze));
   exports.Set("timeStretch", Napi::Function::New(env, TimeStretch));
+  exports.Set("renderTransition", Napi::Function::New(env, RenderTransition));
   exports.Set(
     "maxTransparentRatioDeviation",
     Napi::Number::New(env, orchard::kMaxTransparentRatioDeviation)

--- a/native/transition/transition_render.cpp
+++ b/native/transition/transition_render.cpp
@@ -82,6 +82,15 @@ float Smooth(double progress) {
   return clamped * clamped * (3.0f - 2.0f * clamped);
 }
 
+// Maps position in the overlap onto position along the equal-power curve. The
+// pre-roll covers the curve up to `bed` and the tail covers the rest, so both
+// the length of the pre-roll and how much of the fade it is allowed to spend
+// are set independently. Linear within each segment.
+double FadePosition(double progress, double handoff, double bed) {
+  if (progress <= handoff) return bed * (progress / handoff);
+  return bed + (1.0 - bed) * ((progress - handoff) / (1.0 - handoff));
+}
+
 }  // namespace
 
 TransitionResult RenderTransition(
@@ -155,6 +164,11 @@ TransitionResult RenderTransition(
     std::clamp(config.bass_crossover_hz, 40.0, 500.0),
     config.sample_rate
   );
+  // Kept clear of both edges: at exactly 0 or 1 the fade would be a step.
+  const auto handoff = std::clamp(config.handoff, 0.05, 0.95);
+  // Above 0.5 the pre-roll would fade the outgoing track further than the
+  // tail does, which is no longer a pre-roll.
+  const auto bed = std::clamp(config.bed, 0.0, 0.5);
   const auto swap_point = std::clamp(config.bass_swap, 0.0, 1.0) * overlap_samples;
   const auto swap_ramp =
     std::max(1.0, config.bass_swap_seconds * config.sample_rate);
@@ -178,8 +192,9 @@ TransitionResult RenderTransition(
     for (size_t index = 0; index < overlap_samples; ++index) {
       const double progress =
         static_cast<double>(index) / static_cast<double>(overlap_samples);
-      const auto fade_out = std::cos(static_cast<float>(progress) * kPi * 0.5f);
-      const auto fade_in = std::sin(static_cast<float>(progress) * kPi * 0.5f);
+      const auto position = static_cast<float>(FadePosition(progress, handoff, bed));
+      const auto fade_out = std::cos(position * kPi * 0.5f);
+      const auto fade_in = std::sin(position * kPi * 0.5f);
 
       // Exactly one track owns the low end at any instant; the handover is a
       // short ramp centred on the swap point. Equal power again, for the same

--- a/native/transition/transition_render.cpp
+++ b/native/transition/transition_render.cpp
@@ -193,9 +193,16 @@ TransitionResult RenderTransition(
       const auto from_bass = std::cos(handover * kPi * 0.5f);
       const auto to_bass = std::sin(handover * kPi * 0.5f);
 
-      const auto from_mixed = from_high[index] + from_bass * (from[index] - from_high[index]);
-      const auto to_mixed = to_high[index] + to_bass * (to[index] - to_high[index]);
-      destination[index] = from_mixed * fade_out + to_mixed * fade_in;
+      // The two bands are mixed independently. Above the crossover the tracks
+      // crossfade; below it they only ever hand over, so the low end holds a
+      // constant full level across the whole overlap instead of following the
+      // outgoing fade down and dipping before the swap. This is what an EQ kill
+      // on a mixer does, and it is why the groove stays solid through a mix.
+      const auto from_low = from[index] - from_high[index];
+      const auto to_low = to[index] - to_high[index];
+      destination[index] =
+        from_high[index] * fade_out + to_high[index] * fade_in +
+        from_low * from_bass + to_low * to_bass;
     }
   }
 

--- a/native/transition/transition_render.cpp
+++ b/native/transition/transition_render.cpp
@@ -1,0 +1,198 @@
+#include "transition_render.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+#include "wsola.h"
+
+namespace orchard {
+namespace {
+
+constexpr float kPi = 3.14159265358979323846f;
+
+// Outside this range the input is not a tempo and the pairing is refused
+// rather than silently rendered onto a nonsense grid.
+constexpr double kMinBpm = 40;
+constexpr double kMaxBpm = 220;
+
+struct Biquad {
+  float b0 = 1, b1 = 0, b2 = 0, a1 = 0, a2 = 0;
+};
+
+// RBJ cookbook second-order Butterworth high-pass, normalized by a0.
+Biquad HighPass(double cutoff, double sample_rate) {
+  const double w0 = 2.0 * kPi * cutoff / sample_rate;
+  const double cosine = std::cos(w0);
+  const double alpha = std::sin(w0) / (2.0 * 0.70710678);
+  const double a0 = 1.0 + alpha;
+  Biquad filter;
+  filter.b0 = static_cast<float>(((1.0 + cosine) / 2.0) / a0);
+  filter.b1 = static_cast<float>((-(1.0 + cosine)) / a0);
+  filter.b2 = filter.b0;
+  filter.a1 = static_cast<float>((-2.0 * cosine) / a0);
+  filter.a2 = static_cast<float>((1.0 - alpha) / a0);
+  return filter;
+}
+
+// Direct form I, run forward only. The resulting phase shift is identical on
+// every channel and on both tracks, so it does not smear the stereo image or
+// misalign the two sides of the mix against each other.
+std::vector<float> ApplyHighPass(const std::vector<float>& input, const Biquad& filter) {
+  std::vector<float> output(input.size(), 0.0f);
+  float x1 = 0, x2 = 0, y1 = 0, y2 = 0;
+  for (size_t index = 0; index < input.size(); ++index) {
+    const float x0 = input[index];
+    const float y0 =
+      filter.b0 * x0 + filter.b1 * x1 + filter.b2 * x2 - filter.a1 * y1 - filter.a2 * y2;
+    output[index] = y0;
+    x2 = x1;
+    x1 = x0;
+    y2 = y1;
+    y1 = y0;
+  }
+  return output;
+}
+
+TransitionResult Refuse(const std::string& reason) {
+  TransitionResult result;
+  result.rendered = false;
+  result.rejected = reason;
+  return result;
+}
+
+bool Ragged(const std::vector<std::vector<float>>& channels) {
+  if (channels.empty() || channels.front().empty()) return true;
+  const auto length = channels.front().size();
+  for (const auto& channel : channels) {
+    if (channel.size() != length) return true;
+  }
+  return false;
+}
+
+// Smoothstep, so the low-end handover eases in and out instead of cornering.
+float Smooth(double progress) {
+  const auto clamped = static_cast<float>(std::clamp(progress, 0.0, 1.0));
+  return clamped * clamped * (3.0f - 2.0f * clamped);
+}
+
+}  // namespace
+
+TransitionResult RenderTransition(
+  const TransitionSource& outgoing,
+  const TransitionSource& incoming,
+  const TransitionConfig& config
+) {
+  if (!std::isfinite(config.sample_rate) || config.sample_rate < 1000) {
+    return Refuse("invalid sample rate");
+  }
+  if (Ragged(outgoing.channels) || Ragged(incoming.channels)) {
+    return Refuse("empty or ragged input channels");
+  }
+  if (outgoing.channels.size() != incoming.channels.size()) {
+    return Refuse("channel count mismatch");
+  }
+  if (!std::isfinite(outgoing.bpm) || outgoing.bpm < kMinBpm || outgoing.bpm > kMaxBpm ||
+      !std::isfinite(incoming.bpm) || incoming.bpm < kMinBpm || incoming.bpm > kMaxBpm) {
+    return Refuse("missing or implausible tempo");
+  }
+  if (!std::isfinite(config.beats) || config.beats <= 0) {
+    return Refuse("invalid overlap length");
+  }
+
+  // The overlap runs on the incoming track's grid, so the outgoing track is
+  // the one that moves. WsolaConfig::ratio is output-over-input length, so
+  // reaching a faster grid means compressing: a 120 BPM outgoing onto a 126
+  // BPM grid is 120/126, below 1. Inverting this silently detunes the mix by
+  // twice the tempo gap in the wrong direction.
+  const double ratio = outgoing.bpm / incoming.bpm;
+  if (std::abs(ratio - 1.0) > kMaxTransparentRatioDeviation) {
+    return Refuse("tempo difference beyond transparent stretch range");
+  }
+
+  const double beat_seconds = 60.0 / incoming.bpm;
+  const auto overlap_samples =
+    static_cast<size_t>(std::llround(config.beats * beat_seconds * config.sample_rate));
+  if (overlap_samples == 0) return Refuse("overlap rounds to zero samples");
+
+  // The outgoing anchor is expressed on its own timeline, so it moves with the
+  // stretch; the incoming anchor is already on the output timeline.
+  const auto incoming_start =
+    static_cast<int64_t>(std::llround(incoming.anchor * config.sample_rate));
+  if (incoming_start < 0 ||
+      static_cast<size_t>(incoming_start) + overlap_samples > incoming.channels.front().size()) {
+    return Refuse("incoming track too short for the requested overlap");
+  }
+
+  WsolaConfig stretch;
+  stretch.ratio = ratio;
+  if (config.tempo_glide > 0 && std::abs(ratio - 1.0) > 1e-6) {
+    // Slide onto the new tempo across the opening of the overlap instead of
+    // stepping onto it, the way a DJ rides a pitch fader.
+    stretch.start_ratio = 1.0;
+    stretch.glide = std::min(1.0, config.tempo_glide);
+  }
+  const auto stretched = WsolaStretch(outgoing.channels, config.sample_rate, stretch);
+  if (stretched.empty() || stretched.front().empty()) {
+    return Refuse("outgoing track too short to time-scale");
+  }
+
+  const auto outgoing_start =
+    static_cast<int64_t>(std::llround(outgoing.anchor * ratio * config.sample_rate));
+  if (outgoing_start < 0 ||
+      static_cast<size_t>(outgoing_start) + overlap_samples > stretched.front().size()) {
+    return Refuse("outgoing track too short for the requested overlap");
+  }
+
+  const auto channel_count = incoming.channels.size();
+  const auto crossover = HighPass(
+    std::clamp(config.bass_crossover_hz, 40.0, 500.0),
+    config.sample_rate
+  );
+  const auto swap_point = std::clamp(config.bass_swap, 0.0, 1.0) * overlap_samples;
+  const auto swap_ramp =
+    std::max(1.0, config.bass_swap_seconds * config.sample_rate);
+
+  TransitionResult result;
+  result.channels.assign(channel_count, std::vector<float>(overlap_samples, 0.0f));
+
+  for (size_t channel = 0; channel < channel_count; ++channel) {
+    std::vector<float> from(overlap_samples);
+    std::vector<float> to(overlap_samples);
+    for (size_t index = 0; index < overlap_samples; ++index) {
+      from[index] = stretched[channel][static_cast<size_t>(outgoing_start) + index];
+      to[index] = incoming.channels[channel][static_cast<size_t>(incoming_start) + index];
+    }
+    // Interpolating between a signal and its own high-passed copy is a clean
+    // low shelf, and avoids recomputing biquad coefficients per sample.
+    const auto from_high = ApplyHighPass(from, crossover);
+    const auto to_high = ApplyHighPass(to, crossover);
+
+    auto& destination = result.channels[channel];
+    for (size_t index = 0; index < overlap_samples; ++index) {
+      const double progress =
+        static_cast<double>(index) / static_cast<double>(overlap_samples);
+      // Equal power, so the perceived level stays flat across the overlap
+      // rather than dipping in the middle the way a linear fade does.
+      const auto fade_out = std::cos(static_cast<float>(progress) * kPi * 0.5f);
+      const auto fade_in = std::sin(static_cast<float>(progress) * kPi * 0.5f);
+
+      // Exactly one track owns the low end at any instant; the handover is a
+      // short ramp centred on the swap point.
+      const auto handover = Smooth((static_cast<double>(index) - swap_point) / swap_ramp + 0.5);
+      const auto from_bass = 1.0f - handover;
+      const auto to_bass = handover;
+
+      const auto from_mixed = from_high[index] + from_bass * (from[index] - from_high[index]);
+      const auto to_mixed = to_high[index] + to_bass * (to[index] - to_high[index]);
+      destination[index] = from_mixed * fade_out + to_mixed * fade_in;
+    }
+  }
+
+  result.rendered = true;
+  result.stretch_ratio = ratio;
+  result.bpm = incoming.bpm;
+  return result;
+}
+
+}  // namespace orchard

--- a/native/transition/transition_render.cpp
+++ b/native/transition/transition_render.cpp
@@ -35,21 +35,28 @@ Biquad HighPass(double cutoff, double sample_rate) {
   return filter;
 }
 
+// Two identical Butterworth sections in series: a fourth-order Linkwitz-Riley
+// high-pass at 24 dB/octave, the slope DJ mixers use for a bass kill. A single
+// 12 dB/octave section leaves the incoming low end only about 15 dB down at
+// the crossover, which is audible as bass arriving before the swap.
+//
 // Direct form I, run forward only. The resulting phase shift is identical on
 // every channel and on both tracks, so it does not smear the stereo image or
 // misalign the two sides of the mix against each other.
 std::vector<float> ApplyHighPass(const std::vector<float>& input, const Biquad& filter) {
-  std::vector<float> output(input.size(), 0.0f);
-  float x1 = 0, x2 = 0, y1 = 0, y2 = 0;
-  for (size_t index = 0; index < input.size(); ++index) {
-    const float x0 = input[index];
-    const float y0 =
-      filter.b0 * x0 + filter.b1 * x1 + filter.b2 * x2 - filter.a1 * y1 - filter.a2 * y2;
-    output[index] = y0;
-    x2 = x1;
-    x1 = x0;
-    y2 = y1;
-    y1 = y0;
+  std::vector<float> output(input);
+  for (int section = 0; section < 2; ++section) {
+    float x1 = 0, x2 = 0, y1 = 0, y2 = 0;
+    for (size_t index = 0; index < output.size(); ++index) {
+      const float x0 = output[index];
+      const float y0 =
+        filter.b0 * x0 + filter.b1 * x1 + filter.b2 * x2 - filter.a1 * y1 - filter.a2 * y2;
+      output[index] = y0;
+      x2 = x1;
+      x1 = x0;
+      y2 = y1;
+      y1 = y0;
+    }
   }
   return output;
 }
@@ -178,10 +185,13 @@ TransitionResult RenderTransition(
       const auto fade_in = std::sin(static_cast<float>(progress) * kPi * 0.5f);
 
       // Exactly one track owns the low end at any instant; the handover is a
-      // short ramp centred on the swap point.
+      // short ramp centred on the swap point. Equal power again, for the same
+      // reason as the main fade: the two low ends are uncorrelated, so linear
+      // gains would leave them summing 3 dB down at the midpoint and put an
+      // audible hole in the bass exactly where it changes hands.
       const auto handover = Smooth((static_cast<double>(index) - swap_point) / swap_ramp + 0.5);
-      const auto from_bass = 1.0f - handover;
-      const auto to_bass = handover;
+      const auto from_bass = std::cos(handover * kPi * 0.5f);
+      const auto to_bass = std::sin(handover * kPi * 0.5f);
 
       const auto from_mixed = from_high[index] + from_bass * (from[index] - from_high[index]);
       const auto to_mixed = to_high[index] + to_bass * (to[index] - to_high[index]);

--- a/native/transition/transition_render.cpp
+++ b/native/transition/transition_render.cpp
@@ -77,7 +77,6 @@ bool Ragged(const std::vector<std::vector<float>>& channels) {
   return false;
 }
 
-// Smoothstep, so the low-end handover eases in and out instead of cornering.
 float Smooth(double progress) {
   const auto clamped = static_cast<float>(std::clamp(progress, 0.0, 1.0));
   return clamped * clamped * (3.0f - 2.0f * clamped);
@@ -179,8 +178,6 @@ TransitionResult RenderTransition(
     for (size_t index = 0; index < overlap_samples; ++index) {
       const double progress =
         static_cast<double>(index) / static_cast<double>(overlap_samples);
-      // Equal power, so the perceived level stays flat across the overlap
-      // rather than dipping in the middle the way a linear fade does.
       const auto fade_out = std::cos(static_cast<float>(progress) * kPi * 0.5f);
       const auto fade_in = std::sin(static_cast<float>(progress) * kPi * 0.5f);
 
@@ -193,11 +190,6 @@ TransitionResult RenderTransition(
       const auto from_bass = std::cos(handover * kPi * 0.5f);
       const auto to_bass = std::sin(handover * kPi * 0.5f);
 
-      // The two bands are mixed independently. Above the crossover the tracks
-      // crossfade; below it they only ever hand over, so the low end holds a
-      // constant full level across the whole overlap instead of following the
-      // outgoing fade down and dipping before the swap. This is what an EQ kill
-      // on a mixer does, and it is why the groove stays solid through a mix.
       const auto from_low = from[index] - from_high[index];
       const auto to_low = to[index] - to_high[index];
       destination[index] =

--- a/native/transition/transition_render.h
+++ b/native/transition/transition_render.h
@@ -36,8 +36,15 @@ struct TransitionConfig {
   // the finished transition runs on.
   double beats = 32;
   // Point in the overlap, as a fraction, where the low end hands over from the
-  // outgoing to the incoming track. Callers should quantize this to a downbeat.
-  double bass_swap = 0.5;
+  // outgoing to the incoming track. Callers should quantize this to a downbeat,
+  // so the effective swap lands on the nearest one rather than exactly here.
+  //
+  // Later than the midpoint by choice: the equal-power fades cross at 0.5, and
+  // handing the low end over at the same instant makes the incoming track
+  // arrive early, because it gains the bass while still fading up. Holding the
+  // low end on the outgoing track past the crossover was judged better by ear
+  // on real material than 0.55.
+  double bass_swap = 0.7;
   // Corner frequency of the bass handover. Everything below it belongs to
   // exactly one track at a time, which is what keeps the overlap from turning
   // to mud when two kick drums collide.

--- a/native/transition/transition_render.h
+++ b/native/transition/transition_render.h
@@ -1,0 +1,87 @@
+// Offline renderer for a single beat-matched transition between two tracks.
+// Produces one finished stereo overlap buffer that the player can schedule as
+// a plain audio source, replacing per-node gain and filter automation with a
+// deterministic, testable mix.
+//
+// The outgoing track is the one that gets time-scaled. It is discarded once
+// the overlap ends, so any tempo artefact dies with it and the incoming track
+// runs at its native rate throughout -- there is no seam, and no tempo step,
+// at the point where playback hands over. Stretching the incoming instead
+// would leave it detuned from its own file for the rest of playback.
+//
+// All PCM is planar (non-interleaved) Float32 in [-1, 1], every channel the
+// same length. Calls borrow their inputs only until they return, own all
+// returned storage, and are reentrant. Rendering allocates and performs O(n)
+// work, so it belongs on a worker thread and must never run in a real-time
+// audio callback.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace orchard {
+
+struct TransitionSource {
+  std::vector<std::vector<float>> channels;
+  // Seconds from the start of `channels` to the beat the mix aligns on.
+  // Both tracks are positioned so these two instants coincide.
+  double anchor = 0;
+  double bpm = 0;
+};
+
+struct TransitionConfig {
+  double sample_rate = 44100;
+  // Overlap length in beats of the incoming track's grid, which is the grid
+  // the finished transition runs on.
+  double beats = 32;
+  // Point in the overlap, as a fraction, where the low end hands over from the
+  // outgoing to the incoming track. Callers should quantize this to a downbeat.
+  double bass_swap = 0.5;
+  // Corner frequency of the bass handover. Everything below it belongs to
+  // exactly one track at a time, which is what keeps the overlap from turning
+  // to mud when two kick drums collide.
+  double bass_crossover_hz = 200;
+  // Duration of the low-end handover ramp.
+  double bass_swap_seconds = 0.75;
+  // Fraction of the outgoing audio over which it glides onto the incoming
+  // tempo instead of starting there.
+  //
+  // Defaults to off, and should stay off for an overlap that begins at the
+  // first sample: during the glide the outgoing track is by definition not on
+  // the incoming grid, and it is loudest exactly then, so the listener hears a
+  // beat clash through the opening of the mix. Measured on a 120 -> 126 BPM
+  // pair, a quarter-length glide held the opening at 123 BPM instead of 126.
+  // It is only useful when the caller passes extra outgoing audio ahead of the
+  // overlap, so the tempo move lands while that track is still playing solo.
+  double tempo_glide = 0;
+};
+
+struct TransitionResult {
+  std::vector<std::vector<float>> channels;
+  // Time-scaling applied to the outgoing track; 1 when the tempos matched.
+  double stretch_ratio = 1;
+  // Tempo the rendered overlap runs at, equal to the incoming track's.
+  double bpm = 0;
+  bool rendered = false;
+  // Empty when `rendered`; otherwise why the pairing was refused, so callers
+  // can fall back to a plain crossfade and log a reason.
+  std::string rejected;
+};
+
+/**
+ * Renders the overlap between two tracks as a single mixed buffer.
+ *
+ * Refuses rather than throws when the pairing cannot be rendered
+ * transparently: missing or absurd tempo, a stretch beyond
+ * kMaxTransparentRatioDeviation, or too little audio on either side to fill
+ * the requested overlap. Callers are expected to treat a refusal as "use the
+ * ordinary crossfade instead".
+ */
+TransitionResult RenderTransition(
+  const TransitionSource& outgoing,
+  const TransitionSource& incoming,
+  const TransitionConfig& config
+);
+
+}  // namespace orchard

--- a/native/transition/transition_render.h
+++ b/native/transition/transition_render.h
@@ -43,6 +43,33 @@ struct TransitionConfig {
   // low end on the outgoing track past the crossover was judged better by ear
   // on real material than 0.55.
   double bass_swap = 0.7;
+  // Point in the overlap, as a fraction, where the two tracks cross at equal
+  // power. Everything before it is the incoming track's pre-roll: its intro
+  // playing underneath the outgoing track, rising like a fader ride rather
+  // than a crossfade.
+  //
+  // A DJ does not start a blend at the incoming track's drop, because that is
+  // where its vocal and full arrangement arrive, and the outgoing track is
+  // still singing. They bring the intro in early, underneath, and let the drop
+  // be the moment the mix changes hands. Callers place this at the incoming
+  // drop so the mix changes hands there.
+  //
+  // 0.5 reproduces the plain symmetric equal-power crossfade.
+  double handoff = 0.5;
+  // How far along the equal-power curve the pre-roll travels: the incoming
+  // track's level at the handoff, and the outgoing track's loss up to it.
+  //
+  // The pre-roll is a fader ride under a track that is still playing, not the
+  // first half of a crossfade. At 0.25 the incoming intro reaches -8 dB while
+  // the outgoing has given up 0.7 dB -- a bed -- and the whole audible fade
+  // then happens in the tail. Spending the curve's first half on the pre-roll
+  // instead (bed = 0.5) costs the outgoing track only 3 dB over what may be
+  // fifteen seconds, which reads as no fade at all, and then leaves it fading
+  // for the entire tail on top: slow at both ends.
+  //
+  // 0.5 makes the fade one continuous equal-power curve across the overlap,
+  // which with handoff = 0.5 is the plain symmetric crossfade.
+  double bed = 0.5;
   // Corner frequency of the bass handover. Everything below it belongs to
   // exactly one track at a time, which is what keeps the overlap from turning
   // to mud when two kick drums collide.

--- a/native/transition/transition_render.h
+++ b/native/transition/transition_render.h
@@ -32,8 +32,6 @@ struct TransitionSource {
 
 struct TransitionConfig {
   double sample_rate = 44100;
-  // Overlap length in beats of the incoming track's grid, which is the grid
-  // the finished transition runs on.
   double beats = 32;
   // Point in the overlap, as a fraction, where the low end hands over from the
   // outgoing to the incoming track. Callers should quantize this to a downbeat,
@@ -49,7 +47,6 @@ struct TransitionConfig {
   // exactly one track at a time, which is what keeps the overlap from turning
   // to mud when two kick drums collide.
   double bass_crossover_hz = 200;
-  // Duration of the low-end handover ramp.
   double bass_swap_seconds = 0.75;
   // Fraction of the outgoing audio over which it glides onto the incoming
   // tempo instead of starting there.
@@ -66,9 +63,7 @@ struct TransitionConfig {
 
 struct TransitionResult {
   std::vector<std::vector<float>> channels;
-  // Time-scaling applied to the outgoing track; 1 when the tempos matched.
   double stretch_ratio = 1;
-  // Tempo the rendered overlap runs at, equal to the incoming track's.
   double bpm = 0;
   bool rendered = false;
   // Empty when `rendered`; otherwise why the pairing was refused, so callers

--- a/native/transition/wsola.cpp
+++ b/native/transition/wsola.cpp
@@ -1,0 +1,178 @@
+#include "wsola.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace orchard {
+namespace {
+
+// MSVC only defines M_PI when _USE_MATH_DEFINES is set before <cmath>, and the
+// binding is built on Windows too, so the constant is spelled out here.
+constexpr float kPi = 3.14159265358979323846f;
+
+// 46 ms at 44.1 kHz. Long enough that a 40 Hz bass period fits inside the
+// overlap, short enough that transients do not smear across a beat.
+constexpr double kFrameSeconds = 0.046;
+
+// Guards the normalized cross-correlation denominator on near-silent frames,
+// where the numerator is noise and any offset would otherwise "win".
+constexpr float kCorrelationEpsilon = 1e-9f;
+
+int ResolveFrameSize(const WsolaConfig& config, double sample_rate) {
+  if (config.frame_size > 0) return config.frame_size;
+  const auto derived = static_cast<int>(std::lround(sample_rate * kFrameSeconds));
+  // Force an even frame so the synthesis hop is exactly half and the Hann
+  // window satisfies constant overlap-add.
+  return std::max(4, derived - (derived % 2));
+}
+
+std::vector<float> Downmix(const std::vector<std::vector<float>>& channels, size_t length) {
+  std::vector<float> mono(length, 0.0f);
+  if (channels.empty()) return mono;
+  const auto scale = 1.0f / static_cast<float>(channels.size());
+  for (const auto& channel : channels) {
+    for (size_t index = 0; index < length; ++index) {
+      mono[index] += channel[index] * scale;
+    }
+  }
+  return mono;
+}
+
+std::vector<float> HannWindow(int size) {
+  std::vector<float> window(static_cast<size_t>(size));
+  for (int index = 0; index < size; ++index) {
+    window[static_cast<size_t>(index)] =
+      0.5f - 0.5f * std::cos(2.0f * kPi * static_cast<float>(index) /
+                             static_cast<float>(size));
+  }
+  return window;
+}
+
+// Normalized cross-correlation between the candidate segment at `start` and
+// `reference`. Normalizing by the candidate's own energy stops loud passages
+// from always outscoring the genuinely better-aligned quiet ones.
+float Similarity(const std::vector<float>& mono, int64_t start,
+                 const std::vector<float>& reference) {
+  float dot = 0.0f;
+  float energy = 0.0f;
+  for (size_t index = 0; index < reference.size(); ++index) {
+    const auto value = mono[static_cast<size_t>(start) + index];
+    dot += value * reference[index];
+    energy += value * value;
+  }
+  return dot / std::sqrt(energy + kCorrelationEpsilon);
+}
+
+}  // namespace
+
+std::vector<std::vector<float>> WsolaStretch(
+  const std::vector<std::vector<float>>& channels,
+  double sample_rate,
+  const WsolaConfig& config
+) {
+  if (channels.empty() || !std::isfinite(sample_rate) || sample_rate < 1000) return {};
+  if (!std::isfinite(config.ratio) || config.ratio <= 0) return {};
+
+  const auto input_length = channels.front().size();
+  if (input_length == 0) return {};
+  for (const auto& channel : channels) {
+    if (channel.size() != input_length) return {};
+  }
+
+  const int frame = ResolveFrameSize(config, sample_rate);
+  const int synthesis_hop = frame / 2;
+  const int overlap = frame - synthesis_hop;
+  // The analysis hop is what actually realizes the ratio: output advances by
+  // synthesis_hop per frame while input advances by analysis_hop.
+  const int analysis_hop =
+    std::max(1, static_cast<int>(std::lround(synthesis_hop / config.ratio)));
+  const int radius = config.search_radius > 0 ? config.search_radius : frame / 4;
+  if (input_length < static_cast<size_t>(frame)) return {};
+
+  const auto window = HannWindow(frame);
+  const auto mono = Downmix(channels, input_length);
+
+  const auto output_length =
+    static_cast<size_t>(std::llround(static_cast<double>(input_length) * config.ratio)) +
+    static_cast<size_t>(frame);
+  std::vector<std::vector<float>> output(channels.size(),
+                                         std::vector<float>(output_length, 0.0f));
+  // Hann at 50% overlap sums to unity in steady state but not across the first
+  // and last frames, so the accumulated window is divided out at the end
+  // rather than assumed.
+  std::vector<float> window_sum(output_length, 0.0f);
+
+  std::vector<float> reference(static_cast<size_t>(overlap), 0.0f);
+  bool have_reference = false;
+
+  for (size_t frame_index = 0;; ++frame_index) {
+    const auto nominal =
+      static_cast<int64_t>(frame_index) * static_cast<int64_t>(analysis_hop);
+    const auto synthesis_start =
+      static_cast<int64_t>(frame_index) * static_cast<int64_t>(synthesis_hop);
+    if (synthesis_start + frame > static_cast<int64_t>(output_length)) break;
+
+    int64_t chosen = nominal;
+    if (have_reference) {
+      // Slide the analysis window within +/-radius to find the placement whose
+      // leading overlap best continues the waveform already written out. This
+      // is the whole point of WSOLA: it removes the phase discontinuity that
+      // plain OLA resampling would leave at every frame boundary.
+      const auto lowest = std::max<int64_t>(0, nominal - radius);
+      const auto highest = std::min<int64_t>(
+        nominal + radius,
+        static_cast<int64_t>(input_length) - frame
+      );
+      float best_score = -std::numeric_limits<float>::infinity();
+      for (auto candidate = lowest; candidate <= highest; ++candidate) {
+        const auto score = Similarity(mono, candidate, reference);
+        if (score > best_score) {
+          best_score = score;
+          chosen = candidate;
+        }
+      }
+    }
+    if (chosen < 0 || chosen + frame > static_cast<int64_t>(input_length)) break;
+
+    for (size_t channel = 0; channel < channels.size(); ++channel) {
+      const auto& source = channels[channel];
+      auto& destination = output[channel];
+      for (int index = 0; index < frame; ++index) {
+        destination[static_cast<size_t>(synthesis_start) + index] +=
+          source[static_cast<size_t>(chosen) + index] * window[static_cast<size_t>(index)];
+      }
+    }
+    for (int index = 0; index < frame; ++index) {
+      window_sum[static_cast<size_t>(synthesis_start) + index] +=
+        window[static_cast<size_t>(index)];
+    }
+
+    // The natural continuation of what was just emitted: one synthesis hop on
+    // from the chosen offset. The next frame is scored against this.
+    const auto continuation = chosen + synthesis_hop;
+    if (continuation + overlap > static_cast<int64_t>(input_length)) break;
+    for (int index = 0; index < overlap; ++index) {
+      reference[static_cast<size_t>(index)] =
+        mono[static_cast<size_t>(continuation) + index];
+    }
+    have_reference = true;
+  }
+
+  // Trim to the last sample that actually received window energy so callers do
+  // not inherit the frame of zero padding the accumulator reserved.
+  size_t written = 0;
+  for (size_t index = 0; index < output_length; ++index) {
+    if (window_sum[index] > 1e-6f) written = index + 1;
+  }
+  for (auto& channel : output) {
+    for (size_t index = 0; index < written; ++index) {
+      if (window_sum[index] > 1e-6f) channel[index] /= window_sum[index];
+    }
+    channel.resize(written);
+  }
+  return output;
+}
+
+}  // namespace orchard

--- a/native/transition/wsola.cpp
+++ b/native/transition/wsola.cpp
@@ -84,18 +84,22 @@ std::vector<std::vector<float>> WsolaStretch(
   const int frame = ResolveFrameSize(config, sample_rate);
   const int synthesis_hop = frame / 2;
   const int overlap = frame - synthesis_hop;
-  // The analysis hop is what actually realizes the ratio: output advances by
-  // synthesis_hop per frame while input advances by analysis_hop.
-  const int analysis_hop =
-    std::max(1, static_cast<int>(std::lround(synthesis_hop / config.ratio)));
   const int radius = config.search_radius > 0 ? config.search_radius : frame / 4;
+
+  const bool gliding =
+    config.start_ratio > 0 && config.glide > 0 && std::isfinite(config.start_ratio);
+  const double glide_span = gliding ? std::min(1.0, config.glide) : 0.0;
+  const double opening_ratio = gliding ? config.start_ratio : config.ratio;
   if (input_length < static_cast<size_t>(frame)) return {};
 
   const auto window = HannWindow(frame);
   const auto mono = Downmix(channels, input_length);
 
+  // Allocated against the slowest ratio in play so a glide cannot overrun the
+  // buffer; the unused tail is trimmed once the window accumulator is known.
   const auto output_length =
-    static_cast<size_t>(std::llround(static_cast<double>(input_length) * config.ratio)) +
+    static_cast<size_t>(std::llround(static_cast<double>(input_length) *
+                                     std::max(config.ratio, opening_ratio))) +
     static_cast<size_t>(frame);
   std::vector<std::vector<float>> output(channels.size(),
                                          std::vector<float>(output_length, 0.0f));
@@ -106,13 +110,26 @@ std::vector<std::vector<float>> WsolaStretch(
 
   std::vector<float> reference(static_cast<size_t>(overlap), 0.0f);
   bool have_reference = false;
+  // Advanced by a per-frame hop rather than derived from the frame index, so a
+  // glide can vary the rate at which input is consumed.
+  double analysis_position = 0;
 
   for (size_t frame_index = 0;; ++frame_index) {
-    const auto nominal =
-      static_cast<int64_t>(frame_index) * static_cast<int64_t>(analysis_hop);
+    const auto nominal = static_cast<int64_t>(std::llround(analysis_position));
     const auto synthesis_start =
       static_cast<int64_t>(frame_index) * static_cast<int64_t>(synthesis_hop);
     if (synthesis_start + frame > static_cast<int64_t>(output_length)) break;
+
+    // The glide is scheduled against input consumed, which is monotonic and
+    // known exactly, unlike the output length under a varying ratio.
+    const double consumed = analysis_position / static_cast<double>(input_length);
+    const double active_ratio =
+      gliding && consumed < glide_span
+        ? opening_ratio + (config.ratio - opening_ratio) * (consumed / glide_span)
+        : config.ratio;
+    // The analysis hop is what actually realizes the ratio: output advances by
+    // synthesis_hop per frame while input advances by analysis_hop.
+    const double analysis_hop = std::max(1.0, synthesis_hop / active_ratio);
 
     int64_t chosen = nominal;
     if (have_reference) {
@@ -158,6 +175,9 @@ std::vector<std::vector<float>> WsolaStretch(
         mono[static_cast<size_t>(continuation) + index];
     }
     have_reference = true;
+    // The chosen offset is a local perturbation only; the nominal grid keeps
+    // advancing on schedule so search jitter cannot accumulate into drift.
+    analysis_position += analysis_hop;
   }
 
   // Trim to the last sample that actually received window energy so callers do

--- a/native/transition/wsola.cpp
+++ b/native/transition/wsola.cpp
@@ -28,14 +28,41 @@ int ResolveFrameSize(const WsolaConfig& config, double sample_rate) {
   return std::max(4, derived - (derived % 2));
 }
 
-std::vector<float> Downmix(const std::vector<std::vector<float>>& channels, size_t length) {
+std::vector<float> CorrelationGuide(
+  const std::vector<std::vector<float>>& channels,
+  size_t length
+) {
   std::vector<float> mono(length, 0.0f);
   if (channels.empty()) return mono;
   const auto scale = 1.0f / static_cast<float>(channels.size());
+  std::vector<double> channel_energy(channels.size(), 0.0);
+  double mono_energy = 0.0;
   for (const auto& channel : channels) {
     for (size_t index = 0; index < length; ++index) {
       mono[index] += channel[index] * scale;
     }
+  }
+  for (size_t channel = 0; channel < channels.size(); ++channel) {
+    for (size_t index = 0; index < length; ++index) {
+      const auto value = channels[channel][index];
+      channel_energy[channel] += static_cast<double>(value) * value;
+    }
+  }
+  for (const auto value : mono) {
+    mono_energy += static_cast<double>(value) * value;
+  }
+
+  // Wide stereo masters can carry nearly opposite-phase material. Their mono
+  // sum is then mostly quantization noise, which makes the similarity search
+  // jump between arbitrary offsets and produces a fluttering/glitchy stretch.
+  // Keep the shared offset search, but guide it with the loudest channel when
+  // the downmix has lost more than 20 dB of the available signal energy.
+  const auto loudest = static_cast<size_t>(std::distance(
+    channel_energy.begin(),
+    std::max_element(channel_energy.begin(), channel_energy.end())
+  ));
+  if (!channel_energy.empty() && mono_energy < channel_energy[loudest] * 0.01) {
+    return channels[loudest];
   }
   return mono;
 }
@@ -93,7 +120,7 @@ std::vector<std::vector<float>> WsolaStretch(
   if (input_length < static_cast<size_t>(frame)) return {};
 
   const auto window = HannWindow(frame);
-  const auto mono = Downmix(channels, input_length);
+  const auto mono = CorrelationGuide(channels, input_length);
 
   // Allocated against the slowest ratio in play so a glide cannot overrun the
   // buffer; the unused tail is trimmed once the window accumulator is known.

--- a/native/transition/wsola.h
+++ b/native/transition/wsola.h
@@ -1,0 +1,54 @@
+// Waveform-Similarity Overlap-Add time scaling for offline transition
+// rendering. `channels` is planar (non-interleaved) Float32 PCM in [-1, 1],
+// every channel the same length, matching the layout AudioBuffer exposes.
+//
+// The similarity search runs once on a mono downmix and the resulting input
+// offsets are applied to every channel, so a stereo image survives the stretch
+// intact; searching per channel would decorrelate them and collapse the image.
+//
+// Calls borrow the input only until they return and produce results that own
+// all storage. Stretching is reentrant because every mutable value is
+// call-local. It allocates and performs O(n * search_radius) work, so it
+// belongs on a worker thread and must never run in a real-time audio callback.
+
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace orchard {
+
+struct WsolaConfig {
+  // Output length divided by input length. Values above 1 stretch the signal
+  // (playing it slower); values below 1 compress it. To retune a track of
+  // tempo `source_bpm` onto a grid of `target_bpm`, use source_bpm/target_bpm.
+  double ratio = 1.0;
+  // Analysis/synthesis window in samples. Zero derives ~46 ms from the sample
+  // rate, which keeps bass periods intact on four-to-the-floor material.
+  int frame_size = 0;
+  // Half-width of the similarity search in samples. Zero derives a quarter of
+  // the frame, enough to slide over one period of a low bass note.
+  int search_radius = 0;
+};
+
+// The largest deviation from unity this implementation is willing to render.
+// WSOLA stays transparent on music to roughly +/-8%; past that it audibly
+// stutters on sustained tones, so callers should reject the pairing instead.
+inline constexpr double kMaxTransparentRatioDeviation = 0.08;
+
+/**
+ * Time-scales planar audio by `config.ratio` while preserving pitch.
+ *
+ * Returns an empty vector when the input is empty, ragged, or the resolved
+ * configuration cannot produce a frame; the caller is expected to treat that
+ * as "do not attempt this transition" rather than as a fatal error. A ratio of
+ * exactly 1 still round-trips through the overlap-add path so that callers get
+ * identical framing behaviour regardless of tempo.
+ */
+std::vector<std::vector<float>> WsolaStretch(
+  const std::vector<std::vector<float>>& channels,
+  double sample_rate,
+  const WsolaConfig& config
+);
+
+}  // namespace orchard

--- a/native/transition/wsola.h
+++ b/native/transition/wsola.h
@@ -2,9 +2,11 @@
 // rendering. `channels` is planar (non-interleaved) Float32 PCM in [-1, 1],
 // every channel the same length, matching the layout AudioBuffer exposes.
 //
-// The similarity search runs once on a mono downmix and the resulting input
-// offsets are applied to every channel, so a stereo image survives the stretch
-// intact; searching per channel would decorrelate them and collapse the image.
+// The similarity search runs once on a shared correlation guide and the
+// resulting input offsets are applied to every channel, so a stereo image
+// survives the stretch intact. The guide normally uses a mono downmix, but
+// falls back to the loudest channel when phase cancellation makes that downmix
+// unreliable; searching independently per channel would decorrelate them.
 //
 // Calls borrow the input only until they return and produce results that own
 // all storage. Stretching is reentrant because every mutable value is

--- a/native/transition/wsola.h
+++ b/native/transition/wsola.h
@@ -23,6 +23,13 @@ struct WsolaConfig {
   // (playing it slower); values below 1 compress it. To retune a track of
   // tempo `source_bpm` onto a grid of `target_bpm`, use source_bpm/target_bpm.
   double ratio = 1.0;
+  // Ratio to begin at before gliding to `ratio`, letting a track slide onto a
+  // new tempo the way a DJ rides a pitch fader instead of stepping onto it.
+  // Zero disables the glide and holds `ratio` throughout.
+  double start_ratio = 0;
+  // Fraction of the input over which `start_ratio` reaches `ratio`. Ignored
+  // when there is no glide; clamped to (0, 1].
+  double glide = 0;
   // Analysis/synthesis window in samples. Zero derives ~46 ms from the sample
   // rate, which keeps bass periods intact on four-to-the-floor material.
   int frame_size = 0;

--- a/shared/ipcChannels.js
+++ b/shared/ipcChannels.js
@@ -19,6 +19,7 @@ export const IPC_CHANNELS = Object.freeze({
     AVAILABLE: 'audio-analysis:available',
     DEBUG: 'audio-analysis:debug',
     GET: 'audio-analysis:get',
+    RENDER_TRANSITION: 'audio-analysis:render-transition',
     STORE: 'audio-analysis:store'
   }),
   CLIPBOARD: Object.freeze({

--- a/src/app/core/computedState.js
+++ b/src/app/core/computedState.js
@@ -228,14 +228,27 @@ export function installComputedState(ctx) {
       };
     }
 
-    const plan = ctx.autoCrossfade.transitionPlan({
-      analysis: ctx.crossfadeAnalysis.value,
-      currentTime: 0,
-      currentTrack: ctx.activeTrack.value,
-      duration: length,
-      nextAnalysis: ctx.nextCrossfadeAnalysis.value,
-      nextTrack
-    });
+    // The marker must describe the engine that will actually run. A qualifying
+    // WSOLA pairing overrides the legacy plan, whose Apple-style overlap starts
+    // many seconds earlier and would put the marker in the wrong place.
+    const wsolaPlan = ctx.crossfadeMode.value === 'smart'
+      ? ctx.wsolaCrossfade?.plan({
+        analysis: ctx.crossfadeAnalysis.value,
+        nextAnalysis: ctx.nextCrossfadeAnalysis.value,
+        duration: length,
+        nextDuration: Number(nextTrack.durationSeconds) || 0
+      })
+      : null;
+    const plan = wsolaPlan?.ok
+      ? { transitionStart: wsolaPlan.transitionStart, markerVisible: true }
+      : ctx.autoCrossfade.transitionPlan({
+        analysis: ctx.crossfadeAnalysis.value,
+        currentTime: 0,
+        currentTrack: ctx.activeTrack.value,
+        duration: length,
+        nextAnalysis: ctx.nextCrossfadeAnalysis.value,
+        nextTrack
+      });
     const start = length > 0
       ? Math.max(0, Math.min(100, (Number(plan.transitionStart) / length) * 100))
       : 100;

--- a/src/app/core/computedState.js
+++ b/src/app/core/computedState.js
@@ -228,15 +228,19 @@ export function installComputedState(ctx) {
       };
     }
 
-    // Smart mode has no fixed-duration fallback: when WSOLA cannot plan the
-    // pairing there is no transition to mark.
-    const plan = ctx.crossfadeMode.value === 'smart'
+    // The marker must describe the engine that will actually run. A qualifying
+    // WSOLA pairing overrides the legacy plan, whose Apple-style overlap starts
+    // many seconds earlier and would put the marker in the wrong place.
+    const wsolaPlan = ctx.crossfadeMode.value === 'smart'
       ? ctx.wsolaCrossfade?.plan({
         analysis: ctx.crossfadeAnalysis.value,
         nextAnalysis: ctx.nextCrossfadeAnalysis.value,
         duration: length,
         nextDuration: Number(nextTrack.durationSeconds) || 0
       })
+      : null;
+    const plan = wsolaPlan?.ok
+      ? { transitionStart: wsolaPlan.transitionStart, markerVisible: true }
       : ctx.autoCrossfade.transitionPlan({
         analysis: ctx.crossfadeAnalysis.value,
         currentTime: 0,
@@ -245,19 +249,15 @@ export function installComputedState(ctx) {
         nextAnalysis: ctx.nextCrossfadeAnalysis.value,
         nextTrack
       });
-    const markerVisible = ctx.crossfadeMode.value === 'smart'
-      ? Boolean(plan?.ok)
-      : Boolean(plan?.markerVisible);
-    const transitionStart = Number(plan?.transitionStart);
-    const start = length > 0 && Number.isFinite(transitionStart)
-      ? Math.max(0, Math.min(100, (transitionStart / length) * 100))
+    const start = length > 0
+      ? Math.max(0, Math.min(100, (Number(plan.transitionStart) / length) * 100))
       : 100;
     return {
       '--crossfade-left': `${start}%`,
       '--crossfade-right': '0%',
       '--crossfade-opacity': ctx.crossfadeEnabled.value &&
         ctx.activeTrack.value &&
-        markerVisible ? 1 : 0
+        plan.markerVisible ? 1 : 0
     };
   });
 

--- a/src/app/core/computedState.js
+++ b/src/app/core/computedState.js
@@ -1,4 +1,5 @@
 import { computed } from 'vue';
+import { wsolaProcessingCompatible } from '../../audio/crossfade/wsolaCrossfade.js';
 import { playlistArtworkDetection } from '../appearance/playlistArtwork.js';
 import { sortBySearchPopularity, sortByTopMatch } from '../browse/searchRanking.js';
 
@@ -231,7 +232,14 @@ export function installComputedState(ctx) {
     // The marker must describe the engine that will actually run. A qualifying
     // WSOLA pairing overrides the legacy plan, whose Apple-style overlap starts
     // many seconds earlier and would put the marker in the wrong place.
-    const wsolaPlan = ctx.crossfadeMode.value === 'smart'
+    const trackGains = ctx.audioEngineTrackGains?.value || {};
+    const wsolaEligible = wsolaProcessingCompatible({
+      normalizationEnabled: ctx.volumeNormalizationEnabled?.value,
+      audioEngineConfig: ctx.audioEngineConfig?.value,
+      outgoingGainDb: trackGains[ctx.activeTrack.value?.id],
+      incomingGainDb: trackGains[nextTrack.id]
+    });
+    const wsolaPlan = ctx.crossfadeMode.value === 'smart' && wsolaEligible
       ? ctx.wsolaCrossfade?.plan({
         analysis: ctx.crossfadeAnalysis.value,
         nextAnalysis: ctx.nextCrossfadeAnalysis.value,

--- a/src/app/core/computedState.js
+++ b/src/app/core/computedState.js
@@ -228,19 +228,15 @@ export function installComputedState(ctx) {
       };
     }
 
-    // The marker must describe the engine that will actually run. A qualifying
-    // WSOLA pairing overrides the legacy plan, whose Apple-style overlap starts
-    // many seconds earlier and would put the marker in the wrong place.
-    const wsolaPlan = ctx.crossfadeMode.value === 'smart'
+    // Smart mode has no fixed-duration fallback: when WSOLA cannot plan the
+    // pairing there is no transition to mark.
+    const plan = ctx.crossfadeMode.value === 'smart'
       ? ctx.wsolaCrossfade?.plan({
         analysis: ctx.crossfadeAnalysis.value,
         nextAnalysis: ctx.nextCrossfadeAnalysis.value,
         duration: length,
         nextDuration: Number(nextTrack.durationSeconds) || 0
       })
-      : null;
-    const plan = wsolaPlan?.ok
-      ? { transitionStart: wsolaPlan.transitionStart, markerVisible: true }
       : ctx.autoCrossfade.transitionPlan({
         analysis: ctx.crossfadeAnalysis.value,
         currentTime: 0,
@@ -249,15 +245,19 @@ export function installComputedState(ctx) {
         nextAnalysis: ctx.nextCrossfadeAnalysis.value,
         nextTrack
       });
-    const start = length > 0
-      ? Math.max(0, Math.min(100, (Number(plan.transitionStart) / length) * 100))
+    const markerVisible = ctx.crossfadeMode.value === 'smart'
+      ? Boolean(plan?.ok)
+      : Boolean(plan?.markerVisible);
+    const transitionStart = Number(plan?.transitionStart);
+    const start = length > 0 && Number.isFinite(transitionStart)
+      ? Math.max(0, Math.min(100, (transitionStart / length) * 100))
       : 100;
     return {
       '--crossfade-left': `${start}%`,
       '--crossfade-right': '0%',
       '--crossfade-opacity': ctx.crossfadeEnabled.value &&
         ctx.activeTrack.value &&
-        plan.markerVisible ? 1 : 0
+        markerVisible ? 1 : 0
     };
   });
 

--- a/src/app/core/lifecycle.js
+++ b/src/app/core/lifecycle.js
@@ -1,6 +1,18 @@
 import { nextTick, onBeforeUnmount, onMounted, watch } from 'vue';
 import { io } from 'socket.io-client';
 
+export function disableCrossfadePlayback(ctx) {
+  ctx.stopCrossfadeClock();
+  if (ctx.cancelActiveCrossfade) {
+    ctx.cancelActiveCrossfade();
+  } else {
+    ctx.autoCrossfade?.cancel?.();
+    ctx.wsolaCrossfade?.cancel?.();
+  }
+  ctx.dismissSmartCrossfadeMix?.();
+  ctx.setCurrentAudioVolume();
+}
+
 export function installLifecycle(ctx) {
   watch(ctx.volume, (value) => {
     ctx.autoCrossfade.setTargetVolume(value);
@@ -237,10 +249,7 @@ export function installLifecycle(ctx) {
       if (ctx.isPlaying.value) ctx.startCrossfadeClock();
       return;
     }
-    ctx.stopCrossfadeClock();
-    ctx.autoCrossfade.cancel();
-    ctx.dismissSmartCrossfadeMix?.();
-    ctx.setCurrentAudioVolume();
+    disableCrossfadePlayback(ctx);
   });
 
   watch(ctx.discordRpcEnabled, (enabled) => {
@@ -420,6 +429,7 @@ export function installLifecycle(ctx) {
     ctx.dismissSmartCrossfadeMix?.();
     ctx.autoplayRequest += 1;
     ctx.autoCrossfade.cancel();
+    ctx.wsolaCrossfade?.cancel?.();
     ctx.finishYouTubeHistory?.();
     ctx.destroySleepTimer();
     ctx.audioAnalyzer.destroy();

--- a/src/app/core/lifecycle.js
+++ b/src/app/core/lifecycle.js
@@ -4,6 +4,7 @@ import { io } from 'socket.io-client';
 export function installLifecycle(ctx) {
   watch(ctx.volume, (value) => {
     ctx.autoCrossfade.setTargetVolume(value);
+    ctx.wsolaCrossfade?.setTargetVolume?.(value);
     ctx.setCurrentAudioVolume(value);
   });
 

--- a/src/app/core/lifecycle.js
+++ b/src/app/core/lifecycle.js
@@ -4,10 +4,10 @@ import { io } from 'socket.io-client';
 export function disableCrossfadePlayback(ctx) {
   ctx.stopCrossfadeClock();
   if (ctx.cancelActiveCrossfade) {
-    ctx.cancelActiveCrossfade();
+    ctx.cancelActiveCrossfade('crossfade-disabled');
   } else {
     ctx.autoCrossfade?.cancel?.();
-    ctx.wsolaCrossfade?.cancel?.();
+    ctx.wsolaCrossfade?.cancel?.('crossfade-disabled');
   }
   ctx.dismissSmartCrossfadeMix?.();
   ctx.setCurrentAudioVolume();
@@ -429,7 +429,7 @@ export function installLifecycle(ctx) {
     ctx.dismissSmartCrossfadeMix?.();
     ctx.autoplayRequest += 1;
     ctx.autoCrossfade.cancel();
-    ctx.wsolaCrossfade?.cancel?.();
+    ctx.wsolaCrossfade?.cancel?.('app-teardown');
     ctx.finishYouTubeHistory?.();
     ctx.destroySleepTimer();
     ctx.audioAnalyzer.destroy();

--- a/src/app/core/state.js
+++ b/src/app/core/state.js
@@ -6,6 +6,7 @@ import {
   normalizeCrossfadeMode,
   createAutoCrossfade
 } from '../../audio/crossfade/autoCrossfade.js';
+import { createWsolaCrossfade } from '../../audio/crossfade/wsolaCrossfade.js';
 import orchardLogoUrl from '../../assets/orchard-logo.png';
 import {
   ACCENT_COLOR_SOURCE_OPTIONS,
@@ -405,6 +406,12 @@ export function installState(ctx) {
       fadeSeconds: ctx.crossfadeSeconds.value,
       mode: ctx.crossfadeMode.value
     }
+  });
+  ctx.wsolaCrossfade = createWsolaCrossfade({
+    analyzer: ctx.audioAnalyzer,
+    // Lazy lookup: the smart-crossfade analyzer that owns diagnostics is
+    // installed after core state.
+    report: (event, details) => ctx.smartCrossfadeAnalyzer?.report?.(event, details)
   });
   ctx.artworkLookupRequest = 0;
   ctx.detailArtworkLookupRequest = 0;

--- a/src/app/playback/mediaHandlers.js
+++ b/src/app/playback/mediaHandlers.js
@@ -175,7 +175,7 @@ export function installMediaHandlers(ctx) {
 
   ctx.onAudioPause = function onAudioPause(event) {
     if (!ctx.isCurrentAudioEvent(event)) return;
-    if (ctx.autoCrossfade?.isActive?.()) ctx.cancelActiveCrossfade?.();
+    if (ctx.autoCrossfade?.isActive?.() || ctx.wsolaCrossfade?.isActive?.()) ctx.cancelActiveCrossfade?.();
     ctx.clearPlaybackStallRecovery();
     ctx.reportYouTubeHistoryProgress?.({ force: true });
     ctx.buffering.value = false;
@@ -185,7 +185,7 @@ export function installMediaHandlers(ctx) {
 
   ctx.onAudioEnded = function onAudioEnded(event) {
     if (!ctx.isCurrentAudioEvent(event)) return;
-    if (ctx.autoCrossfade.isActive()) return;
+    if (ctx.autoCrossfade.isActive() || ctx.wsolaCrossfade?.isActive?.()) return;
     if (!ctx.activeTrackIsVideo.value && ctx.recoverPrematureAudioEnd(event.target)) return;
     ctx.clearPlaybackStallRecovery();
     ctx.finishYouTubeHistory?.();

--- a/src/app/playback/mediaHandlers.js
+++ b/src/app/playback/mediaHandlers.js
@@ -175,7 +175,12 @@ export function installMediaHandlers(ctx) {
 
   ctx.onAudioPause = function onAudioPause(event) {
     if (!ctx.isCurrentAudioEvent(event)) return;
-    if (ctx.autoCrossfade?.isActive?.() || ctx.wsolaCrossfade?.isActive?.()) ctx.cancelActiveCrossfade?.();
+    if (ctx.autoCrossfade?.isActive?.() || ctx.wsolaCrossfade?.isActive?.()) {
+      // A transition pauses the outgoing element itself at the handoff, so the
+      // reason distinguishes the element running out of media from a genuine
+      // pause arriving mid-overlap.
+      ctx.cancelActiveCrossfade?.(event?.target?.ended ? 'audio-pause-ended' : 'audio-pause-event');
+    }
     ctx.clearPlaybackStallRecovery();
     ctx.reportYouTubeHistoryProgress?.({ force: true });
     ctx.buffering.value = false;

--- a/src/app/playback/playbackControls.js
+++ b/src/app/playback/playbackControls.js
@@ -4,7 +4,8 @@ import { reliablePlaybackDuration } from './playbackDuration.js';
 import { createSmartCrossfadeMixPresentation } from './smartCrossfadeMixPresentation.js';
 import {
   WSOLA_PREPARE_LEAD_SECONDS,
-  WSOLA_START_LEAD_SECONDS
+  WSOLA_START_LEAD_SECONDS,
+  wsolaProcessingCompatible
 } from '../../audio/crossfade/wsolaCrossfade.js';
 
 const LYRIC_AUTO_SCROLL_RESUME_DELAY_MS = 1800;
@@ -334,6 +335,16 @@ export function installPlaybackControls(ctx) {
     // buffer already contains the incoming track, so letting the legacy engine
     // start its own fade on the same standby element plays it a second time.
     if (engine.isActive()) return 'hold';
+    const fromTrackId = ctx.activeTrack.value?.id;
+    const trackGains = ctx.audioEngineTrackGains?.value || {};
+    if (!wsolaProcessingCompatible({
+      normalizationEnabled: ctx.volumeNormalizationEnabled?.value,
+      audioEngineConfig: ctx.audioEngineConfig?.value,
+      outgoingGainDb: trackGains[fromTrackId],
+      incomingGainDb: trackGains[next.id]
+    })) {
+      return 'fallback';
+    }
     const plan = engine.plan({
       analysis: ctx.crossfadeAnalysis.value,
       nextAnalysis: ctx.nextCrossfadeAnalysis.value,
@@ -341,7 +352,6 @@ export function installPlaybackControls(ctx) {
       nextDuration: Number(next.durationSeconds) || 0
     });
     if (!plan.ok) return 'fallback';
-    const fromTrackId = ctx.activeTrack.value?.id;
     if (engine.preparationStatus(fromTrackId, next.id) === 'failed') return 'fallback';
 
     const untilStart = plan.transitionStart - playbackTime;

--- a/src/app/playback/playbackControls.js
+++ b/src/app/playback/playbackControls.js
@@ -318,27 +318,21 @@ export function installPlaybackControls(ctx) {
     return ctx.nextTrackPreload.value?.resolved || null;
   }
 
-  // Routes a smart-mode transition to the beat-matched WSOLA engine when the
-  // pairing qualifies. Returns 'started' when the engine took over, 'hold'
-  // while a viable plan is waiting on its render (the legacy engine must not
-  // fire its own, earlier overlap in the meantime), and 'fallback' when the
-  // pairing is refused or preparation failed.
+  // Smart mode is owned exclusively by the beat-matched WSOLA engine. A
+  // refused pairing or failed preparation skips the transition instead of
+  // handing it to the fixed-duration crossfade engine.
   async function maybeRunWsolaTransition({ next, fromAudio, toAudio, playbackTime, mediaDuration }) {
     const engine = ctx.wsolaCrossfade;
-    if (!engine) return 'fallback';
-    // An overlap already playing must hold, never fall back: the rendered
-    // buffer already contains the incoming track, so letting the legacy engine
-    // start its own fade on the same standby element plays it a second time.
-    if (engine.isActive()) return 'hold';
+    if (!engine || engine.isActive()) return false;
     const plan = engine.plan({
       analysis: ctx.crossfadeAnalysis.value,
       nextAnalysis: ctx.nextCrossfadeAnalysis.value,
       duration: mediaDuration,
       nextDuration: Number(next.durationSeconds) || 0
     });
-    if (!plan.ok) return 'fallback';
+    if (!plan.ok) return false;
     const fromTrackId = ctx.activeTrack.value?.id;
-    if (engine.preparationStatus(fromTrackId, next.id) === 'failed') return 'fallback';
+    if (engine.preparationStatus(fromTrackId, next.id) === 'failed') return false;
 
     const untilStart = plan.transitionStart - playbackTime;
     if (untilStart > WSOLA_START_LEAD_SECONDS) {
@@ -352,18 +346,18 @@ export function installPlaybackControls(ctx) {
           void ctx.preloadNextTrack();
         }
       }
-      return 'hold';
+      return false;
     }
     if (engine.preparationStatus(fromTrackId, next.id) !== 'ready') {
-      return untilStart > -0.2 ? 'hold' : 'fallback';
+      return false;
     }
 
     const resolved = await confirmNextPreload(next, toAudio);
-    if (!resolved) return 'fallback';
+    if (!resolved) return false;
     // Start against the plan the buffer was rendered with; a fresher plan may
     // have shifted after metadata enrichment and would misplace the downbeats.
     const prepared = engine.preparedTransition(fromTrackId, next.id);
-    if (!prepared) return 'fallback';
+    if (!prepared) return false;
     const previousTrack = ctx.activeTrack.value;
     const nextTrack = ctx.activeTrackFromResolved(next, resolved);
     const nextQueue = ctx.queue.value.slice(1);
@@ -438,9 +432,9 @@ export function installPlaybackControls(ctx) {
     });
     if (!didStart) {
       ctx.dismissSmartCrossfadeMix();
-      return 'fallback';
+      return false;
     }
-    return 'started';
+    return true;
   }
 
   ctx.maybeStartAutoCrossfade = async function maybeStartAutoCrossfade(options = {}) {
@@ -464,17 +458,18 @@ export function installPlaybackControls(ctx) {
     const mediaCurrentTime = Number(fromAudio.currentTime);
     const mediaDuration = reliablePlaybackDuration(ctx, fromAudio);
 
-    if (!options.force && ctx.crossfadeMode.value === 'smart' &&
-        ctx.isPlaying.value && !ctx.isSeeking.value && !ctx.autoCrossfade.isActive()) {
-      const routed = await maybeRunWsolaTransition({
+    if (ctx.crossfadeMode.value === 'smart') {
+      if (options.force || !ctx.isPlaying.value || ctx.isSeeking.value ||
+          ctx.autoCrossfade.isActive()) {
+        return false;
+      }
+      return maybeRunWsolaTransition({
         next,
         fromAudio,
         toAudio,
         playbackTime: Number.isFinite(mediaCurrentTime) ? mediaCurrentTime : ctx.currentTime.value,
         mediaDuration
       });
-      if (routed === 'started') return true;
-      if (routed === 'hold') return false;
     }
 
     const forceFadeSeconds = options.reason === 'ended-handoff'
@@ -511,20 +506,6 @@ export function installPlaybackControls(ctx) {
     const nextTrack = ctx.activeTrackFromResolved(next, resolved);
     const nextQueue = ctx.queue.value.slice(1);
     const nextDeck = ctx.activeAudioDeck.value === 'main' ? 'next' : 'main';
-    const showSmartMix = ctx.crossfadeMode.value === 'smart' &&
-      !options.force &&
-      transition.transitionStyle !== 'gapless';
-
-    if (showSmartMix) {
-      ctx.showSmartCrossfadeMix({
-        fromTrack: previousTrack,
-        toTrack: nextTrack,
-        transition,
-        analysis: ctx.crossfadeAnalysis.value,
-        nextAnalysis: ctx.nextCrossfadeAnalysis.value
-      });
-    }
-
     const didCrossfade = await ctx.autoCrossfade.start({
       fromAudio,
       toAudio,
@@ -572,12 +553,10 @@ export function installPlaybackControls(ctx) {
         void ctx.preloadNextTrack();
       },
       onError: (error) => {
-        if (showSmartMix) ctx.dismissSmartCrossfadeMix();
         ctx.playbackError.value = error.message;
       }
     });
 
-    if (!didCrossfade && showSmartMix) ctx.dismissSmartCrossfadeMix();
     return didCrossfade;
   };
 

--- a/src/app/playback/playbackControls.js
+++ b/src/app/playback/playbackControls.js
@@ -2,6 +2,10 @@ import { nextTick } from 'vue';
 import { playlistPreviousState } from './playbackCollectionQueue.js';
 import { reliablePlaybackDuration } from './playbackDuration.js';
 import { createSmartCrossfadeMixPresentation } from './smartCrossfadeMixPresentation.js';
+import {
+  WSOLA_PREPARE_LEAD_SECONDS,
+  WSOLA_START_LEAD_SECONDS
+} from '../../audio/crossfade/wsolaCrossfade.js';
 
 const LYRIC_AUTO_SCROLL_RESUME_DELAY_MS = 1800;
 
@@ -45,8 +49,10 @@ export function installPlaybackControls(ctx) {
   };
 
   ctx.cancelActiveCrossfade = function cancelActiveCrossfade() {
-    const wasActive = Boolean(ctx.autoCrossfade?.isActive?.());
+    const wasActive = Boolean(ctx.autoCrossfade?.isActive?.()) ||
+      Boolean(ctx.wsolaCrossfade?.isActive?.());
     ctx.autoCrossfade?.cancel?.();
+    ctx.wsolaCrossfade?.cancel?.();
     if (ctx.smartCrossfadeMix?.value?.visible) ctx.dismissSmartCrossfadeMix();
     return wasActive;
   };
@@ -299,6 +305,142 @@ export function installPlaybackControls(ctx) {
     ctx.clearNextPreload();
   };
 
+  // Confirms the incoming track is preloaded on the standby element and
+  // returns its resolved stream, forcing the preload when the transition is
+  // imminent. Shared by both transition engines.
+  async function confirmNextPreload(next, toAudio) {
+    if (!ctx.preloadedTrackMatches(next) || !toAudio.src) {
+      const didPreload = await ctx.preloadNextTrack({ force: true });
+      if (!didPreload || !ctx.preloadedTrackMatches(next) || !toAudio.src) {
+        return null;
+      }
+    }
+    return ctx.nextTrackPreload.value?.resolved || null;
+  }
+
+  // Routes a smart-mode transition to the beat-matched WSOLA engine when the
+  // pairing qualifies. Returns 'started' when the engine took over, 'hold'
+  // while a viable plan is waiting on its render (the legacy engine must not
+  // fire its own, earlier overlap in the meantime), and 'fallback' when the
+  // pairing is refused or preparation failed.
+  async function maybeRunWsolaTransition({ next, fromAudio, toAudio, playbackTime, mediaDuration }) {
+    const engine = ctx.wsolaCrossfade;
+    if (!engine || engine.isActive()) return 'fallback';
+    const plan = engine.plan({
+      analysis: ctx.crossfadeAnalysis.value,
+      nextAnalysis: ctx.nextCrossfadeAnalysis.value,
+      duration: mediaDuration,
+      nextDuration: Number(next.durationSeconds) || 0
+    });
+    if (!plan.ok) return 'fallback';
+    const fromTrackId = ctx.activeTrack.value?.id;
+    if (engine.preparationStatus(fromTrackId, next.id) === 'failed') return 'fallback';
+
+    const untilStart = plan.transitionStart - playbackTime;
+    if (untilStart > WSOLA_START_LEAD_SECONDS) {
+      if (untilStart <= WSOLA_PREPARE_LEAD_SECONDS &&
+          engine.preparationStatus(fromTrackId, next.id) === 'idle') {
+        const fromUrl = fromAudio.currentSrc || fromAudio.src || '';
+        const toUrl = ctx.nextTrackPreload.value?.resolved?.streamUrl || '';
+        if (fromUrl && toUrl) {
+          void engine.prepare({ fromTrackId, toTrackId: next.id, fromUrl, toUrl, plan });
+        } else if (!toUrl) {
+          void ctx.preloadNextTrack();
+        }
+      }
+      return 'hold';
+    }
+    if (engine.preparationStatus(fromTrackId, next.id) !== 'ready') {
+      // Inside the start window without a finished render: hold while the
+      // start is still achievable, otherwise let the legacy engine recover.
+      return untilStart > -0.2 ? 'hold' : 'fallback';
+    }
+
+    const resolved = await confirmNextPreload(next, toAudio);
+    if (!resolved) return 'fallback';
+    // Start against the plan the buffer was rendered with; a fresher plan may
+    // have shifted after metadata enrichment and would misplace the downbeats.
+    const prepared = engine.preparedTransition(fromTrackId, next.id);
+    if (!prepared) return 'fallback';
+    const previousTrack = ctx.activeTrack.value;
+    const nextTrack = ctx.activeTrackFromResolved(next, resolved);
+    const nextQueue = ctx.queue.value.slice(1);
+    const nextDeck = ctx.activeAudioDeck.value === 'main' ? 'next' : 'main';
+    const transition = {
+      transitionStart: prepared.plan.transitionStart,
+      transitionEnd: prepared.plan.transitionEnd,
+      fadeSeconds: prepared.plan.overlapSeconds,
+      transitionStyle: 'wsola_blend',
+      incomingCueTime: prepared.plan.incomingCueTime,
+      incomingPlaybackRate: 1,
+      reason: 'wsola-beat-match'
+    };
+    ctx.showSmartCrossfadeMix({
+      fromTrack: previousTrack,
+      toTrack: nextTrack,
+      transition,
+      analysis: ctx.crossfadeAnalysis.value,
+      nextAnalysis: ctx.nextCrossfadeAnalysis.value
+    });
+
+    const didStart = await engine.start({
+      fromAudio,
+      toAudio,
+      plan: prepared.plan,
+      render: prepared.render,
+      volume: ctx.volume.value,
+      onPromote: () => {
+        ctx.finishYouTubeHistory?.();
+        ctx.markPlaylistTrackPlayed?.(previousTrack);
+        if (previousTrack?.id) {
+          ctx.history.value.unshift(previousTrack);
+          ctx.history.value = ctx.history.value.slice(0, 30);
+        }
+        ctx.nextPreloadRequest += 1;
+        ctx.nextTrackPreload.value = null;
+        ctx.activeAudioDeck.value = nextDeck;
+        ctx.activeTrack.value = nextTrack;
+        ctx.startYouTubeHistory?.(nextTrack.youtubeVideoId || nextTrack.id);
+        ctx.promoteCrossfadeAnalysis(nextTrack.id);
+        if (ctx.crossfadeAnalysis.value.status !== 'ready') {
+          void ctx.analyzeCurrentCrossfadeTrack(nextTrack, resolved.streamUrl, nextTrack.durationSeconds || 0);
+        }
+        ctx.queue.value = nextQueue;
+        if (ctx.shuffleEnabled.value && ctx.shuffleSourceQueue.value.length) {
+          ctx.shuffleSourceQueue.value = ctx.shuffleSourceQueue.value.filter((track) => track.id !== nextTrack.id);
+        }
+        void ctx.refillPlaylistQueue?.();
+        ctx.currentTime.value = toAudio.currentTime || 0;
+        ctx.seekPosition.value = ctx.currentTime.value;
+        ctx.duration.value = reliablePlaybackDuration(ctx, toAudio, nextTrack);
+        ctx.buffering.value = false;
+        ctx.isPlaying.value = true;
+        ctx.recordSessionEvent?.('crossfade', nextTrack, {
+          fromTrack: previousTrack,
+          queue: nextQueue,
+          transitionMode: ctx.crossfadeMode.value,
+          transitionReason: transition.reason,
+          transitionStyle: transition.transitionStyle,
+          progressSeconds: ctx.currentTime.value,
+          durationSeconds: ctx.duration.value
+        });
+      },
+      onComplete: () => {
+        ctx.clearAudioElement(fromAudio);
+        void ctx.preloadNextTrack();
+      },
+      onError: (error) => {
+        ctx.dismissSmartCrossfadeMix();
+        ctx.playbackError.value = error.message;
+      }
+    });
+    if (!didStart) {
+      ctx.dismissSmartCrossfadeMix();
+      return 'fallback';
+    }
+    return 'started';
+  }
+
   ctx.maybeStartAutoCrossfade = async function maybeStartAutoCrossfade(options = {}) {
     if (!ctx.crossfadeEnabled.value) return false;
     if (ctx.sleepTimerMode.value === 'end-track' || ctx.sleepTimerVolumeFactor.value < 1) {
@@ -316,6 +458,20 @@ export function installPlaybackControls(ctx) {
     }
     const mediaCurrentTime = Number(fromAudio.currentTime);
     const mediaDuration = reliablePlaybackDuration(ctx, fromAudio);
+
+    if (!options.force && ctx.crossfadeMode.value === 'smart' &&
+        ctx.isPlaying.value && !ctx.isSeeking.value && !ctx.autoCrossfade.isActive()) {
+      const routed = await maybeRunWsolaTransition({
+        next,
+        fromAudio,
+        toAudio,
+        playbackTime: Number.isFinite(mediaCurrentTime) ? mediaCurrentTime : ctx.currentTime.value,
+        mediaDuration
+      });
+      if (routed === 'started') return true;
+      if (routed === 'hold') return false;
+    }
+
     const forceFadeSeconds = options.reason === 'ended-handoff'
       ? 0.05
       : Math.min(1, ctx.crossfadeSeconds.value || 1);

--- a/src/app/playback/playbackControls.js
+++ b/src/app/playback/playbackControls.js
@@ -318,21 +318,27 @@ export function installPlaybackControls(ctx) {
     return ctx.nextTrackPreload.value?.resolved || null;
   }
 
-  // Smart mode is owned exclusively by the beat-matched WSOLA engine. A
-  // refused pairing or failed preparation skips the transition instead of
-  // handing it to the fixed-duration crossfade engine.
+  // Routes a smart-mode transition to the beat-matched WSOLA engine when the
+  // pairing qualifies. Returns 'started' when the engine took over, 'hold'
+  // while a viable plan is waiting on its render (the legacy engine must not
+  // fire its own, earlier overlap in the meantime), and 'fallback' when the
+  // pairing is refused or preparation failed.
   async function maybeRunWsolaTransition({ next, fromAudio, toAudio, playbackTime, mediaDuration }) {
     const engine = ctx.wsolaCrossfade;
-    if (!engine || engine.isActive()) return false;
+    if (!engine) return 'fallback';
+    // An overlap already playing must hold, never fall back: the rendered
+    // buffer already contains the incoming track, so letting the legacy engine
+    // start its own fade on the same standby element plays it a second time.
+    if (engine.isActive()) return 'hold';
     const plan = engine.plan({
       analysis: ctx.crossfadeAnalysis.value,
       nextAnalysis: ctx.nextCrossfadeAnalysis.value,
       duration: mediaDuration,
       nextDuration: Number(next.durationSeconds) || 0
     });
-    if (!plan.ok) return false;
+    if (!plan.ok) return 'fallback';
     const fromTrackId = ctx.activeTrack.value?.id;
-    if (engine.preparationStatus(fromTrackId, next.id) === 'failed') return false;
+    if (engine.preparationStatus(fromTrackId, next.id) === 'failed') return 'fallback';
 
     const untilStart = plan.transitionStart - playbackTime;
     if (untilStart > WSOLA_START_LEAD_SECONDS) {
@@ -346,18 +352,18 @@ export function installPlaybackControls(ctx) {
           void ctx.preloadNextTrack();
         }
       }
-      return false;
+      return 'hold';
     }
     if (engine.preparationStatus(fromTrackId, next.id) !== 'ready') {
-      return false;
+      return untilStart > -0.2 ? 'hold' : 'fallback';
     }
 
     const resolved = await confirmNextPreload(next, toAudio);
-    if (!resolved) return false;
+    if (!resolved) return 'fallback';
     // Start against the plan the buffer was rendered with; a fresher plan may
     // have shifted after metadata enrichment and would misplace the downbeats.
     const prepared = engine.preparedTransition(fromTrackId, next.id);
-    if (!prepared) return false;
+    if (!prepared) return 'fallback';
     const previousTrack = ctx.activeTrack.value;
     const nextTrack = ctx.activeTrackFromResolved(next, resolved);
     const nextQueue = ctx.queue.value.slice(1);
@@ -432,9 +438,9 @@ export function installPlaybackControls(ctx) {
     });
     if (!didStart) {
       ctx.dismissSmartCrossfadeMix();
-      return false;
+      return 'fallback';
     }
-    return true;
+    return 'started';
   }
 
   ctx.maybeStartAutoCrossfade = async function maybeStartAutoCrossfade(options = {}) {
@@ -458,18 +464,17 @@ export function installPlaybackControls(ctx) {
     const mediaCurrentTime = Number(fromAudio.currentTime);
     const mediaDuration = reliablePlaybackDuration(ctx, fromAudio);
 
-    if (ctx.crossfadeMode.value === 'smart') {
-      if (options.force || !ctx.isPlaying.value || ctx.isSeeking.value ||
-          ctx.autoCrossfade.isActive()) {
-        return false;
-      }
-      return maybeRunWsolaTransition({
+    if (!options.force && ctx.crossfadeMode.value === 'smart' &&
+        ctx.isPlaying.value && !ctx.isSeeking.value && !ctx.autoCrossfade.isActive()) {
+      const routed = await maybeRunWsolaTransition({
         next,
         fromAudio,
         toAudio,
         playbackTime: Number.isFinite(mediaCurrentTime) ? mediaCurrentTime : ctx.currentTime.value,
         mediaDuration
       });
+      if (routed === 'started') return true;
+      if (routed === 'hold') return false;
     }
 
     const forceFadeSeconds = options.reason === 'ended-handoff'
@@ -506,6 +511,20 @@ export function installPlaybackControls(ctx) {
     const nextTrack = ctx.activeTrackFromResolved(next, resolved);
     const nextQueue = ctx.queue.value.slice(1);
     const nextDeck = ctx.activeAudioDeck.value === 'main' ? 'next' : 'main';
+    const showSmartMix = ctx.crossfadeMode.value === 'smart' &&
+      !options.force &&
+      transition.transitionStyle !== 'gapless';
+
+    if (showSmartMix) {
+      ctx.showSmartCrossfadeMix({
+        fromTrack: previousTrack,
+        toTrack: nextTrack,
+        transition,
+        analysis: ctx.crossfadeAnalysis.value,
+        nextAnalysis: ctx.nextCrossfadeAnalysis.value
+      });
+    }
+
     const didCrossfade = await ctx.autoCrossfade.start({
       fromAudio,
       toAudio,
@@ -553,10 +572,12 @@ export function installPlaybackControls(ctx) {
         void ctx.preloadNextTrack();
       },
       onError: (error) => {
+        if (showSmartMix) ctx.dismissSmartCrossfadeMix();
         ctx.playbackError.value = error.message;
       }
     });
 
+    if (!didCrossfade && showSmartMix) ctx.dismissSmartCrossfadeMix();
     return didCrossfade;
   };
 

--- a/src/app/playback/playbackControls.js
+++ b/src/app/playback/playbackControls.js
@@ -14,6 +14,10 @@ function isUnavailableTrackError(error) {
     .test(String(error?.message || error || ''));
 }
 
+export function queueAfterTransitionPromotion(queue = [], incomingTrackId = '') {
+  return queue.filter((track) => track?.id !== incomingTrackId);
+}
+
 export function playbackNeedsFreshStream(media, playbackError = '') {
   return Boolean(
     playbackError || media?.ended || media?.error || media?.networkState === 3
@@ -366,7 +370,6 @@ export function installPlaybackControls(ctx) {
     if (!prepared) return 'fallback';
     const previousTrack = ctx.activeTrack.value;
     const nextTrack = ctx.activeTrackFromResolved(next, resolved);
-    const nextQueue = ctx.queue.value.slice(1);
     const nextDeck = ctx.activeAudioDeck.value === 'main' ? 'next' : 'main';
     const transition = {
       transitionStart: prepared.plan.transitionStart,
@@ -392,6 +395,7 @@ export function installPlaybackControls(ctx) {
       render: prepared.render,
       volume: ctx.volume.value,
       onPromote: () => {
+        const nextQueue = queueAfterTransitionPromotion(ctx.queue.value, next.id);
         ctx.finishYouTubeHistory?.();
         ctx.markPlaylistTrackPlayed?.(previousTrack);
         if (previousTrack?.id) {
@@ -509,7 +513,6 @@ export function installPlaybackControls(ctx) {
 
     const previousTrack = ctx.activeTrack.value;
     const nextTrack = ctx.activeTrackFromResolved(next, resolved);
-    const nextQueue = ctx.queue.value.slice(1);
     const nextDeck = ctx.activeAudioDeck.value === 'main' ? 'next' : 'main';
     const showSmartMix = ctx.crossfadeMode.value === 'smart' &&
       !options.force &&
@@ -531,6 +534,7 @@ export function installPlaybackControls(ctx) {
       transition,
       volume: ctx.volume.value,
       onPromote: () => {
+        const nextQueue = queueAfterTransitionPromotion(ctx.queue.value, next.id);
         ctx.finishYouTubeHistory?.();
         ctx.markPlaylistTrackPlayed?.(previousTrack);
         if (previousTrack?.id) {

--- a/src/app/playback/playbackControls.js
+++ b/src/app/playback/playbackControls.js
@@ -355,8 +355,6 @@ export function installPlaybackControls(ctx) {
       return 'hold';
     }
     if (engine.preparationStatus(fromTrackId, next.id) !== 'ready') {
-      // Inside the start window without a finished render: hold while the
-      // start is still achievable, otherwise let the legacy engine recover.
       return untilStart > -0.2 ? 'hold' : 'fallback';
     }
 

--- a/src/app/playback/playbackControls.js
+++ b/src/app/playback/playbackControls.js
@@ -325,7 +325,11 @@ export function installPlaybackControls(ctx) {
   // pairing is refused or preparation failed.
   async function maybeRunWsolaTransition({ next, fromAudio, toAudio, playbackTime, mediaDuration }) {
     const engine = ctx.wsolaCrossfade;
-    if (!engine || engine.isActive()) return 'fallback';
+    if (!engine) return 'fallback';
+    // An overlap already playing must hold, never fall back: the rendered
+    // buffer already contains the incoming track, so letting the legacy engine
+    // start its own fade on the same standby element plays it a second time.
+    if (engine.isActive()) return 'hold';
     const plan = engine.plan({
       analysis: ctx.crossfadeAnalysis.value,
       nextAnalysis: ctx.nextCrossfadeAnalysis.value,
@@ -448,6 +452,9 @@ export function installPlaybackControls(ctx) {
     }
     if (ctx.repeatMode.value === 'one') return false;
     if (ctx.activeTrackIsVideo.value) return false;
+    // Covers the forced end-of-track handoff too: only one engine may ever own
+    // the standby element, or the incoming track is heard from both.
+    if (ctx.wsolaCrossfade?.isActive?.()) return false;
 
     const next = ctx.queue.value[0];
     const fromAudio = ctx.currentAudio();

--- a/src/app/playback/playbackControls.js
+++ b/src/app/playback/playbackControls.js
@@ -52,11 +52,11 @@ export function installPlaybackControls(ctx) {
     );
   };
 
-  ctx.cancelActiveCrossfade = function cancelActiveCrossfade() {
+  ctx.cancelActiveCrossfade = function cancelActiveCrossfade(reason = 'unspecified') {
     const wasActive = Boolean(ctx.autoCrossfade?.isActive?.()) ||
       Boolean(ctx.wsolaCrossfade?.isActive?.());
     ctx.autoCrossfade?.cancel?.();
-    ctx.wsolaCrossfade?.cancel?.();
+    ctx.wsolaCrossfade?.cancel?.(reason);
     if (ctx.smartCrossfadeMix?.value?.visible) ctx.dismissSmartCrossfadeMix();
     return wasActive;
   };
@@ -173,7 +173,7 @@ export function installPlaybackControls(ctx) {
       ctx.sendListeningPartyRequest({ action: ctx.isPlaying.value ? 'pause' : 'play' });
       return;
     }
-    ctx.cancelActiveCrossfade();
+    ctx.cancelActiveCrossfade('toggle-playback');
     const media = ctx.currentPlaybackElement();
     if (ctx.activeTrack.value && (!media?.src || playbackNeedsFreshStream(media, ctx.playbackError.value))) {
       ctx.playTrack(ctx.activeTrack.value, {
@@ -243,7 +243,7 @@ export function installPlaybackControls(ctx) {
 
   ctx.playNext = async function playNext(options = {}) {
     if (!options.fromListeningPartyRequest && !options.fromEnded && ctx.requestListeningPartyHostControl?.({ action: 'next' })) return;
-    ctx.cancelActiveCrossfade();
+    ctx.cancelActiveCrossfade('play-next');
     if (ctx.repeatMode.value === 'one' && ctx.activeTrack.value && !options.skipRepeatOne) {
       await ctx.playTrack(ctx.activeTrack.value, {
         mediaKind: ctx.activeMediaKind.value,
@@ -596,7 +596,7 @@ export function installPlaybackControls(ctx) {
 
   ctx.playPrevious = function playPrevious(options = {}) {
     if (!options.fromListeningPartyRequest && ctx.requestListeningPartyHostControl?.({ action: 'previous' })) return;
-    ctx.cancelActiveCrossfade();
+    ctx.cancelActiveCrossfade('play-previous');
     const playlistContext = ctx.playbackPlaylistContext.value;
     if (playlistContext && !ctx.shuffleEnabled.value && !playlistContext.shuffled) {
       const { activeIndex, previousTrack } = playlistPreviousState(playlistContext.allTracks, ctx.activeTrack.value?.id);
@@ -658,7 +658,7 @@ export function installPlaybackControls(ctx) {
       ctx.sendListeningPartyRequest({ action: 'seek', currentTime: Number(value) || 0 });
       return;
     }
-    ctx.cancelActiveCrossfade();
+    ctx.cancelActiveCrossfade('seek');
     const media = ctx.currentPlaybackElement();
     if (!media || !ctx.duration.value || ctx.activeTrackIsLive.value) return;
     const target = Math.max(0, Math.min(Number(value) || 0, ctx.duration.value));

--- a/src/app/playback/playbackResolve.js
+++ b/src/app/playback/playbackResolve.js
@@ -121,7 +121,10 @@ export function installPlaybackResolve(ctx) {
   };
 
   ctx.clearNextPreload = function clearNextPreload(options = {}) {
-    if (!options.force && ctx.autoCrossfade?.isActive?.()) {
+    // The active transition owns the standby deck until handoff completes.
+    // Queue edits may invalidate metadata for a future preload, but clearing
+    // this element now would erase the already-playing incoming track.
+    if (ctx.autoCrossfade?.isActive?.() || ctx.wsolaCrossfade?.isActive?.()) {
       return false;
     }
 
@@ -158,6 +161,12 @@ export function installPlaybackResolve(ctx) {
   };
 
   ctx.preloadNextTrack = async function preloadNextTrack(options = {}) {
+    // A transition may have promoted queue state logically before its standby
+    // element has finished the audible handoff. Do not let a queue edit load a
+    // different source into that transition-owned deck.
+    if (ctx.autoCrossfade?.isActive?.() || ctx.wsolaCrossfade?.isActive?.()) {
+      return false;
+    }
     const next = ctx.queue.value[0];
     if (!ctx.isPlayableTrack(next) || next.mediaKind === 'video' || !ctx.socket.value?.connected) {
       return false;

--- a/src/app/playback/playbackResolve.js
+++ b/src/app/playback/playbackResolve.js
@@ -240,7 +240,7 @@ export function installPlaybackResolve(ctx) {
     const trackItem = options.recoveryAttempt
       ? item
       : { ...item, playbackFallbackTried: false, streamRefreshTried: false };
-    if (ctx.cancelActiveCrossfade) ctx.cancelActiveCrossfade();
+    if (ctx.cancelActiveCrossfade) ctx.cancelActiveCrossfade('play-track');
     else {
       ctx.autoCrossfade.cancel();
       ctx.dismissSmartCrossfadeMix?.();

--- a/src/app/playback/smartCrossfadeMixPresentation.js
+++ b/src/app/playback/smartCrossfadeMixPresentation.js
@@ -6,7 +6,8 @@ const STYLE_LABELS = {
   dj_filter: 'Filter mix',
   dj_switch: 'Phrase switch',
   equal_power: 'Smart fade',
-  gapless: 'Gapless handoff'
+  gapless: 'Gapless handoff',
+  wsola_blend: 'Beat-matched mix'
 };
 
 function clamp(value, min, max) {

--- a/src/audio/crossfade/wsolaCrossfade.js
+++ b/src/audio/crossfade/wsolaCrossfade.js
@@ -163,8 +163,10 @@ export function createWsolaCrossfade({
     targetVolume = clamped;
     if (!session) return;
     session.handle?.setVolume(clamped);
-    // Only the audible element follows live volume; muted elements stay muted.
-    if (session.promoted) analyzer.setVolume(session.toAudio, clamped);
+    // Element audibility lives on the normalized mix envelope, so both master
+    // gains can follow the slider without unmuting either shadow deck.
+    analyzer.setVolume(session.fromAudio, clamped);
+    analyzer.setVolume(session.toAudio, clamped);
   }
 
   function clearTimers(state) {
@@ -184,6 +186,8 @@ export function createWsolaCrossfade({
     state.finish?.();
 
     const elapsed = Math.max(0, analyzer.currentTime() - state.overlapStartTime);
+    analyzer.resetMixElement?.(state.fromAudio);
+    analyzer.resetMixElement?.(state.toAudio);
     if (state.promoted) {
       // The incoming element is already the active deck; it has been playing
       // muted in position, so restoring volume is the whole recovery.
@@ -194,7 +198,8 @@ export function createWsolaCrossfade({
       // Pre-promote the outgoing element is still authoritative. The buffer
       // consumed its media at the stretch ratio while the element ran at unit
       // rate, so realign before unmuting.
-      const expected = state.plan.transitionStart + elapsed * state.render.stretchRatio;
+      const ratio = Math.max(0.0001, Number(state.render.stretchRatio) || 1);
+      const expected = state.plan.transitionStart + elapsed / ratio;
       if (Math.abs(state.fromAudio.currentTime - expected) > DRIFT_TOLERANCE_SECONDS) {
         try {
           state.fromAudio.currentTime = expected;
@@ -211,7 +216,7 @@ export function createWsolaCrossfade({
     if (session || !fromAudio || !toAudio || !transitionPlan?.ok || !render?.channels?.length) {
       return false;
     }
-    const untilStart = transitionPlan.transitionStart - fromAudio.currentTime;
+    let untilStart = transitionPlan.transitionStart - fromAudio.currentTime;
     if (untilStart < -MAX_LATE_START_SECONDS) {
       report('wsola-start-too-late', { lateBySeconds: -untilStart });
       return false;
@@ -223,8 +228,20 @@ export function createWsolaCrossfade({
       await analyzer.resume?.();
       if (mySequence !== sequence) return false;
 
+      // `resume()` is asynchronous while the media element keeps advancing.
+      // Re-sample its clock so context startup latency cannot put the buffer
+      // behind the live deck before the first handoff.
+      untilStart = transitionPlan.transitionStart - fromAudio.currentTime;
+      if (untilStart < -MAX_LATE_START_SECONDS) {
+        report('wsola-start-too-late', { lateBySeconds: -untilStart });
+        return false;
+      }
+
       const now = analyzer.currentTime();
-      const offset = Math.max(0, -untilStart);
+      const stretchRatio = Math.max(0.0001, Number(render.stretchRatio) || 1);
+      // `untilStart` is measured on the outgoing media timeline, while the
+      // buffer offset is measured on its stretched output timeline.
+      const offset = Math.max(0, -untilStart) * stretchRatio;
       const when = now + Math.max(0, untilStart);
       const handle = analyzer.playPcmBuffer({
         channels: render.channels,
@@ -254,14 +271,17 @@ export function createWsolaCrossfade({
       // track at full gain. The element keeps playing muted afterwards so a
       // cancel can restore it instantly.
       const connected = analyzer.fadeVolume(
-        fromAudio, targetVolume, 0, when, HANDOFF_FADE_SECONDS
+        fromAudio, 1, 0, when, HANDOFF_FADE_SECONDS
       );
       if (!connected) throw new Error('Transition elements are outside the audio graph');
-      handle.fade(0, targetVolume, when, HANDOFF_FADE_SECONDS);
+      handle.fade(0, 1, when, HANDOFF_FADE_SECONDS);
 
       // The incoming element shadows the buffer's incoming side, muted. It
       // only has to be exactly placed by the time the buffer ends.
-      analyzer.setVolume(toAudio, 0);
+      analyzer.setVolume(toAudio, targetVolume);
+      if (!analyzer.setMixVolume?.(toAudio, 0)) {
+        throw new Error('Transition elements are outside the audio graph');
+      }
       toAudio.currentTime = transitionPlan.incomingCueTime + offset;
       await toAudio.play();
       if (mySequence !== sequence) return false;
@@ -286,11 +306,12 @@ export function createWsolaCrossfade({
       const swapAt = state.overlapStartTime +
         transitionPlan.overlapSeconds * transitionPlan.bassSwapFraction;
       const endAt = handle.endTime;
-      // Both corrections sit in the first two thirds of the overlap: each one
+      // All corrections sit in the first two thirds of the overlap: each one
       // is a seek, and the element needs settled, steady playback well before
       // it becomes audible.
       schedule(state.overlapStartTime + transitionPlan.overlapSeconds * 0.15, correctDrift);
       schedule((state.overlapStartTime + swapAt) / 2, correctDrift);
+      schedule(state.overlapStartTime + transitionPlan.overlapSeconds * 0.6, correctDrift);
       schedule(Math.max(now, swapAt), () => {
         if (state.promoted) return;
         state.promoted = true;
@@ -300,9 +321,9 @@ export function createWsolaCrossfade({
       // Hand back to the element as the buffer's last samples play out, with
       // the same complementary pair of fades used at the start. Both carry the
       // incoming track here, so the exchange is level-preserving.
-      handle.fade(targetVolume, 0, endAt - HANDOFF_FADE_SECONDS, HANDOFF_FADE_SECONDS);
+      handle.fade(1, 0, endAt - HANDOFF_FADE_SECONDS, HANDOFF_FADE_SECONDS);
       analyzer.fadeVolume(
-        toAudio, 0, targetVolume, endAt - HANDOFF_FADE_SECONDS, HANDOFF_FADE_SECONDS
+        toAudio, 0, 1, endAt - HANDOFF_FADE_SECONDS, HANDOFF_FADE_SECONDS
       );
 
       await new Promise((resolve) => {
@@ -313,6 +334,8 @@ export function createWsolaCrossfade({
 
       session = null;
       clearTimers(state);
+      analyzer.resetMixElement?.(toAudio);
+      analyzer.resetMixElement?.(fromAudio);
       analyzer.setVolume(toAudio, targetVolume);
       analyzer.setVolume(fromAudio, 0);
       fromAudio.pause();
@@ -327,6 +350,8 @@ export function createWsolaCrossfade({
         clearTimers(state);
         state.handle?.stop();
       }
+      analyzer.resetMixElement?.(fromAudio);
+      analyzer.resetMixElement?.(toAudio);
       analyzer.setVolume(fromAudio, targetVolume);
       toAudio.pause();
       analyzer.setVolume(toAudio, 0);

--- a/src/audio/crossfade/wsolaCrossfade.js
+++ b/src/audio/crossfade/wsolaCrossfade.js
@@ -123,7 +123,9 @@ export function createWsolaCrossfade({
       const result = await bridge.renderTransition(outgoing, incoming, {
         sampleRate,
         beats: transitionPlan.beats,
-        bassSwap: transitionPlan.bassSwapFraction
+        bassSwap: transitionPlan.bassSwapFraction,
+        handoff: transitionPlan.handoffFraction,
+        bed: transitionPlan.bedPosition
       });
       if (!result?.rendered) {
         entry.status = 'failed';
@@ -174,7 +176,10 @@ export function createWsolaCrossfade({
     state.timers.length = 0;
   }
 
-  function cancel() {
+  // `reason` names the caller, so a session that ends early can be told apart
+  // from an ordinary teardown without reproducing it under a debugger. A
+  // healthy transition never arrives here at all -- it reports wsola-complete.
+  function cancel(reason = 'unspecified') {
     const state = session;
     if (!state) return;
     session = null;
@@ -209,7 +214,14 @@ export function createWsolaCrossfade({
       state.toAudio.pause();
       analyzer.setVolume(state.toAudio, 0);
     }
-    report('wsola-cancelled', { promoted: state.promoted, elapsedSeconds: elapsed });
+    report('wsola-cancelled', {
+      reason: String(reason),
+      promoted: state.promoted,
+      elapsedSeconds: elapsed,
+      // How much of the rendered overlap was thrown away. Small but non-zero
+      // means the buffer was cut short of its own tail.
+      remainingSeconds: Math.max(0, (Number(state.plan?.overlapSeconds) || 0) - elapsed)
+    });
   }
 
   async function start({ fromAudio, toAudio, plan: transitionPlan, render, volume, onPromote, onComplete, onError }) {

--- a/src/audio/crossfade/wsolaCrossfade.js
+++ b/src/audio/crossfade/wsolaCrossfade.js
@@ -20,7 +20,7 @@ export const WSOLA_PREPARE_LEAD_SECONDS = 30;
 export const WSOLA_START_LEAD_SECONDS = 1.2;
 
 // Starting later than this after the planned downbeat would audibly clip the
-// front of the overlap; past it the caller should use the ordinary crossfade.
+// front of the overlap, so the transition is skipped.
 const MAX_LATE_START_SECONDS = 0.35;
 
 // The incoming element runs muted during the overlap; corrections are

--- a/src/audio/crossfade/wsolaCrossfade.js
+++ b/src/audio/crossfade/wsolaCrossfade.js
@@ -20,7 +20,7 @@ export const WSOLA_PREPARE_LEAD_SECONDS = 30;
 export const WSOLA_START_LEAD_SECONDS = 1.2;
 
 // Starting later than this after the planned downbeat would audibly clip the
-// front of the overlap, so the transition is skipped.
+// front of the overlap; past it the caller should use the ordinary crossfade.
 const MAX_LATE_START_SECONDS = 0.35;
 
 // The incoming element runs muted during the overlap; corrections are

--- a/src/audio/crossfade/wsolaCrossfade.js
+++ b/src/audio/crossfade/wsolaCrossfade.js
@@ -7,10 +7,6 @@
 // audible playback to the incoming element the instant the buffer ends. The
 // elements keep playing silently underneath so a cancel at any point can
 // restore ordinary playback without re-buffering.
-//
-// Lifecycle per pairing: plan (pure, every tick) -> prepare (decode + IPC
-// render, once, well before the transition) -> start (schedule everything on
-// the context clock) -> promote at the bass swap -> complete at buffer end.
 import { planWsolaTransition } from './wsolaPlanner.js';
 
 // How far ahead of the transition preparation may begin. Decoding two tracks
@@ -27,9 +23,21 @@ export const WSOLA_START_LEAD_SECONDS = 1.2;
 // front of the overlap; past it the caller should use the ordinary crossfade.
 const MAX_LATE_START_SECONDS = 0.35;
 
-// The incoming element runs muted during the overlap and only needs to be
-// exactly placed by the end of it; corrections stay inaudible while muted.
-const DRIFT_TOLERANCE_SECONDS = 0.08;
+// The incoming element runs muted during the overlap; corrections are
+// inaudible while muted, but each one is a seek the element needs time to
+// settle after, so they are kept well clear of the handoff.
+const DRIFT_TOLERANCE_SECONDS = 0.04;
+
+// Length of the fades that hand audio between the rendered buffer and a media
+// element, at each end of the overlap.
+//
+// Deliberately tiny. Both sides carry the same audio at the handoff, but a
+// media element's position is only accurate to tens of milliseconds, so any
+// window where both are audible is two near-copies of the same signal offset
+// in time -- comb filtering, heard as a metallic rasp over the transition.
+// Ten milliseconds is long enough to avoid a click and short enough that the
+// residual is a single transient rather than an audible effect.
+const HANDOFF_FADE_SECONDS = 0.01;
 
 function pairKey(fromTrackId, toTrackId) {
   return `${String(fromTrackId || '')}>${String(toTrackId || '')}`;
@@ -190,9 +198,7 @@ export function createWsolaCrossfade({
       if (Math.abs(state.fromAudio.currentTime - expected) > DRIFT_TOLERANCE_SECONDS) {
         try {
           state.fromAudio.currentTime = expected;
-        } catch {
-          // Seek failures leave the element where it was; volume still returns.
-        }
+        } catch {}
       }
       analyzer.setVolume(state.fromAudio, targetVolume);
       state.toAudio.pause();
@@ -243,9 +249,15 @@ export function createWsolaCrossfade({
       };
       session = state;
 
-      // The outgoing element goes silent exactly as the buffer takes over; it
-      // keeps playing muted so a cancel can restore it instantly.
-      analyzer.rampVolume(fromAudio, 0, when, 0.05);
+      // Hand over from the outgoing element to the buffer with complementary
+      // fades over the same instant, so the two never both carry the outgoing
+      // track at full gain. The element keeps playing muted afterwards so a
+      // cancel can restore it instantly.
+      const connected = analyzer.fadeVolume(
+        fromAudio, targetVolume, 0, when, HANDOFF_FADE_SECONDS
+      );
+      if (!connected) throw new Error('Transition elements are outside the audio graph');
+      handle.fade(0, targetVolume, when, HANDOFF_FADE_SECONDS);
 
       // The incoming element shadows the buffer's incoming side, muted. It
       // only has to be exactly placed by the time the buffer ends.
@@ -267,28 +279,31 @@ export function createWsolaCrossfade({
         if (Math.abs(toAudio.currentTime - expected) > DRIFT_TOLERANCE_SECONDS) {
           try {
             toAudio.currentTime = expected;
-          } catch {
-            // A failed muted seek only risks a small offset at handoff.
-          }
+          } catch {}
         }
       };
 
       const swapAt = state.overlapStartTime +
         transitionPlan.overlapSeconds * transitionPlan.bassSwapFraction;
       const endAt = handle.endTime;
+      // Both corrections sit in the first two thirds of the overlap: each one
+      // is a seek, and the element needs settled, steady playback well before
+      // it becomes audible.
+      schedule(state.overlapStartTime + transitionPlan.overlapSeconds * 0.15, correctDrift);
       schedule((state.overlapStartTime + swapAt) / 2, correctDrift);
       schedule(Math.max(now, swapAt), () => {
         if (state.promoted) return;
         state.promoted = true;
-        // Past the swap the outgoing element can never come back; release it.
         fromAudio.pause();
         onPromote?.();
       });
-      schedule(endAt - 0.3, correctDrift);
-      // The element takes over slightly before the buffer's final samples;
-      // both carry identical incoming audio, so the short overlap is a
-      // seam-masking equal exchange rather than a double-play.
-      analyzer.rampVolume(toAudio, targetVolume, endAt - 0.05, 0.08);
+      // Hand back to the element as the buffer's last samples play out, with
+      // the same complementary pair of fades used at the start. Both carry the
+      // incoming track here, so the exchange is level-preserving.
+      handle.fade(targetVolume, 0, endAt - HANDOFF_FADE_SECONDS, HANDOFF_FADE_SECONDS);
+      analyzer.fadeVolume(
+        toAudio, 0, targetVolume, endAt - HANDOFF_FADE_SECONDS, HANDOFF_FADE_SECONDS
+      );
 
       await new Promise((resolve) => {
         state.finish = resolve;

--- a/src/audio/crossfade/wsolaCrossfade.js
+++ b/src/audio/crossfade/wsolaCrossfade.js
@@ -1,0 +1,334 @@
+// Runs a beat-matched transition from a pre-rendered overlap buffer.
+//
+// The overlap itself — time-stretch, beat alignment, bass handover — was mixed
+// offline by the native renderer into one finished stereo buffer, so playback
+// here is a scheduling problem, not a DSP problem: play the buffer on the
+// sample-accurate context clock while both media elements run muted, then hand
+// audible playback to the incoming element the instant the buffer ends. The
+// elements keep playing silently underneath so a cancel at any point can
+// restore ordinary playback without re-buffering.
+//
+// Lifecycle per pairing: plan (pure, every tick) -> prepare (decode + IPC
+// render, once, well before the transition) -> start (schedule everything on
+// the context clock) -> promote at the bass swap -> complete at buffer end.
+import { planWsolaTransition } from './wsolaPlanner.js';
+
+// How far ahead of the transition preparation may begin. Decoding two tracks
+// and rendering the overlap takes a few seconds; starting ~30s out leaves
+// slack for slow networks without holding PCM in memory for whole tracks.
+export const WSOLA_PREPARE_LEAD_SECONDS = 30;
+
+// How far ahead of the transition start() wants to be called. Scheduling needs
+// a moment of runway on the context clock; the playback clock ticks every
+// 120ms, so a lead over ~0.5s guarantees at least one tick lands in time.
+export const WSOLA_START_LEAD_SECONDS = 1.2;
+
+// Starting later than this after the planned downbeat would audibly clip the
+// front of the overlap; past it the caller should use the ordinary crossfade.
+const MAX_LATE_START_SECONDS = 0.35;
+
+// The incoming element runs muted during the overlap and only needs to be
+// exactly placed by the end of it; corrections stay inaudible while muted.
+const DRIFT_TOLERANCE_SECONDS = 0.08;
+
+function pairKey(fromTrackId, toTrackId) {
+  return `${String(fromTrackId || '')}>${String(toTrackId || '')}`;
+}
+
+function sliceChannels(buffer, startSeconds, endSeconds) {
+  const sampleRate = buffer.sampleRate;
+  const start = Math.max(0, Math.floor(startSeconds * sampleRate));
+  const end = Math.min(buffer.length, Math.ceil(endSeconds * sampleRate));
+  if (end <= start) return [];
+  const channels = [];
+  for (let index = 0; index < buffer.numberOfChannels; index += 1) {
+    channels.push(buffer.getChannelData(index).slice(start, end));
+  }
+  // Mono tracks are duplicated so both sources always present the same
+  // channel count to the renderer, which refuses mismatched layouts.
+  if (channels.length === 1) channels.push(new Float32Array(channels[0]));
+  return channels.slice(0, 2);
+}
+
+export function createWsolaCrossfade({
+  analyzer,
+  bridge = globalThis.orchardAudioAnalysis,
+  report = () => {}
+} = {}) {
+  // One preparation at a time: transitions are strictly sequential, so a new
+  // pairing always supersedes whatever was prepared before it.
+  let preparation = null;
+  let session = null;
+  let sequence = 0;
+  let targetVolume = 1;
+
+  function plan(options) {
+    return planWsolaTransition(options);
+  }
+
+  function preparationStatus(fromTrackId, toTrackId) {
+    if (!preparation || preparation.key !== pairKey(fromTrackId, toTrackId)) return 'idle';
+    return preparation.status;
+  }
+
+  // Returns the plan and render together: the buffer was mixed against the
+  // plan captured at prepare time, and starting against a fresher plan (for
+  // example after BPM metadata enrichment shifted the analysis) would place
+  // the rendered downbeats at the wrong media positions.
+  function preparedTransition(fromTrackId, toTrackId) {
+    if (preparationStatus(fromTrackId, toTrackId) !== 'ready') return null;
+    return { plan: preparation.plan, render: preparation.render };
+  }
+
+  function prepare({ fromTrackId, toTrackId, fromUrl, toUrl, plan: transitionPlan }) {
+    const key = pairKey(fromTrackId, toTrackId);
+    if (preparation?.key === key && preparation.status !== 'failed') return preparation.promise;
+    if (!transitionPlan?.ok || !fromUrl || !toUrl || typeof bridge?.renderTransition !== 'function') {
+      preparation = { key, status: 'failed', reason: 'unavailable', promise: Promise.resolve(null) };
+      return preparation.promise;
+    }
+
+    const entry = { key, status: 'pending', plan: transitionPlan, render: null, reason: '' };
+    report('wsola-prepare-start', {
+      trackId: String(toTrackId),
+      transitionStart: transitionPlan.transitionStart,
+      overlapSeconds: transitionPlan.overlapSeconds
+    });
+    entry.promise = (async () => {
+      const startedAt = Date.now();
+      const [fromBuffer, toBuffer] = await Promise.all([
+        analyzer.decodeAudio(fromUrl),
+        analyzer.decodeAudio(toUrl)
+      ]);
+      if (!fromBuffer || !toBuffer) throw new Error('Transition PCM decoding returned no audio');
+      const sampleRate = fromBuffer.sampleRate;
+      const outgoing = {
+        channels: sliceChannels(fromBuffer, transitionPlan.outgoingSlice.start, transitionPlan.outgoingSlice.end),
+        anchor: transitionPlan.outgoingSlice.anchor,
+        bpm: transitionPlan.outgoingBpm
+      };
+      const incoming = {
+        channels: sliceChannels(toBuffer, transitionPlan.incomingSlice.start, transitionPlan.incomingSlice.end),
+        anchor: transitionPlan.incomingSlice.anchor,
+        bpm: transitionPlan.incomingBpm
+      };
+      const result = await bridge.renderTransition(outgoing, incoming, {
+        sampleRate,
+        beats: transitionPlan.beats,
+        bassSwap: transitionPlan.bassSwapFraction
+      });
+      if (!result?.rendered) {
+        entry.status = 'failed';
+        entry.reason = String(result?.rejected || 'render-refused');
+        report('wsola-prepare-refused', { trackId: String(toTrackId), reason: entry.reason });
+        return null;
+      }
+      entry.render = {
+        channels: result.channels,
+        sampleRate: result.sampleRate,
+        stretchRatio: result.stretchRatio
+      };
+      entry.status = 'ready';
+      report('wsola-prepare-ready', {
+        trackId: String(toTrackId),
+        elapsedMs: Date.now() - startedAt,
+        stretchRatio: result.stretchRatio,
+        overlapSeconds: result.channels?.[0]?.length / result.sampleRate || 0
+      });
+      return entry.render;
+    })().catch((error) => {
+      entry.status = 'failed';
+      entry.reason = String(error?.message || error || 'prepare-failed');
+      report('wsola-prepare-failed', { trackId: String(toTrackId), errorMessage: entry.reason });
+      return null;
+    });
+    preparation = entry;
+    return entry.promise;
+  }
+
+  function isActive() {
+    return Boolean(session);
+  }
+
+  function setTargetVolume(value) {
+    const clamped = Math.max(0, Math.min(1, Number(value) || 0));
+    targetVolume = clamped;
+    if (!session) return;
+    session.handle?.setVolume(clamped);
+    // Only the audible element follows live volume; muted elements stay muted.
+    if (session.promoted) analyzer.setVolume(session.toAudio, clamped);
+  }
+
+  function clearTimers(state) {
+    state.timers.forEach((timer) => window.clearTimeout(timer));
+    state.timers.length = 0;
+  }
+
+  function cancel() {
+    const state = session;
+    if (!state) return;
+    session = null;
+    sequence += 1;
+    clearTimers(state);
+    state.handle?.stop();
+    // Settle the pending start() so its caller never hangs on a cancelled
+    // completion timer; the sequence bump makes the resolution a no-op there.
+    state.finish?.();
+
+    const elapsed = Math.max(0, analyzer.currentTime() - state.overlapStartTime);
+    if (state.promoted) {
+      // The incoming element is already the active deck; it has been playing
+      // muted in position, so restoring volume is the whole recovery.
+      analyzer.setVolume(state.toAudio, targetVolume);
+      state.fromAudio.pause();
+      analyzer.setVolume(state.fromAudio, 0);
+    } else {
+      // Pre-promote the outgoing element is still authoritative. The buffer
+      // consumed its media at the stretch ratio while the element ran at unit
+      // rate, so realign before unmuting.
+      const expected = state.plan.transitionStart + elapsed * state.render.stretchRatio;
+      if (Math.abs(state.fromAudio.currentTime - expected) > DRIFT_TOLERANCE_SECONDS) {
+        try {
+          state.fromAudio.currentTime = expected;
+        } catch {
+          // Seek failures leave the element where it was; volume still returns.
+        }
+      }
+      analyzer.setVolume(state.fromAudio, targetVolume);
+      state.toAudio.pause();
+      analyzer.setVolume(state.toAudio, 0);
+    }
+    report('wsola-cancelled', { promoted: state.promoted, elapsedSeconds: elapsed });
+  }
+
+  async function start({ fromAudio, toAudio, plan: transitionPlan, render, volume, onPromote, onComplete, onError }) {
+    if (session || !fromAudio || !toAudio || !transitionPlan?.ok || !render?.channels?.length) {
+      return false;
+    }
+    const untilStart = transitionPlan.transitionStart - fromAudio.currentTime;
+    if (untilStart < -MAX_LATE_START_SECONDS) {
+      report('wsola-start-too-late', { lateBySeconds: -untilStart });
+      return false;
+    }
+
+    const mySequence = ++sequence;
+    setTargetVolume(volume);
+    try {
+      await analyzer.resume?.();
+      if (mySequence !== sequence) return false;
+
+      const now = analyzer.currentTime();
+      const offset = Math.max(0, -untilStart);
+      const when = now + Math.max(0, untilStart);
+      const handle = analyzer.playPcmBuffer({
+        channels: render.channels,
+        sampleRate: render.sampleRate,
+        when,
+        offset,
+        volume: targetVolume
+      });
+      if (!handle) throw new Error('Web Audio transition playback is unavailable');
+
+      const state = {
+        fromAudio,
+        toAudio,
+        plan: transitionPlan,
+        render,
+        handle,
+        // Context time at which buffer position `offset` began: the anchor for
+        // every mapping between the overlap and the media timelines.
+        overlapStartTime: when - offset,
+        promoted: false,
+        timers: []
+      };
+      session = state;
+
+      // The outgoing element goes silent exactly as the buffer takes over; it
+      // keeps playing muted so a cancel can restore it instantly.
+      analyzer.rampVolume(fromAudio, 0, when, 0.05);
+
+      // The incoming element shadows the buffer's incoming side, muted. It
+      // only has to be exactly placed by the time the buffer ends.
+      analyzer.setVolume(toAudio, 0);
+      toAudio.currentTime = transitionPlan.incomingCueTime + offset;
+      await toAudio.play();
+      if (mySequence !== sequence) return false;
+
+      const schedule = (atContextTime, callback) => {
+        const delayMs = Math.max(0, (atContextTime - analyzer.currentTime()) * 1000);
+        state.timers.push(window.setTimeout(() => {
+          if (mySequence !== sequence) return;
+          callback();
+        }, delayMs));
+      };
+      const correctDrift = () => {
+        const expected = transitionPlan.incomingCueTime +
+          (analyzer.currentTime() - state.overlapStartTime);
+        if (Math.abs(toAudio.currentTime - expected) > DRIFT_TOLERANCE_SECONDS) {
+          try {
+            toAudio.currentTime = expected;
+          } catch {
+            // A failed muted seek only risks a small offset at handoff.
+          }
+        }
+      };
+
+      const swapAt = state.overlapStartTime +
+        transitionPlan.overlapSeconds * transitionPlan.bassSwapFraction;
+      const endAt = handle.endTime;
+      schedule((state.overlapStartTime + swapAt) / 2, correctDrift);
+      schedule(Math.max(now, swapAt), () => {
+        if (state.promoted) return;
+        state.promoted = true;
+        // Past the swap the outgoing element can never come back; release it.
+        fromAudio.pause();
+        onPromote?.();
+      });
+      schedule(endAt - 0.3, correctDrift);
+      // The element takes over slightly before the buffer's final samples;
+      // both carry identical incoming audio, so the short overlap is a
+      // seam-masking equal exchange rather than a double-play.
+      analyzer.rampVolume(toAudio, targetVolume, endAt - 0.05, 0.08);
+
+      await new Promise((resolve) => {
+        state.finish = resolve;
+        schedule(endAt + 0.05, resolve);
+      });
+      if (mySequence !== sequence) return false;
+
+      session = null;
+      clearTimers(state);
+      analyzer.setVolume(toAudio, targetVolume);
+      analyzer.setVolume(fromAudio, 0);
+      fromAudio.pause();
+      report('wsola-complete', { stretchRatio: render.stretchRatio });
+      onComplete?.();
+      return true;
+    } catch (error) {
+      if (mySequence !== sequence) return false;
+      const state = session;
+      session = null;
+      if (state) {
+        clearTimers(state);
+        state.handle?.stop();
+      }
+      analyzer.setVolume(fromAudio, targetVolume);
+      toAudio.pause();
+      analyzer.setVolume(toAudio, 0);
+      report('wsola-start-failed', { errorMessage: String(error?.message || error) });
+      onError?.(error);
+      return false;
+    }
+  }
+
+  return {
+    cancel,
+    isActive,
+    plan,
+    prepare,
+    preparationStatus,
+    preparedTransition,
+    setTargetVolume,
+    start
+  };
+}

--- a/src/audio/crossfade/wsolaCrossfade.js
+++ b/src/audio/crossfade/wsolaCrossfade.js
@@ -39,6 +39,28 @@ const DRIFT_TOLERANCE_SECONDS = 0.04;
 // residual is a single transient rather than an audible effect.
 const HANDOFF_FADE_SECONDS = 0.01;
 
+/**
+ * The rendered overlap contains raw decoded PCM, so it can only replace the
+ * live decks when their per-source processing is effectively flat. The legacy
+ * crossfade keeps both media elements in their normal graphs and is therefore
+ * the safe fallback whenever normalization, EQ, balance, preamp, or track gain
+ * would make the rendered audio sound different.
+ */
+export function wsolaProcessingCompatible({
+  normalizationEnabled = false,
+  audioEngineConfig = {},
+  outgoingGainDb = 0,
+  incomingGainDb = 0
+} = {}) {
+  if (normalizationEnabled) return false;
+  if (!audioEngineConfig?.enabled) return true;
+  // Preamp is only active as part of the manual-EQ branch.
+  if (audioEngineConfig.eqEnabled || audioEngineConfig.autoEqEnabled) return false;
+  if (Math.abs(Number(audioEngineConfig.balance) || 0) > 0.001) return false;
+  return Math.abs(Number(outgoingGainDb) || 0) <= 0.001 &&
+    Math.abs(Number(incomingGainDb) || 0) <= 0.001;
+}
+
 function pairKey(fromTrackId, toTrackId) {
   return `${String(fromTrackId || '')}>${String(toTrackId || '')}`;
 }

--- a/src/audio/crossfade/wsolaPlanner.js
+++ b/src/audio/crossfade/wsolaPlanner.js
@@ -1,0 +1,174 @@
+// Plans a beat-matched WSOLA transition in the Spotify AutoMix style measured
+// from reference captures: the outgoing track runs to its mix-out point, the
+// incoming track enters at a mix-in point deep in the track (skipping its
+// intro), and the two overlap for a fixed number of beats on a shared grid.
+//
+// Planning is pure and cheap so it can run on every playback tick. The heavy
+// work — decoding PCM and rendering the overlap in the native addon — belongs
+// to the session controller, which calls this first to learn whether a pairing
+// is even worth preparing.
+
+// One octave either side of a typical dance tempo; outside this the analysis
+// is treated as noise rather than a tempo.
+const MIN_BPM = 40;
+const MAX_BPM = 220;
+
+// Mirrors kMaxTransparentRatioDeviation in native/transition/wsola.h. The
+// native renderer re-checks this; duplicating the number here avoids shipping
+// PCM across the IPC boundary for a pairing that is certain to be refused.
+const MAX_STRETCH_DEVIATION = 0.08;
+
+// Measured from the Spotify reference capture: a 16-beat overlap (~7.6s at
+// 126 BPM). The overlap spans the same beat count on both grids because the
+// outgoing track is stretched onto the incoming tempo.
+const OVERLAP_BEATS = 16;
+
+// Fraction of the overlap where the low end hands over, chosen by ear against
+// rendered A/B pairs; quantized to a bar so the swap lands on a downbeat.
+const BASS_SWAP_FRACTION = 0.7;
+
+// Extra PCM around each slice so the WSOLA similarity search and filter
+// warm-up never run against a hard buffer edge.
+const SLICE_PADDING_SECONDS = 1.5;
+
+// The outgoing track must have at least this much audio before the overlap,
+// and the incoming at least this much after it, so a transition never lands
+// immediately after a track starts or runs into an unresolved tail.
+const MIN_CLEARANCE_SECONDS = 5;
+
+function finiteOrZero(value) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function refuse(reason) {
+  return { ok: false, reason };
+}
+
+// Halves or doubles the incoming tempo until it is as close as possible to the
+// outgoing, the way a DJ counts a 63 BPM track against a 126 BPM one. The
+// returned tempo defines the shared grid; "beats" elsewhere are beats of that
+// grid, not of the incoming track's own metadata.
+export function alignTempoOctave(outgoingBpm, incomingBpm) {
+  let aligned = incomingBpm;
+  while (aligned / outgoingBpm > 1.5) aligned /= 2;
+  while (aligned / outgoingBpm < 0.67) aligned *= 2;
+  return aligned;
+}
+
+function nearestAtOrBefore(values, target) {
+  const candidates = (Array.isArray(values) ? values : [])
+    .map(Number)
+    .filter((value) => Number.isFinite(value) && value >= 0 && value <= target);
+  return candidates.length ? Math.max(...candidates) : null;
+}
+
+function nearest(values, target, tolerance) {
+  const candidates = (Array.isArray(values) ? values : [])
+    .map(Number)
+    .filter((value) => Number.isFinite(value) && value >= 0 && Math.abs(value - target) <= tolerance);
+  if (!candidates.length) return null;
+  return candidates.reduce((best, value) =>
+    Math.abs(value - target) < Math.abs(best - target) ? value : best
+  );
+}
+
+// Where the incoming track should enter: its analyzed drop or best mix-in
+// candidate, snapped to a downbeat so the shared grid starts on a bar.
+export function incomingMixInPoint(analysis = {}) {
+  const beatSeconds = finiteOrZero(analysis.beatInterval) ||
+    (finiteOrZero(analysis.bpm) > 0 ? 60 / analysis.bpm : 0);
+  const tolerance = Math.max(0.5, beatSeconds * 2);
+  const candidates = Array.isArray(analysis.mixInCandidates) ? analysis.mixInCandidates : [];
+  const drop = candidates.find((candidate) =>
+    candidate?.type === 'main_drop' || candidate?.type === 'intro_drop');
+  const scored = [...candidates].sort((left, right) =>
+    finiteOrZero(right?.score) - finiteOrZero(left?.score))[0];
+  const target = [drop?.time, scored?.time, analysis.mixInTime]
+    .map(Number)
+    .find((value) => Number.isFinite(value) && value > 0);
+  if (!Number.isFinite(target)) return null;
+  return nearest(analysis.downbeats, target, tolerance) ?? target;
+}
+
+/**
+ * Plans one beat-matched transition. Returns `{ ok: false, reason }` when the
+ * pairing cannot be rendered transparently, in which case the caller should
+ * use the ordinary crossfade; a refusal here is a routing decision, not an
+ * error. All times are seconds on each track's own media timeline.
+ */
+export function planWsolaTransition({
+  analysis = {},
+  nextAnalysis = {},
+  duration = 0,
+  nextDuration = 0
+} = {}) {
+  const outgoingBpm = finiteOrZero(analysis.bpm);
+  const rawIncomingBpm = finiteOrZero(nextAnalysis.bpm);
+  if (outgoingBpm < MIN_BPM || outgoingBpm > MAX_BPM) return refuse('outgoing-tempo');
+  if (rawIncomingBpm < MIN_BPM || rawIncomingBpm > MAX_BPM) return refuse('incoming-tempo');
+
+  const incomingBpm = alignTempoOctave(outgoingBpm, rawIncomingBpm);
+  const stretchRatio = outgoingBpm / incomingBpm;
+  if (Math.abs(stretchRatio - 1) > MAX_STRETCH_DEVIATION) return refuse('tempo-distance');
+
+  const outgoingLength = Math.max(finiteOrZero(duration), finiteOrZero(analysis.duration));
+  const incomingLength = Math.max(finiteOrZero(nextDuration), finiteOrZero(nextAnalysis.duration));
+  if (outgoingLength <= 0 || incomingLength <= 0) return refuse('missing-duration');
+
+  // The same beat count on both grids: the outgoing side is consumed at its
+  // own tempo and stretched onto the incoming grid by the renderer.
+  const outgoingOverlapSeconds = OVERLAP_BEATS * (60 / outgoingBpm);
+  const overlapSeconds = OVERLAP_BEATS * (60 / incomingBpm);
+
+  // The outgoing overlap ends where its content does: an interior mix-out if
+  // the analyzer found one, otherwise the end of real content.
+  const contentEnd = finiteOrZero(analysis.contentEndTime) || outgoingLength;
+  const mixOut = finiteOrZero(analysis.mixOutTime);
+  const overlapEndTarget = Math.min(
+    outgoingLength,
+    mixOut > 0 && mixOut < contentEnd - 1 ? mixOut : contentEnd
+  );
+  const startTarget = overlapEndTarget - outgoingOverlapSeconds;
+  const transitionStart = nearestAtOrBefore(analysis.downbeats, startTarget) ?? startTarget;
+  if (transitionStart < MIN_CLEARANCE_SECONDS) return refuse('outgoing-too-short');
+  const transitionEnd = transitionStart + outgoingOverlapSeconds;
+  if (transitionEnd > outgoingLength + 0.05) return refuse('outgoing-overlap-overruns');
+
+  const incomingCueTime = incomingMixInPoint(nextAnalysis);
+  if (!Number.isFinite(incomingCueTime) || incomingCueTime < 0) return refuse('incoming-mix-in');
+  const incomingResumeTime = incomingCueTime + overlapSeconds;
+  if (incomingResumeTime + MIN_CLEARANCE_SECONDS > incomingLength) return refuse('incoming-too-short');
+
+  // Swap the bass on a bar boundary of the shared grid, staying at least one
+  // bar clear of each edge so the handover is audible as an event.
+  const swapBeat = Math.max(4, Math.min(OVERLAP_BEATS - 4,
+    Math.round((BASS_SWAP_FRACTION * OVERLAP_BEATS) / 4) * 4));
+  const bassSwapFraction = swapBeat / OVERLAP_BEATS;
+
+  const outgoingSliceStart = Math.max(0, transitionStart - SLICE_PADDING_SECONDS);
+  const incomingSliceStart = Math.max(0, incomingCueTime - SLICE_PADDING_SECONDS);
+  return {
+    ok: true,
+    transitionStart,
+    transitionEnd,
+    overlapSeconds,
+    beats: OVERLAP_BEATS,
+    bassSwapFraction,
+    outgoingBpm,
+    incomingBpm,
+    stretchRatio,
+    incomingCueTime,
+    incomingResumeTime,
+    outgoingSlice: {
+      start: outgoingSliceStart,
+      end: Math.min(outgoingLength, transitionEnd + SLICE_PADDING_SECONDS),
+      anchor: transitionStart - outgoingSliceStart
+    },
+    incomingSlice: {
+      start: incomingSliceStart,
+      end: Math.min(incomingLength, incomingResumeTime + SLICE_PADDING_SECONDS),
+      anchor: incomingCueTime - incomingSliceStart
+    }
+  };
+}

--- a/src/audio/crossfade/wsolaPlanner.js
+++ b/src/audio/crossfade/wsolaPlanner.js
@@ -1,7 +1,14 @@
 // Plans a beat-matched WSOLA transition in the Spotify AutoMix style measured
-// from reference captures: the outgoing track runs to its mix-out point, the
-// incoming track enters at a mix-in point deep in the track (skipping its
-// intro), and the two overlap for a fixed number of beats on a shared grid.
+// from reference captures: the outgoing track runs to its mix-out point while
+// the incoming track's intro plays underneath it, and the two cross at equal
+// power on the incoming track's drop.
+//
+// The pre-roll is the point of the whole shape. Entering at the drop instead
+// puts the incoming vocal on top of an outgoing track that is still singing --
+// on a typical pop pairing that is several seconds of two lead vocals at once,
+// which reads as a mistake however well the grids line up. The intro is the
+// part of a track written to sit under something else, so that is the part
+// that overlaps.
 //
 // Planning is pure and cheap so it can run on every playback tick. The heavy
 // work — decoding PCM and rendering the overlap in the native addon — belongs
@@ -18,14 +25,27 @@ const MAX_BPM = 220;
 // PCM across the IPC boundary for a pairing that is certain to be refused.
 const MAX_STRETCH_DEVIATION = 0.08;
 
-// Measured from the Spotify reference capture: a 16-beat overlap (~7.6s at
-// 126 BPM). The overlap spans the same beat count on both grids because the
-// outgoing track is stretched onto the incoming tempo.
-const OVERLAP_BEATS = 16;
+// Beats of overlap after the handoff: the outgoing track's fade once the
+// incoming has arrived. Measured from the Spotify reference capture.
+const TAIL_BEATS = 16;
 
-// Fraction of the overlap where the low end hands over, chosen by ear against
-// rendered A/B pairs; quantized to a bar so the swap lands on a downbeat.
-const BASS_SWAP_FRACTION = 0.7;
+// The incoming track's intro plays underneath the outgoing track before the
+// handoff. Quantized to bars, and bounded: too short and the drop arrives
+// unannounced, too long and the outgoing track is buried under a bed for most
+// of its final phrase. Four bars is the cap because a long intro is not an
+// invitation to play all of it -- at 48 beats a slow track sat under the
+// outgoing one for fifteen seconds before anything started to move.
+const MIN_PREROLL_BEATS = 4;
+const MAX_PREROLL_BEATS = 16;
+
+// A ceiling on the whole overlap regardless of how long the incoming intro is.
+const MAX_OVERLAP_SECONDS = 20;
+
+// How far along the equal-power fade the pre-roll travels; see `bed` in
+// native/transition/transition_render.h. Low, so the pre-roll is the incoming
+// intro rising to a bed under a still-full outgoing track, and the outgoing
+// track's audible fade is the tail alone rather than the whole overlap.
+const BED_POSITION = 0.25;
 
 // Extra PCM around each slice so the WSOLA similarity search and filter
 // warm-up never run against a hard buffer edge.
@@ -73,8 +93,10 @@ function nearest(values, target, tolerance) {
   );
 }
 
-// Where the incoming track should enter: its analyzed drop or best mix-in
-// candidate, snapped to a downbeat so the shared grid starts on a bar.
+// Where the incoming track takes over: its analyzed drop or best mix-in
+// candidate, snapped to a downbeat so the shared grid starts on a bar. This is
+// the handoff, not the point where the incoming track starts making sound --
+// it begins its intro a pre-roll earlier, underneath the outgoing track.
 export function incomingMixInPoint(analysis = {}) {
   const beatSeconds = finiteOrZero(analysis.beatInterval) ||
     (finiteOrZero(analysis.bpm) > 0 ? 60 / analysis.bpm : 0);
@@ -89,6 +111,15 @@ export function incomingMixInPoint(analysis = {}) {
     .find((value) => Number.isFinite(value) && value > 0);
   if (!Number.isFinite(target)) return null;
   return nearest(analysis.downbeats, target, tolerance) ?? target;
+}
+
+// Where the incoming track first makes sound. The pre-roll starts here at the
+// earliest; anything before it is lead-in silence that would blend as a gap.
+export function incomingAudibleStart(analysis = {}) {
+  const candidates = [analysis.audibleStartTime, analysis.pickupTime, analysis.firstBeat]
+    .map(Number)
+    .filter((value) => Number.isFinite(value) && value >= 0);
+  return candidates.length ? Math.min(...candidates) : 0;
 }
 
 /**
@@ -116,10 +147,44 @@ export function planWsolaTransition({
   const incomingLength = Math.max(finiteOrZero(nextDuration), finiteOrZero(nextAnalysis.duration));
   if (outgoingLength <= 0 || incomingLength <= 0) return refuse('missing-duration');
 
+  const incomingBeatSeconds = 60 / incomingBpm;
+  const outgoingBeatSeconds = 60 / outgoingBpm;
+
+  // The handoff: where the incoming track's arrangement and vocal arrive.
+  const incomingDropTime = incomingMixInPoint(nextAnalysis);
+  if (!Number.isFinite(incomingDropTime) || incomingDropTime < 0) return refuse('incoming-mix-in');
+
+  // The incoming track's intro is what plays underneath the outgoing track, so
+  // the pre-roll can be at most as long as that intro. Quantized down to whole
+  // bars of the shared grid, so the handoff stays on a downbeat.
+  const audibleStart = incomingAudibleStart(nextAnalysis);
+  const availablePrerollBeats = Math.max(0, incomingDropTime - audibleStart) / incomingBeatSeconds;
+  const cappedByOverlap = Math.floor(MAX_OVERLAP_SECONDS / incomingBeatSeconds) - TAIL_BEATS;
+  const prerollBeats = Math.max(
+    MIN_PREROLL_BEATS,
+    Math.min(
+      MAX_PREROLL_BEATS,
+      cappedByOverlap,
+      Math.floor(availablePrerollBeats / 4) * 4
+    )
+  );
+
+  const overlapBeats = prerollBeats + TAIL_BEATS;
   // The same beat count on both grids: the outgoing side is consumed at its
   // own tempo and stretched onto the incoming grid by the renderer.
-  const outgoingOverlapSeconds = OVERLAP_BEATS * (60 / outgoingBpm);
-  const overlapSeconds = OVERLAP_BEATS * (60 / incomingBpm);
+  const outgoingOverlapSeconds = overlapBeats * outgoingBeatSeconds;
+  const overlapSeconds = overlapBeats * incomingBeatSeconds;
+
+  // The incoming track enters a pre-roll ahead of its drop. Clamped at its
+  // audible start so the mix never opens on lead-in silence.
+  const incomingCueTime = Math.max(
+    audibleStart,
+    incomingDropTime - prerollBeats * incomingBeatSeconds
+  );
+  // Whatever the clamp took away shortens the pre-roll rather than shifting
+  // the drop, which must stay where the analyzer found it.
+  const prerollSeconds = incomingDropTime - incomingCueTime;
+  if (prerollSeconds <= 0) return refuse('incoming-no-preroll');
 
   // The outgoing overlap ends where its content does: an interior mix-out if
   // the analyzer found one, otherwise the end of real content.
@@ -135,16 +200,17 @@ export function planWsolaTransition({
   const transitionEnd = transitionStart + outgoingOverlapSeconds;
   if (transitionEnd > outgoingLength + 0.05) return refuse('outgoing-overlap-overruns');
 
-  const incomingCueTime = incomingMixInPoint(nextAnalysis);
-  if (!Number.isFinite(incomingCueTime) || incomingCueTime < 0) return refuse('incoming-mix-in');
   const incomingResumeTime = incomingCueTime + overlapSeconds;
   if (incomingResumeTime + MIN_CLEARANCE_SECONDS > incomingLength) return refuse('incoming-too-short');
 
-  // Swap the bass on a bar boundary of the shared grid, staying at least one
-  // bar clear of each edge so the handover is audible as an event.
-  const swapBeat = Math.max(4, Math.min(OVERLAP_BEATS - 4,
-    Math.round((BASS_SWAP_FRACTION * OVERLAP_BEATS) / 4) * 4));
-  const bassSwapFraction = swapBeat / OVERLAP_BEATS;
+  // The mix changes hands on the drop: before it the incoming track is a bed
+  // under the outgoing one, after it the outgoing track fades away.
+  const handoffFraction = prerollSeconds / overlapSeconds;
+
+  // The low end changes hands on the drop too -- that is what the drop is --
+  // held a bar past it so the incoming track does not arrive early.
+  const swapBeat = Math.max(4, Math.min(overlapBeats - 4, prerollBeats + 4));
+  const bassSwapFraction = swapBeat / overlapBeats;
 
   const outgoingSliceStart = Math.max(0, transitionStart - SLICE_PADDING_SECONDS);
   const incomingSliceStart = Math.max(0, incomingCueTime - SLICE_PADDING_SECONDS);
@@ -153,12 +219,17 @@ export function planWsolaTransition({
     transitionStart,
     transitionEnd,
     overlapSeconds,
-    beats: OVERLAP_BEATS,
+    beats: overlapBeats,
+    prerollBeats,
+    tailBeats: TAIL_BEATS,
+    handoffFraction,
+    bedPosition: BED_POSITION,
     bassSwapFraction,
     outgoingBpm,
     incomingBpm,
     stretchRatio,
     incomingCueTime,
+    incomingDropTime,
     incomingResumeTime,
     outgoingSlice: {
       start: outgoingSliceStart,

--- a/src/audio/crossfade/wsolaPlanner.js
+++ b/src/audio/crossfade/wsolaPlanner.js
@@ -160,6 +160,7 @@ export function planWsolaTransition({
   const audibleStart = incomingAudibleStart(nextAnalysis);
   const availablePrerollBeats = Math.max(0, incomingDropTime - audibleStart) / incomingBeatSeconds;
   const cappedByOverlap = Math.floor(MAX_OVERLAP_SECONDS / incomingBeatSeconds) - TAIL_BEATS;
+  if (cappedByOverlap < MIN_PREROLL_BEATS) return refuse('overlap-too-long');
   const prerollBeats = Math.max(
     MIN_PREROLL_BEATS,
     Math.min(

--- a/src/audio/engine/audioAnalyzer.js
+++ b/src/audio/engine/audioAnalyzer.js
@@ -43,6 +43,18 @@ export function createAudioAnalyzer(options = {}) {
     return context;
   }
 
+  function outputFilters(ctx) {
+    const lowPass = ctx.createBiquadFilter();
+    const highPass = ctx.createBiquadFilter();
+    lowPass.type = 'lowpass';
+    lowPass.frequency.value = Math.min(20000, ctx.sampleRate * 0.45);
+    lowPass.Q.value = 0.707;
+    highPass.type = 'highpass';
+    highPass.frequency.value = 20;
+    highPass.Q.value = 0.707;
+    return { lowPass, highPass };
+  }
+
   function connectElement(element) {
     if (!element) return null;
     const existing = nodes.get(element);
@@ -58,14 +70,7 @@ export function createAudioAnalyzer(options = {}) {
     const normalizedGain = ctx.createGain();
     const gain = ctx.createGain();
     const mixGain = ctx.createGain();
-    const lowPass = ctx.createBiquadFilter();
-    const highPass = ctx.createBiquadFilter();
-    lowPass.type = 'lowpass';
-    lowPass.frequency.value = Math.min(20000, ctx.sampleRate * 0.45);
-    lowPass.Q.value = 0.707;
-    highPass.type = 'highpass';
-    highPass.frequency.value = 20;
-    highPass.Q.value = 0.707;
+    const { lowPass, highPass } = outputFilters(ctx);
     analyser.fftSize = config.fftSize;
     analyser.smoothingTimeConstant = config.smoothingTimeConstant;
     normalizer.threshold.value = -24;
@@ -512,8 +517,8 @@ export function createAudioAnalyzer(options = {}) {
    * Plays raw planar PCM as a scheduled one-shot source on the context clock.
    * Used for pre-rendered transition overlaps, which need sample-accurate
    * scheduling that media elements cannot provide. The chain is source ->
-   * gain -> destination: per-element processing (EQ, normalization) is
-   * intentionally bypassed because the rendered mix is already final audio.
+   * gain -> output filters -> destination. Callers only use this path when
+   * per-source EQ, normalization, balance, preamp, and track gain are flat.
    * @returns {object|null} Handle with the resolved start/end context times,
    * `setVolume`, normalized envelope fades, and a click-free `stop`; null
    * when the context is missing.
@@ -528,12 +533,15 @@ export function createAudioAnalyzer(options = {}) {
     const source = ctx.createBufferSource();
     const envelopeGain = ctx.createGain();
     const volumeGain = ctx.createGain();
+    const { lowPass, highPass } = outputFilters(ctx);
     source.buffer = buffer;
     envelopeGain.gain.value = 1;
     volumeGain.gain.value = clamp01(volume);
     source.connect(envelopeGain);
     envelopeGain.connect(volumeGain);
-    volumeGain.connect(ctx.destination);
+    volumeGain.connect(lowPass);
+    lowPass.connect(highPass);
+    highPass.connect(ctx.destination);
 
     // `offset` skips into the buffer for callers that were scheduled late and
     // need the remainder to stay aligned with the media timeline.

--- a/src/audio/engine/audioAnalyzer.js
+++ b/src/audio/engine/audioAnalyzer.js
@@ -153,14 +153,26 @@ export function createAudioAnalyzer(options = {}) {
     node.gain.gain.setValueAtTime(clamp01(value), now);
   }
 
-  // Scheduled, click-free counterpart to setVolume, for callers that need an
-  // element muted or restored at an exact context time (transition handoffs).
-  function rampVolume(element, value, at = 0, fadeSeconds = 0.03) {
+  /**
+   * Scheduled linear fade between two known gains, for handoffs that must land
+   * at an exact context time. `from` is explicit because an AudioParam's value
+   * at a future scheduled instant cannot be read back.
+   *
+   * Linear rather than equal-power on purpose: these fades hand over between
+   * two sources carrying the *same* audio, which sum coherently, so linear
+   * gains hold a constant level where equal-power would bulge in the middle.
+   * @returns {boolean} False when the element is outside the graph, so callers
+   * can refuse rather than schedule a fade that silently never happens.
+   */
+  function fadeVolume(element, from, to, at = 0, fadeSeconds = 0.01) {
     const node = connectElement(element);
-    if (!node) return;
+    if (!node) return false;
+    const param = node.gain.gain;
     const start = Math.max(currentTime(), Number(at) || 0);
-    node.gain.gain.cancelScheduledValues(start);
-    node.gain.gain.setTargetAtTime(clamp01(value), start, Math.max(0.005, fadeSeconds / 3));
+    param.cancelScheduledValues(start);
+    param.setValueAtTime(clamp01(from), start);
+    param.linearRampToValueAtTime(clamp01(to), start + Math.max(0.001, fadeSeconds));
+    return true;
   }
 
   async function decodeAudio(url, signal) {
@@ -522,6 +534,12 @@ export function createAudioAnalyzer(options = {}) {
         gain.gain.cancelScheduledValues(now);
         gain.gain.setValueAtTime(clamp01(value), now);
       },
+      fade(from, to, at, fadeSeconds = 0.01) {
+        const start = Math.max(ctx.currentTime, Number(at) || 0);
+        gain.gain.cancelScheduledValues(start);
+        gain.gain.setValueAtTime(clamp01(from), start);
+        gain.gain.linearRampToValueAtTime(clamp01(to), start + Math.max(0.001, fadeSeconds));
+      },
       stop(fadeSeconds = 0.03) {
         if (stopped) return;
         stopped = true;
@@ -532,9 +550,7 @@ export function createAudioAnalyzer(options = {}) {
         gain.gain.setTargetAtTime(0, now, Math.max(0.005, fadeSeconds / 3));
         try {
           source.stop(now + Math.max(0.01, fadeSeconds));
-        } catch {
-          // Already ended; the gain ramp is sufficient.
-        }
+        } catch {}
       }
     };
   }
@@ -553,9 +569,9 @@ export function createAudioAnalyzer(options = {}) {
     currentTime,
     decodeAudio,
     destroy,
+    fadeVolume,
     measure,
     playPcmBuffer,
-    rampVolume,
     resume,
     samples,
     resetMixElement: mixer.resetElement,

--- a/src/audio/engine/audioAnalyzer.js
+++ b/src/audio/engine/audioAnalyzer.js
@@ -153,6 +153,16 @@ export function createAudioAnalyzer(options = {}) {
     node.gain.gain.setValueAtTime(clamp01(value), now);
   }
 
+  // Scheduled, click-free counterpart to setVolume, for callers that need an
+  // element muted or restored at an exact context time (transition handoffs).
+  function rampVolume(element, value, at = 0, fadeSeconds = 0.03) {
+    const node = connectElement(element);
+    if (!node) return;
+    const start = Math.max(currentTime(), Number(at) || 0);
+    node.gain.gain.cancelScheduledValues(start);
+    node.gain.gain.setTargetAtTime(clamp01(value), start, Math.max(0.005, fadeSeconds / 3));
+  }
+
   async function decodeAudio(url, signal) {
     const ctx = audioContext();
     if (!ctx) return null;
@@ -473,6 +483,62 @@ export function createAudioAnalyzer(options = {}) {
     return { samples: values, sampleRate: context.sampleRate };
   }
 
+  /**
+   * Plays raw planar PCM as a scheduled one-shot source on the context clock.
+   * Used for pre-rendered transition overlaps, which need sample-accurate
+   * scheduling that media elements cannot provide. The chain is source ->
+   * gain -> destination: per-element processing (EQ, normalization) is
+   * intentionally bypassed because the rendered mix is already final audio.
+   * @returns {object|null} Handle with the resolved start/end context times,
+   * `setVolume`, and a click-free `stop`; null when the context is missing.
+   */
+  function playPcmBuffer({ channels, sampleRate, when = 0, offset = 0, volume = 1 }) {
+    const ctx = audioContext();
+    const frames = channels?.[0]?.length || 0;
+    if (!ctx || !frames) return null;
+
+    const buffer = ctx.createBuffer(channels.length, frames, sampleRate);
+    channels.forEach((data, index) => buffer.copyToChannel(data, index));
+    const source = ctx.createBufferSource();
+    const gain = ctx.createGain();
+    source.buffer = buffer;
+    gain.gain.value = clamp01(volume);
+    source.connect(gain);
+    gain.connect(ctx.destination);
+
+    // `offset` skips into the buffer for callers that were scheduled late and
+    // need the remainder to stay aligned with the media timeline.
+    const skip = Math.min(Math.max(0, Number(offset) || 0), frames / sampleRate);
+    const startTime = Math.max(ctx.currentTime, Number(when) || 0);
+    const endTime = startTime + frames / sampleRate - skip;
+    source.start(startTime, skip);
+    let stopped = false;
+
+    return {
+      startTime,
+      endTime,
+      setVolume(value) {
+        const now = ctx.currentTime;
+        gain.gain.cancelScheduledValues(now);
+        gain.gain.setValueAtTime(clamp01(value), now);
+      },
+      stop(fadeSeconds = 0.03) {
+        if (stopped) return;
+        stopped = true;
+        const now = ctx.currentTime;
+        // A short ramp instead of a hard stop, so cancelling mid-overlap
+        // never leaves a click at whatever sample the source was on.
+        gain.gain.cancelScheduledValues(now);
+        gain.gain.setTargetAtTime(0, now, Math.max(0.005, fadeSeconds / 3));
+        try {
+          source.stop(now + Math.max(0.01, fadeSeconds));
+        } catch {
+          // Already ended; the gain ramp is sufficient.
+        }
+      }
+    };
+  }
+
   function destroy() {
     if (!context) return;
     context.close().catch(() => {});
@@ -488,6 +554,8 @@ export function createAudioAnalyzer(options = {}) {
     decodeAudio,
     destroy,
     measure,
+    playPcmBuffer,
+    rampVolume,
     resume,
     samples,
     resetMixElement: mixer.resetElement,

--- a/src/audio/engine/audioAnalyzer.js
+++ b/src/audio/engine/audioAnalyzer.js
@@ -154,9 +154,10 @@ export function createAudioAnalyzer(options = {}) {
   }
 
   /**
-   * Scheduled linear fade between two known gains, for handoffs that must land
-   * at an exact context time. `from` is explicit because an AudioParam's value
-   * at a future scheduled instant cannot be read back.
+   * Scheduled linear fade between two normalized mix-envelope levels, for
+   * handoffs that must land at an exact context time. `from` is explicit
+   * because an AudioParam's value at a future scheduled instant cannot be
+   * read back.
    *
    * Linear rather than equal-power on purpose: these fades hand over between
    * two sources carrying the *same* audio, which sum coherently, so linear
@@ -167,11 +168,23 @@ export function createAudioAnalyzer(options = {}) {
   function fadeVolume(element, from, to, at = 0, fadeSeconds = 0.01) {
     const node = connectElement(element);
     if (!node) return false;
-    const param = node.gain.gain;
+    // Handoff fades are a normalized envelope on top of the element's master
+    // gain. Keeping them separate means a live volume change can update
+    // `node.gain` without cancelling this scheduled automation.
+    const param = node.mixGain.gain;
     const start = Math.max(currentTime(), Number(at) || 0);
     param.cancelScheduledValues(start);
     param.setValueAtTime(clamp01(from), start);
     param.linearRampToValueAtTime(clamp01(to), start + Math.max(0.001, fadeSeconds));
+    return true;
+  }
+
+  function setMixVolume(element, value) {
+    const node = connectElement(element);
+    if (!node) return false;
+    const now = currentTime();
+    node.mixGain.gain.cancelScheduledValues(now);
+    node.mixGain.gain.setValueAtTime(clamp01(value), now);
     return true;
   }
 
@@ -502,7 +515,8 @@ export function createAudioAnalyzer(options = {}) {
    * gain -> destination: per-element processing (EQ, normalization) is
    * intentionally bypassed because the rendered mix is already final audio.
    * @returns {object|null} Handle with the resolved start/end context times,
-   * `setVolume`, and a click-free `stop`; null when the context is missing.
+   * `setVolume`, normalized envelope fades, and a click-free `stop`; null
+   * when the context is missing.
    */
   function playPcmBuffer({ channels, sampleRate, when = 0, offset = 0, volume = 1 }) {
     const ctx = audioContext();
@@ -512,11 +526,14 @@ export function createAudioAnalyzer(options = {}) {
     const buffer = ctx.createBuffer(channels.length, frames, sampleRate);
     channels.forEach((data, index) => buffer.copyToChannel(data, index));
     const source = ctx.createBufferSource();
-    const gain = ctx.createGain();
+    const envelopeGain = ctx.createGain();
+    const volumeGain = ctx.createGain();
     source.buffer = buffer;
-    gain.gain.value = clamp01(volume);
-    source.connect(gain);
-    gain.connect(ctx.destination);
+    envelopeGain.gain.value = 1;
+    volumeGain.gain.value = clamp01(volume);
+    source.connect(envelopeGain);
+    envelopeGain.connect(volumeGain);
+    volumeGain.connect(ctx.destination);
 
     // `offset` skips into the buffer for callers that were scheduled late and
     // need the remainder to stay aligned with the media timeline.
@@ -531,14 +548,17 @@ export function createAudioAnalyzer(options = {}) {
       endTime,
       setVolume(value) {
         const now = ctx.currentTime;
-        gain.gain.cancelScheduledValues(now);
-        gain.gain.setValueAtTime(clamp01(value), now);
+        volumeGain.gain.cancelScheduledValues(now);
+        volumeGain.gain.setValueAtTime(clamp01(value), now);
       },
       fade(from, to, at, fadeSeconds = 0.01) {
         const start = Math.max(ctx.currentTime, Number(at) || 0);
-        gain.gain.cancelScheduledValues(start);
-        gain.gain.setValueAtTime(clamp01(from), start);
-        gain.gain.linearRampToValueAtTime(clamp01(to), start + Math.max(0.001, fadeSeconds));
+        envelopeGain.gain.cancelScheduledValues(start);
+        envelopeGain.gain.setValueAtTime(clamp01(from), start);
+        envelopeGain.gain.linearRampToValueAtTime(
+          clamp01(to),
+          start + Math.max(0.001, fadeSeconds)
+        );
       },
       stop(fadeSeconds = 0.03) {
         if (stopped) return;
@@ -546,8 +566,8 @@ export function createAudioAnalyzer(options = {}) {
         const now = ctx.currentTime;
         // A short ramp instead of a hard stop, so cancelling mid-overlap
         // never leaves a click at whatever sample the source was on.
-        gain.gain.cancelScheduledValues(now);
-        gain.gain.setTargetAtTime(0, now, Math.max(0.005, fadeSeconds / 3));
+        envelopeGain.gain.cancelScheduledValues(now);
+        envelopeGain.gain.setTargetAtTime(0, now, Math.max(0.005, fadeSeconds / 3));
         try {
           source.stop(now + Math.max(0.01, fadeSeconds));
         } catch {}
@@ -576,6 +596,7 @@ export function createAudioAnalyzer(options = {}) {
     samples,
     resetMixElement: mixer.resetElement,
     scheduleCrossfade: mixer.scheduleCrossfade,
+    setMixVolume,
     setNormalization,
     setVolume,
     spectrum

--- a/src/components/player/FullscreenPlayer.vue
+++ b/src/components/player/FullscreenPlayer.vue
@@ -99,34 +99,37 @@ export default {
     <main class="fullscreen-player__stage">
       <div class="fullscreen-player__left">
         <div class="fullscreen-player__artwork">
-          <video
-            v-if="nowArtworkVideo"
-            ref="fullscreenArtworkVideoRef"
-            :key="nowArtworkVideo"
-            :src="nowArtworkVideo"
-            :poster="fullscreenArtworkImage || nowArtworkImage || activeTrack?.thumbnail"
-            :autoplay="isPlaying"
-            muted
-            loop
-            playsinline
-            preload="auto"
-            aria-hidden="true"
-            @canplay="playFullscreenArtworkVideo"
-            @pause="keepFullscreenArtworkVideoPlaying"
-            @ended="restartFullscreenArtworkVideo"
-            @stalled="keepFullscreenArtworkVideoPlaying"
-            @waiting="keepFullscreenArtworkVideoPlaying"
-            @error="onNowArtworkVideoError"
-          />
-          <img
-            v-else-if="fullscreenArtworkSrc"
-            :src="fullscreenArtworkSrc"
-            :alt="`${activeTrack?.title || 'Current track'} artwork`"
-            @error="onFullscreenArtworkError"
-          />
-          <div v-else class="fullscreen-player__artwork-empty">
-            <q-icon name="music_note" />
-          </div>
+          <transition name="artwork-fade">
+            <video
+              v-if="nowArtworkVideo"
+              ref="fullscreenArtworkVideoRef"
+              :key="nowArtworkVideo"
+              :src="nowArtworkVideo"
+              :poster="fullscreenArtworkImage || nowArtworkImage || activeTrack?.thumbnail"
+              :autoplay="isPlaying"
+              muted
+              loop
+              playsinline
+              preload="auto"
+              aria-hidden="true"
+              @canplay="playFullscreenArtworkVideo"
+              @pause="keepFullscreenArtworkVideoPlaying"
+              @ended="restartFullscreenArtworkVideo"
+              @stalled="keepFullscreenArtworkVideoPlaying"
+              @waiting="keepFullscreenArtworkVideoPlaying"
+              @error="onNowArtworkVideoError"
+            />
+            <img
+              v-else-if="fullscreenArtworkSrc"
+              :key="fullscreenArtworkSrc"
+              :src="fullscreenArtworkSrc"
+              :alt="`${activeTrack?.title || 'Current track'} artwork`"
+              @error="onFullscreenArtworkError"
+            />
+            <div v-else key="empty" class="fullscreen-player__artwork-empty">
+              <q-icon name="music_note" />
+            </div>
+          </transition>
         </div>
 
         <div class="fullscreen-player__track-copy">

--- a/src/styles/fullscreen-player.css
+++ b/src/styles/fullscreen-player.css
@@ -118,6 +118,7 @@
 }
 
 .fullscreen-player__artwork {
+  position: relative;
   width: min(100%, 570px, calc(100vh - 330px));
   aspect-ratio: 1;
   justify-self: center;
@@ -145,6 +146,28 @@
   place-items: center;
   color: rgba(255, 255, 255, 0.28);
   font-size: 68px;
+}
+
+.artwork-fade-enter-active,
+.artwork-fade-leave-active {
+  transition: opacity 0.6s ease, filter 0.6s ease, transform 0.6s ease;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.artwork-fade-enter-from {
+  opacity: 0;
+  filter: blur(16px);
+  transform: scale(1.02);
+}
+
+.artwork-fade-leave-to {
+  opacity: 0;
+  filter: blur(16px);
+  transform: scale(0.98);
 }
 
 .fullscreen-player__track-copy {

--- a/test/audioAnalysisService.test.js
+++ b/test/audioAnalysisService.test.js
@@ -206,3 +206,65 @@ test('audio analysis service rejects invalid BPM and redacts sensitive diagnosti
     await rm(directory, { recursive: true, force: true });
   }
 });
+
+test('audio analysis service renders beat-matched transitions over IPC', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'orchard-transition-'));
+  const cachePath = path.join(directory, 'cache.json');
+  const ipc = fakeIpcMain();
+  const service = setupAudioAnalysisService({
+    cachePath,
+    ipcMain: ipc,
+    nativeModulePath: path.resolve('native/build/Release/orchard_audio_analysis.node'),
+    logger: () => {}
+  });
+
+  function stereoTone(seconds, frequency) {
+    const sampleRate = 44100;
+    const data = new Float32Array(Math.floor(seconds * sampleRate));
+    for (let index = 0; index < data.length; index += 1) {
+      data[index] = 0.3 * Math.sin((2 * Math.PI * frequency * index) / sampleRate);
+    }
+    return [data, new Float32Array(data)];
+  }
+
+  try {
+    const result = await ipc.invoke('audio-analysis:render-transition', {
+      outgoing: { channels: stereoTone(12, 220), anchor: 1, bpm: 126 },
+      incoming: { channels: stereoTone(12, 330), anchor: 1, bpm: 126 },
+      options: { sampleRate: 44100, beats: 8, bassSwap: 0.75 }
+    });
+    assert.equal(result.rendered, true, result.rejected);
+    assert.equal(result.channels.length, 2);
+    const expected = 8 * (60 / 126) * 44100;
+    assert.ok(Math.abs(result.channels[0].length - expected) < 4);
+    assert.equal(result.bpm, 126);
+
+    const refused = await ipc.invoke('audio-analysis:render-transition', {
+      outgoing: { channels: stereoTone(12, 220), anchor: 1, bpm: 100 },
+      incoming: { channels: stereoTone(12, 330), anchor: 1, bpm: 126 },
+      options: { sampleRate: 44100, beats: 8 }
+    });
+    assert.equal(refused.rendered, false);
+    assert.match(refused.rejected, /transparent stretch range/);
+
+    await assert.rejects(
+      ipc.invoke('audio-analysis:render-transition', {
+        outgoing: { channels: [], anchor: 0, bpm: 126 },
+        incoming: { channels: stereoTone(2, 330), anchor: 0, bpm: 126 },
+        options: { sampleRate: 44100 }
+      }),
+      /Invalid outgoing PCM/
+    );
+    await assert.rejects(
+      ipc.invoke('audio-analysis:render-transition', {
+        outgoing: { channels: stereoTone(2, 220), anchor: 0, bpm: 126 },
+        incoming: { channels: stereoTone(2, 330), anchor: 0, bpm: 126 },
+        options: {}
+      }),
+      /valid sample rate/
+    );
+  } finally {
+    await service.stop();
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/test/lifecycleCrossfade.test.js
+++ b/test/lifecycleCrossfade.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { disableCrossfadePlayback } from '../src/app/core/lifecycle.js';
+
+test('disabling crossfade cancels both transition engines before restoring volume', () => {
+  const calls = [];
+  const ctx = {
+    autoCrossfade: { cancel: () => calls.push('auto') },
+    dismissSmartCrossfadeMix: () => calls.push('dismiss'),
+    setCurrentAudioVolume: () => calls.push('volume'),
+    stopCrossfadeClock: () => calls.push('clock'),
+    wsolaCrossfade: { cancel: () => calls.push('wsola') }
+  };
+
+  disableCrossfadePlayback(ctx);
+
+  assert.deepEqual(calls, ['clock', 'auto', 'wsola', 'dismiss', 'volume']);
+});

--- a/test/playbackControls.test.js
+++ b/test/playbackControls.test.js
@@ -1,7 +1,24 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { installMediaHandlers } from '../src/app/playback/mediaHandlers.js';
-import { installPlaybackControls, playbackNeedsFreshStream } from '../src/app/playback/playbackControls.js';
+import {
+  installPlaybackControls,
+  playbackNeedsFreshStream,
+  queueAfterTransitionPromotion
+} from '../src/app/playback/playbackControls.js';
+
+test('transition promotion preserves queue edits made during the overlap', () => {
+  const editedQueue = [
+    { id: 'new-first' },
+    { id: 'incoming' },
+    { id: 'moved-last' }
+  ];
+
+  assert.deepEqual(
+    queueAfterTransitionPromotion(editedQueue, 'incoming'),
+    [{ id: 'new-first' }, { id: 'moved-last' }]
+  );
+});
 
 test('paused playback leaves buffering so the play control is usable again', () => {
   let stallRecoveryCleared = false;

--- a/test/playbackControls.test.js
+++ b/test/playbackControls.test.js
@@ -231,3 +231,93 @@ test('playing from history does not enqueue the rest of listening history', () =
     options: { queueSource: [selected] }
   }]);
 });
+
+// A WSOLA overlap already contains the incoming track, so the legacy engine
+// must never start its own fade on the same standby element underneath it.
+function crossfadeRoutingContext({ wsolaActive, wsolaPlan }) {
+  const legacyStarts = [];
+  const fromAudio = { currentTime: 200, duration: 240, pause() {}, play: async () => {} };
+  const toAudio = { currentTime: 0, src: 'http://127.0.0.1/next', pause() {}, play: async () => {} };
+  const ctx = {
+    activeAudioDeck: { value: 'main' },
+    activeTrack: { value: { id: 'from', durationSeconds: 240 } },
+    activeTrackIsVideo: { value: false },
+    crossfadeAnalysis: { value: { status: 'ready', bpm: 126 } },
+    nextCrossfadeAnalysis: { value: { status: 'ready', bpm: 126 } },
+    crossfadeEnabled: { value: true },
+    crossfadeMode: { value: 'smart' },
+    crossfadeSeconds: { value: 6 },
+    currentAudio: () => fromAudio,
+    standbyAudio: () => toAudio,
+    currentTime: { value: 200 },
+    duration: { value: 240 },
+    isPlaying: { value: true },
+    isSeeking: { value: false },
+    listeningParty: { value: { status: 'offline' } },
+    listeningPartyIsHost: { value: true },
+    playbackError: { value: '' },
+    queue: { value: [{ id: 'to', durationSeconds: 200 }] },
+    repeatMode: { value: 'off' },
+    sleepTimerMode: { value: 'off' },
+    sleepTimerVolumeFactor: { value: 1 },
+    volume: { value: 1 },
+    preloadedTrackMatches: () => true,
+    preloadNextTrack: async () => true,
+    nextTrackPreload: { value: { resolved: { streamUrl: 'http://127.0.0.1/next' } } },
+    activeTrackFromResolved: (track) => track,
+    // Backing state for the real mix overlay, which installPlaybackControls
+    // provides itself.
+    smartCrossfadeMix: { value: { visible: false } },
+    smartCrossfadeMixSequence: 0,
+    nowArtworkImage: { value: '' },
+    fullscreenPlayerOpen: { value: false },
+    autoCrossfade: {
+      isActive: () => false,
+      cancel: () => {},
+      transitionPlan: () => ({ shouldStart: true, transitionStart: 190, fadeSeconds: 20 }),
+      start: async (options) => {
+        legacyStarts.push(options);
+        return true;
+      }
+    },
+    wsolaCrossfade: {
+      isActive: () => wsolaActive,
+      cancel: () => {},
+      plan: () => wsolaPlan,
+      preparationStatus: () => 'idle',
+      preparedTransition: () => null,
+      prepare: async () => null,
+      start: async () => false
+    }
+  };
+  installPlaybackControls(ctx);
+  return { ctx, legacyStarts };
+}
+
+test('an active WSOLA overlap blocks the legacy crossfade instead of doubling it', async () => {
+  const { ctx, legacyStarts } = crossfadeRoutingContext({
+    wsolaActive: true,
+    wsolaPlan: { ok: true, transitionStart: 200 }
+  });
+
+  assert.equal(await ctx.maybeStartAutoCrossfade(), false);
+  assert.equal(await ctx.maybeStartAutoCrossfade({ force: true, reason: 'ended-handoff' }), false);
+  assert.deepEqual(legacyStarts, [], 'legacy engine started under a live WSOLA overlap');
+});
+
+test('a refused WSOLA pairing still falls back to the legacy crossfade', async () => {
+  const originalWindow = globalThis.window;
+  // The mix overlay schedules its own dismissal on the real window timer.
+  globalThis.window = { setTimeout: () => 1, clearTimeout: () => {} };
+  try {
+    const { ctx, legacyStarts } = crossfadeRoutingContext({
+      wsolaActive: false,
+      wsolaPlan: { ok: false, reason: 'tempo-distance' }
+    });
+
+    assert.equal(await ctx.maybeStartAutoCrossfade(), true);
+    assert.equal(legacyStarts.length, 1);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});

--- a/test/playbackControls.test.js
+++ b/test/playbackControls.test.js
@@ -338,3 +338,20 @@ test('a refused WSOLA pairing still falls back to the legacy crossfade', async (
     globalThis.window = originalWindow;
   }
 });
+
+test('processed audio falls back to the legacy crossfade', async () => {
+  const originalWindow = globalThis.window;
+  globalThis.window = { setTimeout: () => 1, clearTimeout: () => {} };
+  try {
+    const { ctx, legacyStarts } = crossfadeRoutingContext({
+      wsolaActive: false,
+      wsolaPlan: { ok: true, transitionStart: 200 }
+    });
+    ctx.volumeNormalizationEnabled = { value: true };
+
+    assert.equal(await ctx.maybeStartAutoCrossfade(), true);
+    assert.equal(legacyStarts.length, 1);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});

--- a/test/playbackControls.test.js
+++ b/test/playbackControls.test.js
@@ -232,10 +232,8 @@ test('playing from history does not enqueue the rest of listening history', () =
   }]);
 });
 
-// A WSOLA overlap already contains the incoming track, so the legacy engine
-// must never start its own fade on the same standby element underneath it.
-function crossfadeRoutingContext({ wsolaActive, wsolaPlan }) {
-  const legacyStarts = [];
+function crossfadeRoutingContext({ mode = 'smart', wsolaActive, wsolaPlan }) {
+  const fixedDurationStarts = [];
   const fromAudio = { currentTime: 200, duration: 240, pause() {}, play: async () => {} };
   const toAudio = { currentTime: 0, src: 'http://127.0.0.1/next', pause() {}, play: async () => {} };
   const ctx = {
@@ -245,7 +243,7 @@ function crossfadeRoutingContext({ wsolaActive, wsolaPlan }) {
     crossfadeAnalysis: { value: { status: 'ready', bpm: 126 } },
     nextCrossfadeAnalysis: { value: { status: 'ready', bpm: 126 } },
     crossfadeEnabled: { value: true },
-    crossfadeMode: { value: 'smart' },
+    crossfadeMode: { value: mode },
     crossfadeSeconds: { value: 6 },
     currentAudio: () => fromAudio,
     standbyAudio: () => toAudio,
@@ -276,7 +274,7 @@ function crossfadeRoutingContext({ wsolaActive, wsolaPlan }) {
       cancel: () => {},
       transitionPlan: () => ({ shouldStart: true, transitionStart: 190, fadeSeconds: 20 }),
       start: async (options) => {
-        legacyStarts.push(options);
+        fixedDurationStarts.push(options);
         return true;
       }
     },
@@ -291,33 +289,50 @@ function crossfadeRoutingContext({ wsolaActive, wsolaPlan }) {
     }
   };
   installPlaybackControls(ctx);
-  return { ctx, legacyStarts };
+  return { ctx, fixedDurationStarts };
 }
 
-test('an active WSOLA overlap blocks the legacy crossfade instead of doubling it', async () => {
-  const { ctx, legacyStarts } = crossfadeRoutingContext({
+test('an active WSOLA overlap never starts the fixed-duration crossfade underneath it', async () => {
+  const { ctx, fixedDurationStarts } = crossfadeRoutingContext({
     wsolaActive: true,
     wsolaPlan: { ok: true, transitionStart: 200 }
   });
 
   assert.equal(await ctx.maybeStartAutoCrossfade(), false);
   assert.equal(await ctx.maybeStartAutoCrossfade({ force: true, reason: 'ended-handoff' }), false);
-  assert.deepEqual(legacyStarts, [], 'legacy engine started under a live WSOLA overlap');
+  assert.deepEqual(fixedDurationStarts, [], 'fixed-duration engine started under a live WSOLA overlap');
 });
 
-test('a refused WSOLA pairing still falls back to the legacy crossfade', async () => {
-  const originalWindow = globalThis.window;
-  // The mix overlay schedules its own dismissal on the real window timer.
-  globalThis.window = { setTimeout: () => 1, clearTimeout: () => {} };
-  try {
-    const { ctx, legacyStarts } = crossfadeRoutingContext({
-      wsolaActive: false,
-      wsolaPlan: { ok: false, reason: 'tempo-distance' }
-    });
+test('a refused smart pairing does not fall back to the fixed-duration crossfade', async () => {
+  const { ctx, fixedDurationStarts } = crossfadeRoutingContext({
+    wsolaActive: false,
+    wsolaPlan: { ok: false, reason: 'tempo-distance' }
+  });
 
-    assert.equal(await ctx.maybeStartAutoCrossfade(), true);
-    assert.equal(legacyStarts.length, 1);
-  } finally {
-    globalThis.window = originalWindow;
-  }
+  assert.equal(await ctx.maybeStartAutoCrossfade(), false);
+  assert.deepEqual(fixedDurationStarts, []);
+});
+
+test('a forced smart handoff does not use the fixed-duration crossfade', async () => {
+  const { ctx, fixedDurationStarts } = crossfadeRoutingContext({
+    wsolaActive: false,
+    wsolaPlan: { ok: true, transitionStart: 200 }
+  });
+
+  assert.equal(
+    await ctx.maybeStartAutoCrossfade({ force: true, reason: 'ended-handoff' }),
+    false
+  );
+  assert.deepEqual(fixedDurationStarts, []);
+});
+
+test('standard mode still uses the fixed-duration crossfade', async () => {
+  const { ctx, fixedDurationStarts } = crossfadeRoutingContext({
+    mode: 'standard',
+    wsolaActive: false,
+    wsolaPlan: { ok: false, reason: 'tempo-distance' }
+  });
+
+  assert.equal(await ctx.maybeStartAutoCrossfade(), true);
+  assert.equal(fixedDurationStarts.length, 1);
 });

--- a/test/playbackControls.test.js
+++ b/test/playbackControls.test.js
@@ -232,8 +232,10 @@ test('playing from history does not enqueue the rest of listening history', () =
   }]);
 });
 
-function crossfadeRoutingContext({ mode = 'smart', wsolaActive, wsolaPlan }) {
-  const fixedDurationStarts = [];
+// A WSOLA overlap already contains the incoming track, so the legacy engine
+// must never start its own fade on the same standby element underneath it.
+function crossfadeRoutingContext({ wsolaActive, wsolaPlan }) {
+  const legacyStarts = [];
   const fromAudio = { currentTime: 200, duration: 240, pause() {}, play: async () => {} };
   const toAudio = { currentTime: 0, src: 'http://127.0.0.1/next', pause() {}, play: async () => {} };
   const ctx = {
@@ -243,7 +245,7 @@ function crossfadeRoutingContext({ mode = 'smart', wsolaActive, wsolaPlan }) {
     crossfadeAnalysis: { value: { status: 'ready', bpm: 126 } },
     nextCrossfadeAnalysis: { value: { status: 'ready', bpm: 126 } },
     crossfadeEnabled: { value: true },
-    crossfadeMode: { value: mode },
+    crossfadeMode: { value: 'smart' },
     crossfadeSeconds: { value: 6 },
     currentAudio: () => fromAudio,
     standbyAudio: () => toAudio,
@@ -274,7 +276,7 @@ function crossfadeRoutingContext({ mode = 'smart', wsolaActive, wsolaPlan }) {
       cancel: () => {},
       transitionPlan: () => ({ shouldStart: true, transitionStart: 190, fadeSeconds: 20 }),
       start: async (options) => {
-        fixedDurationStarts.push(options);
+        legacyStarts.push(options);
         return true;
       }
     },
@@ -289,50 +291,33 @@ function crossfadeRoutingContext({ mode = 'smart', wsolaActive, wsolaPlan }) {
     }
   };
   installPlaybackControls(ctx);
-  return { ctx, fixedDurationStarts };
+  return { ctx, legacyStarts };
 }
 
-test('an active WSOLA overlap never starts the fixed-duration crossfade underneath it', async () => {
-  const { ctx, fixedDurationStarts } = crossfadeRoutingContext({
+test('an active WSOLA overlap blocks the legacy crossfade instead of doubling it', async () => {
+  const { ctx, legacyStarts } = crossfadeRoutingContext({
     wsolaActive: true,
     wsolaPlan: { ok: true, transitionStart: 200 }
   });
 
   assert.equal(await ctx.maybeStartAutoCrossfade(), false);
   assert.equal(await ctx.maybeStartAutoCrossfade({ force: true, reason: 'ended-handoff' }), false);
-  assert.deepEqual(fixedDurationStarts, [], 'fixed-duration engine started under a live WSOLA overlap');
+  assert.deepEqual(legacyStarts, [], 'legacy engine started under a live WSOLA overlap');
 });
 
-test('a refused smart pairing does not fall back to the fixed-duration crossfade', async () => {
-  const { ctx, fixedDurationStarts } = crossfadeRoutingContext({
-    wsolaActive: false,
-    wsolaPlan: { ok: false, reason: 'tempo-distance' }
-  });
+test('a refused WSOLA pairing still falls back to the legacy crossfade', async () => {
+  const originalWindow = globalThis.window;
+  // The mix overlay schedules its own dismissal on the real window timer.
+  globalThis.window = { setTimeout: () => 1, clearTimeout: () => {} };
+  try {
+    const { ctx, legacyStarts } = crossfadeRoutingContext({
+      wsolaActive: false,
+      wsolaPlan: { ok: false, reason: 'tempo-distance' }
+    });
 
-  assert.equal(await ctx.maybeStartAutoCrossfade(), false);
-  assert.deepEqual(fixedDurationStarts, []);
-});
-
-test('a forced smart handoff does not use the fixed-duration crossfade', async () => {
-  const { ctx, fixedDurationStarts } = crossfadeRoutingContext({
-    wsolaActive: false,
-    wsolaPlan: { ok: true, transitionStart: 200 }
-  });
-
-  assert.equal(
-    await ctx.maybeStartAutoCrossfade({ force: true, reason: 'ended-handoff' }),
-    false
-  );
-  assert.deepEqual(fixedDurationStarts, []);
-});
-
-test('standard mode still uses the fixed-duration crossfade', async () => {
-  const { ctx, fixedDurationStarts } = crossfadeRoutingContext({
-    mode: 'standard',
-    wsolaActive: false,
-    wsolaPlan: { ok: false, reason: 'tempo-distance' }
-  });
-
-  assert.equal(await ctx.maybeStartAutoCrossfade(), true);
-  assert.equal(fixedDurationStarts.length, 1);
+    assert.equal(await ctx.maybeStartAutoCrossfade(), true);
+    assert.equal(legacyStarts.length, 1);
+  } finally {
+    globalThis.window = originalWindow;
+  }
 });

--- a/test/playbackResolve.test.js
+++ b/test/playbackResolve.test.js
@@ -7,9 +7,15 @@ import {
 
 function playbackContext() {
   const ctx = {
+    autoCrossfade: { isActive: () => false },
     isPlayableTrack: (item) => Boolean(item?.id),
+    nextPreloadRequest: 0,
+    nextTrackPreload: { value: null },
+    resetNextCrossfadeAnalysis() {},
+    standbyAudio: () => null,
     supportedAudioMimes: () => [],
-    supportedVideoMimes: () => []
+    supportedVideoMimes: () => [],
+    wsolaCrossfade: { isActive: () => false }
   };
   installPlaybackResolve(ctx);
   return ctx;
@@ -30,6 +36,35 @@ test('resolves an established music-video fallback by its video ID', () => {
   assert.equal(payload.originalVideoId, 'song-id');
   assert.equal(payload.musicVideoAudioFallback, true);
   assert.equal(payload.fallbackTargetDurationSeconds, 180);
+});
+
+test('does not clear the transition-owned standby deck during a WSOLA overlap', () => {
+  const ctx = playbackContext();
+  const preload = {
+    track: { id: 'incoming' },
+    resolved: { streamUrl: 'https://example.test/incoming' }
+  };
+  let cleared = 0;
+  ctx.nextTrackPreload.value = preload;
+  ctx.standbyAudio = () => ({});
+  ctx.clearAudioElement = () => {
+    cleared += 1;
+  };
+  ctx.wsolaCrossfade.isActive = () => true;
+
+  assert.equal(ctx.clearNextPreload({ force: true }), false);
+  assert.equal(ctx.nextTrackPreload.value, preload);
+  assert.equal(ctx.nextPreloadRequest, 0);
+  assert.equal(cleared, 0);
+});
+
+test('does not replace the transition-owned standby source after a queue edit', async () => {
+  const ctx = playbackContext();
+  ctx.queue = { value: [{ id: 'new-queue-head' }] };
+  ctx.wsolaCrossfade.isActive = () => true;
+
+  assert.equal(await ctx.preloadNextTrack({ force: true }), false);
+  assert.equal(ctx.nextPreloadRequest, 0);
 });
 
 test('keeps song identity while preserving resolved fallback stream metadata', () => {

--- a/test/transitionRender.test.js
+++ b/test/transitionRender.test.js
@@ -1,0 +1,223 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const native = require('../native/build/Release/orchard_audio_analysis.node');
+
+const SAMPLE_RATE = 44100;
+
+// A steady low tone plus a steady mid tone. Continuous rather than percussive
+// so measurements do not depend on where a window lands relative to a beat,
+// and each track's low end sits at its own frequency so the bass handover can
+// be attributed to one side or the other.
+function track({ duration = 12, bass = 55, tone = 220, amplitude = 0.4 } = {}) {
+  const samples = new Float32Array(Math.floor(duration * SAMPLE_RATE));
+  for (let index = 0; index < samples.length; index += 1) {
+    const time = index / SAMPLE_RATE;
+    samples[index] = amplitude * (
+      Math.sin(2 * Math.PI * bass * time) * 0.6 +
+      Math.sin(2 * Math.PI * tone * time) * 0.4
+    );
+  }
+  return samples;
+}
+
+function source(samples, bpm, anchor = 0) {
+  return { channels: [samples, samples], anchor, bpm };
+}
+
+function rms(samples, from = 0, to = samples.length) {
+  let total = 0;
+  for (let index = from; index < to; index += 1) total += samples[index] ** 2;
+  return Math.sqrt(total / Math.max(1, to - from));
+}
+
+// Amplitude of one frequency over a window, by single-bin DFT.
+function amplitudeAt(samples, from, length, frequency) {
+  let real = 0;
+  let imaginary = 0;
+  for (let index = 0; index < length; index += 1) {
+    const angle = 2 * Math.PI * frequency * (index / SAMPLE_RATE);
+    real += samples[from + index] * Math.cos(angle);
+    imaginary -= samples[from + index] * Math.sin(angle);
+  }
+  return (2 * Math.hypot(real, imaginary)) / length;
+}
+
+test('renders a matched-tempo overlap at the requested length', async () => {
+  const result = await native.renderTransition(
+    source(track(), 126),
+    source(track({ bass: 85, tone: 330 }), 126),
+    { sampleRate: SAMPLE_RATE, beats: 16 }
+  );
+
+  assert.equal(result.rendered, true, result.rejected);
+  assert.equal(result.rejected, '');
+  assert.equal(result.bpm, 126);
+  assert.ok(Math.abs(result.stretchRatio - 1) < 1e-6);
+  assert.equal(result.channels.length, 2);
+  const expected = 16 * (60 / 126) * SAMPLE_RATE;
+  assert.ok(
+    Math.abs(result.channels[0].length - expected) < 2,
+    `expected ~${expected} samples, got ${result.channels[0].length}`
+  );
+});
+
+test('time-scales the outgoing track onto the incoming tempo', async () => {
+  const result = await native.renderTransition(
+    source(track(), 120),
+    source(track({ bass: 85, tone: 330 }), 126),
+    { sampleRate: SAMPLE_RATE, beats: 16 }
+  );
+
+  assert.equal(result.rendered, true, result.rejected);
+  // The overlap runs on the incoming grid, so the outgoing track is the one
+  // that moves. Reaching a faster grid compresses it: 120/126 = 0.9524, below
+  // 1. A ratio above 1 here would mean the mix is being slowed onto a tempo
+  // further from the target than it started.
+  assert.ok(
+    result.stretchRatio < 1,
+    `outgoing was slowed onto a faster grid: ratio ${result.stretchRatio}`
+  );
+  assert.ok(
+    Math.abs(result.stretchRatio - 120 / 126) < 1e-4,
+    `unexpected stretch ratio ${result.stretchRatio}`
+  );
+  assert.equal(result.bpm, 126);
+
+  // The mirrored pairing must move the other way. Pinning both directions is
+  // what catches an inverted ratio, which otherwise still looks plausible.
+  const slower = await native.renderTransition(
+    source(track(), 126),
+    source(track({ bass: 85, tone: 330 }), 120),
+    { sampleRate: SAMPLE_RATE, beats: 16 }
+  );
+  assert.equal(slower.rendered, true, slower.rejected);
+  assert.ok(
+    Math.abs(slower.stretchRatio - 126 / 120) < 1e-4,
+    `unexpected mirrored stretch ratio ${slower.stretchRatio}`
+  );
+});
+
+test('holds a level rather than dipping through the middle', async () => {
+  const result = await native.renderTransition(
+    source(track(), 126),
+    source(track({ bass: 85, tone: 330 }), 126),
+    { sampleRate: SAMPLE_RATE, beats: 16 }
+  );
+
+  const output = result.channels[0];
+  const third = Math.floor(output.length / 3);
+  const opening = rms(output, 0, third);
+  const middle = rms(output, third, third * 2);
+  const closing = rms(output, third * 2, output.length);
+
+  // A linear crossfade sags about 3 dB in the middle; equal power should stay
+  // within roughly 1.5 dB across the whole overlap.
+  for (const [name, value] of [['opening', opening], ['closing', closing]]) {
+    const ratio = middle / value;
+    assert.ok(
+      ratio > 0.84 && ratio < 1.19,
+      `level moved ${name}->middle by ${(20 * Math.log10(ratio)).toFixed(2)} dB`
+    );
+  }
+});
+
+test('hands the low end from one track to the other', async () => {
+  const result = await native.renderTransition(
+    source(track({ bass: 55, tone: 220 }), 126),
+    source(track({ bass: 85, tone: 330 }), 126),
+    { sampleRate: SAMPLE_RATE, beats: 16, bassSwap: 0.6 }
+  );
+  assert.equal(result.rendered, true, result.rejected);
+
+  const output = result.channels[0];
+  const window = Math.floor(SAMPLE_RATE * 0.5);
+  // Each track's bass measured against its own midrange, which cancels out the
+  // crossfade gain and isolates what the filter did.
+  const balance = (fraction, bass, tone) => {
+    const at = Math.floor(output.length * fraction);
+    return amplitudeAt(output, at, window, bass) / amplitudeAt(output, at, window, tone);
+  };
+
+  const outgoingEarly = balance(0.15, 55, 220);
+  const outgoingLate = balance(0.9, 55, 220);
+  const incomingEarly = balance(0.15, 85, 330);
+  const incomingLate = balance(0.9, 85, 330);
+
+  // A plain equal-power sum leaves both balances flat near 1.5 throughout,
+  // piling two low ends on top of each other. A real swap moves them apart.
+  assert.ok(
+    outgoingLate < outgoingEarly / 3,
+    `outgoing kept its low end: ${outgoingEarly.toFixed(3)} -> ${outgoingLate.toFixed(3)}`
+  );
+  assert.ok(
+    incomingLate > incomingEarly * 3,
+    `incoming never gained its low end: ${incomingEarly.toFixed(3)} -> ${incomingLate.toFixed(3)}`
+  );
+});
+
+test('refuses pairings it cannot render transparently', async () => {
+  const base = source(track(), 126);
+
+  const farApart = await native.renderTransition(
+    source(track(), 100),
+    base,
+    { sampleRate: SAMPLE_RATE, beats: 16 }
+  );
+  assert.equal(farApart.rendered, false);
+  assert.match(farApart.rejected, /transparent stretch range/);
+
+  const noTempo = await native.renderTransition(
+    source(track(), 0),
+    base,
+    { sampleRate: SAMPLE_RATE, beats: 16 }
+  );
+  assert.equal(noTempo.rendered, false);
+  assert.match(noTempo.rejected, /tempo/);
+
+  const tooShort = await native.renderTransition(
+    source(track({ duration: 2 }), 126),
+    source(track({ duration: 2 }), 126),
+    { sampleRate: SAMPLE_RATE, beats: 64 }
+  );
+  assert.equal(tooShort.rendered, false);
+  assert.match(tooShort.rejected, /too short/);
+});
+
+test('aligns the two tracks on their anchors', async () => {
+  // Offsetting the incoming anchor by one beat must shift which part of the
+  // incoming track lands at the start of the overlap.
+  const beat = 60 / 126;
+  const incoming = track({ bass: 85, tone: 330 });
+  const aligned = await native.renderTransition(
+    source(track(), 126),
+    source(incoming, 126, 0),
+    { sampleRate: SAMPLE_RATE, beats: 8 }
+  );
+  const shifted = await native.renderTransition(
+    source(track(), 126),
+    source(incoming, 126, beat),
+    { sampleRate: SAMPLE_RATE, beats: 8 }
+  );
+
+  assert.equal(aligned.rendered, true, aligned.rejected);
+  assert.equal(shifted.rendered, true, shifted.rejected);
+  let difference = 0;
+  const length = Math.min(aligned.channels[0].length, shifted.channels[0].length);
+  for (let index = 0; index < length; index += 1) {
+    difference = Math.max(difference, Math.abs(aligned.channels[0][index] - shifted.channels[0][index]));
+  }
+  assert.ok(difference > 0.01, 'anchor offset did not change the rendered overlap');
+});
+
+test('rejects malformed sources without rendering', async () => {
+  const base = source(track(), 126);
+  assert.throws(() => native.renderTransition(null, base, { beats: 8 }), /object/);
+  assert.throws(() => native.renderTransition({ bpm: 126 }, base, { beats: 8 }), /channels array/);
+  assert.throws(
+    () => native.renderTransition({ channels: [[1, 2]], bpm: 126 }, base, { beats: 8 }),
+    /Float32Array/
+  );
+});

--- a/test/transitionRender.test.js
+++ b/test/transitionRender.test.js
@@ -123,6 +123,98 @@ test('holds a level rather than dipping through the middle', async () => {
   }
 });
 
+test('crosses the two tracks on the handoff, not the middle of the overlap', async () => {
+  const handoff = 0.75;
+  // Tones well clear of the 200 Hz bass crossover, so these readings reflect
+  // the main fade rather than the low-end swap.
+  const outgoingTone = 900;
+  const incomingTone = 1500;
+  const result = await native.renderTransition(
+    source(track({ bass: 55, tone: outgoingTone }), 126),
+    source(track({ bass: 85, tone: incomingTone }), 126),
+    { sampleRate: SAMPLE_RATE, beats: 16, handoff, bassSwap: 0.8 }
+  );
+  assert.equal(result.rendered, true, result.rejected);
+
+  const output = result.channels[0];
+  const window = Math.floor(SAMPLE_RATE * 0.4);
+  const level = (fraction, tone) =>
+    amplitudeAt(output, Math.floor(output.length * fraction - window / 2), window, tone);
+
+  // At the handoff the two sit at equal power; the old symmetric fade would
+  // have crossed at 0.5 and left the incoming track already dominant here.
+  const ratio = level(handoff, outgoingTone) / level(handoff, incomingTone);
+  assert.ok(
+    ratio > 0.8 && ratio < 1.25,
+    `tracks not level at the handoff: ${ratio.toFixed(3)}`
+  );
+
+  // Through the pre-roll the outgoing track still leads.
+  assert.ok(
+    level(0.4, outgoingTone) > level(0.4, incomingTone) * 1.5,
+    'incoming track was not a bed underneath during the pre-roll'
+  );
+  // After the handoff the incoming track takes over.
+  assert.ok(
+    level(0.95, incomingTone) > level(0.95, outgoingTone) * 1.5,
+    'incoming track did not take over after the handoff'
+  );
+});
+
+test('a low bed keeps the outgoing track up until the handoff', async () => {
+  const handoff = 0.5;
+  const outgoingTone = 900;
+  const incomingTone = 1500;
+  const result = await native.renderTransition(
+    source(track({ bass: 55, tone: outgoingTone }), 126),
+    source(track({ bass: 85, tone: incomingTone }), 126),
+    { sampleRate: SAMPLE_RATE, beats: 16, handoff, bed: 0.25, bassSwap: 0.6 }
+  );
+  assert.equal(result.rendered, true, result.rejected);
+
+  const output = result.channels[0];
+  const window = Math.floor(SAMPLE_RATE * 0.4);
+  const level = (fraction, tone) =>
+    amplitudeAt(output, Math.floor(output.length * fraction - window / 2), window, tone);
+
+  // The outgoing track gives up under a dB across the whole pre-roll. Running
+  // the fade's first half over it instead would cost 3 dB, which over a
+  // pre-roll of any length is heard as the fade not having started.
+  const held = level(handoff - 0.02, outgoingTone) / level(0.06, outgoingTone);
+  assert.ok(
+    held > 0.85,
+    `outgoing track dropped ${(-20 * Math.log10(held)).toFixed(2)} dB before the handoff`
+  );
+  // The incoming track is present but well underneath, not level with it.
+  assert.ok(
+    level(handoff - 0.02, outgoingTone) > level(handoff - 0.02, incomingTone) * 1.8,
+    'incoming intro came up level with the outgoing track instead of sitting under it'
+  );
+  // The audible fade is the tail: the outgoing track is gone by the end.
+  assert.ok(
+    level(0.94, outgoingTone) < level(0.06, outgoingTone) * 0.25,
+    'outgoing track had not faded out by the end of the tail'
+  );
+});
+
+test('a handoff at the midpoint reproduces the symmetric crossfade', async () => {
+  const config = { sampleRate: SAMPLE_RATE, beats: 16, bassSwap: 0.6 };
+  const [plain, explicit] = await Promise.all([
+    native.renderTransition(source(track(), 126), source(track({ bass: 85, tone: 330 }), 126), config),
+    native.renderTransition(source(track(), 126), source(track({ bass: 85, tone: 330 }), 126),
+      { ...config, handoff: 0.5 })
+  ]);
+
+  assert.equal(plain.rendered, true, plain.rejected);
+  assert.equal(explicit.rendered, true, explicit.rejected);
+  assert.equal(plain.channels[0].length, explicit.channels[0].length);
+  let worst = 0;
+  for (let index = 0; index < plain.channels[0].length; index += 1) {
+    worst = Math.max(worst, Math.abs(plain.channels[0][index] - explicit.channels[0][index]));
+  }
+  assert.ok(worst < 1e-6, `default handoff drifted from 0.5 by ${worst}`);
+});
+
 test('hands the low end from one track to the other', async () => {
   const result = await native.renderTransition(
     source(track({ bass: 55, tone: 220 }), 126),

--- a/test/transitionRender.test.js
+++ b/test/transitionRender.test.js
@@ -33,7 +33,6 @@ function rms(samples, from = 0, to = samples.length) {
   return Math.sqrt(total / Math.max(1, to - from));
 }
 
-// Amplitude of one frequency over a window, by single-bin DFT.
 function amplitudeAt(samples, from, length, frequency) {
   let real = 0;
   let imaginary = 0;
@@ -187,8 +186,6 @@ test('refuses pairings it cannot render transparently', async () => {
 });
 
 test('aligns the two tracks on their anchors', async () => {
-  // Offsetting the incoming anchor by one beat must shift which part of the
-  // incoming track lands at the start of the overlap.
   const beat = 60 / 126;
   const incoming = track({ bass: 85, tone: 330 });
   const aligned = await native.renderTransition(

--- a/test/wsolaCrossfade.test.js
+++ b/test/wsolaCrossfade.test.js
@@ -1,0 +1,298 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createWsolaCrossfade } from '../src/audio/crossfade/wsolaCrossfade.js';
+
+function fakeClock() {
+  const timers = new Map();
+  let nextId = 0;
+  const window = {
+    clearTimeout: (id) => timers.delete(id),
+    setTimeout: (callback, delay) => {
+      const id = ++nextId;
+      timers.set(id, { callback, delay });
+      return id;
+    }
+  };
+  return {
+    window,
+    pending: () => timers.size,
+    async runNext() {
+      const [id, timer] = [...timers].sort((left, right) => left[1].delay - right[1].delay)[0] || [];
+      if (!timer) return false;
+      timers.delete(id);
+      timer.callback();
+      // Let any continuations queued by the callback settle.
+      await Promise.resolve();
+      return true;
+    }
+  };
+}
+
+function fakeAnalyzer() {
+  const calls = { ramps: [], volumes: [], buffers: [] };
+  let now = 100;
+  return {
+    calls,
+    advance(seconds) {
+      now += seconds;
+    },
+    currentTime: () => now,
+    resume: async () => {},
+    setVolume(element, value) {
+      calls.volumes.push({ element, value });
+    },
+    rampVolume(element, value, at) {
+      calls.ramps.push({ element, value, at });
+    },
+    playPcmBuffer({ channels, sampleRate, when, offset, volume }) {
+      const seconds = channels[0].length / sampleRate - offset;
+      const handle = {
+        startTime: Math.max(now, when),
+        endTime: Math.max(now, when) + seconds,
+        volumeCalls: [],
+        stopped: false,
+        setVolume(value) {
+          this.volumeCalls.push(value);
+        },
+        stop() {
+          this.stopped = true;
+        }
+      };
+      calls.buffers.push({ when, offset, volume, handle });
+      return handle;
+    },
+    async decodeAudio() {
+      const sampleRate = 44100;
+      const seconds = 60;
+      const data = new Float32Array(sampleRate * seconds).fill(0.1);
+      return {
+        sampleRate,
+        length: data.length,
+        numberOfChannels: 2,
+        getChannelData: () => data
+      };
+    }
+  };
+}
+
+function fakeElement(currentTime = 0) {
+  return {
+    currentTime,
+    paused: false,
+    pauseCalls: 0,
+    pause() {
+      this.pauseCalls += 1;
+      this.paused = true;
+    },
+    async play() {
+      this.paused = false;
+    }
+  };
+}
+
+function readyPlan({ transitionStart = 200, overlapSeconds = 7.6 } = {}) {
+  return {
+    ok: true,
+    transitionStart,
+    transitionEnd: transitionStart + overlapSeconds,
+    overlapSeconds,
+    beats: 16,
+    bassSwapFraction: 0.75,
+    outgoingBpm: 126,
+    incomingBpm: 126,
+    stretchRatio: 1,
+    incomingCueTime: 20,
+    incomingResumeTime: 20 + overlapSeconds,
+    outgoingSlice: { start: 198.5, end: 209.1, anchor: 1.5 },
+    incomingSlice: { start: 18.5, end: 29.1, anchor: 1.5 }
+  };
+}
+
+function renderFor(plan, sampleRate = 44100) {
+  return {
+    channels: [
+      new Float32Array(Math.round(plan.overlapSeconds * sampleRate)),
+      new Float32Array(Math.round(plan.overlapSeconds * sampleRate))
+    ],
+    sampleRate,
+    stretchRatio: 1.05
+  };
+}
+
+test('prepare slices both tracks and forwards the plan to the native bridge', async () => {
+  const analyzer = fakeAnalyzer();
+  const rendered = [];
+  const engine = createWsolaCrossfade({
+    analyzer,
+    bridge: {
+      renderTransition: async (outgoing, incoming, options) => {
+        rendered.push({ outgoing, incoming, options });
+        return {
+          rendered: true,
+          rejected: '',
+          stretchRatio: 1,
+          bpm: 126,
+          sampleRate: options.sampleRate,
+          channels: [new Float32Array(1000), new Float32Array(1000)]
+        };
+      }
+    }
+  });
+
+  // Slice windows must land inside the 60s fake decode.
+  const plan = {
+    ...readyPlan({ transitionStart: 40 }),
+    outgoingSlice: { start: 38.5, end: 49.1, anchor: 1.5 },
+    incomingSlice: { start: 18.5, end: 29.1, anchor: 1.5 }
+  };
+  await engine.prepare({ fromTrackId: 'a', toTrackId: 'b', fromUrl: 'u1', toUrl: 'u2', plan });
+
+  assert.equal(engine.preparationStatus('a', 'b'), 'ready');
+  assert.equal(engine.preparationStatus('a', 'other'), 'idle');
+  assert.ok(engine.preparedTransition('a', 'b')?.render);
+  assert.equal(rendered.length, 1);
+  const call = rendered[0];
+  assert.equal(call.outgoing.channels.length, 2);
+  assert.equal(call.outgoing.anchor, plan.outgoingSlice.anchor);
+  assert.equal(call.outgoing.bpm, 126);
+  assert.equal(call.incoming.anchor, plan.incomingSlice.anchor);
+  assert.equal(call.options.beats, 16);
+  assert.equal(call.options.bassSwap, 0.75);
+  const expectedFrames = Math.round((plan.outgoingSlice.end - plan.outgoingSlice.start) * 44100);
+  assert.ok(Math.abs(call.outgoing.channels[0].length - expectedFrames) <= 1);
+});
+
+test('a refused render marks the pairing failed instead of throwing', async () => {
+  const engine = createWsolaCrossfade({
+    analyzer: fakeAnalyzer(),
+    bridge: {
+      renderTransition: async () => ({ rendered: false, rejected: 'tempo', channels: [] })
+    }
+  });
+  const result = await engine.prepare({
+    fromTrackId: 'a', toTrackId: 'b', fromUrl: 'u1', toUrl: 'u2', plan: readyPlan()
+  });
+  assert.equal(result, null);
+  assert.equal(engine.preparationStatus('a', 'b'), 'failed');
+  assert.equal(engine.preparedTransition('a', 'b'), null);
+});
+
+test('start schedules the overlap on the context clock and promotes at the swap', async () => {
+  const clock = fakeClock();
+  const originalWindow = globalThis.window;
+  globalThis.window = clock.window;
+  try {
+    const analyzer = fakeAnalyzer();
+    const engine = createWsolaCrossfade({ analyzer, bridge: {} });
+    const plan = readyPlan({ transitionStart: 200, overlapSeconds: 8 });
+    const fromAudio = fakeElement(199.4);
+    const toAudio = fakeElement(0);
+    const events = [];
+
+    const startPromise = engine.start({
+      fromAudio,
+      toAudio,
+      plan,
+      render: renderFor(plan),
+      volume: 0.8,
+      onPromote: () => events.push('promote'),
+      onComplete: () => events.push('complete'),
+      onError: (error) => events.push(`error:${error.message}`)
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(engine.isActive(), true);
+    const buffer = analyzer.calls.buffers[0];
+    // 0.6s early: the buffer is scheduled ahead, not started immediately.
+    assert.ok(Math.abs(buffer.when - 100.6) < 0.01, `when=${buffer.when}`);
+    assert.equal(buffer.offset, 0);
+    assert.equal(buffer.volume, 0.8);
+    // The outgoing element is muted exactly at the buffer start.
+    const outgoingMute = analyzer.calls.ramps.find((ramp) => ramp.element === fromAudio && ramp.value === 0);
+    assert.ok(Math.abs(outgoingMute.at - buffer.when) < 0.01);
+    // The incoming element shadows the buffer from the mix-in point.
+    assert.ok(Math.abs(toAudio.currentTime - plan.incomingCueTime) < 0.01);
+    assert.equal(toAudio.paused, false);
+    // The incoming unmute is scheduled just before the buffer ends.
+    const incomingUnmute = analyzer.calls.ramps.find((ramp) => ramp.element === toAudio && ramp.value === 0.8);
+    assert.ok(Math.abs(incomingUnmute.at - (buffer.handle.endTime - 0.05)) < 0.01);
+
+    // Run: drift check, promote at the swap, final drift check, completion.
+    analyzer.advance(0.6 + 8 * 0.75);
+    while (events.length === 0 && await clock.runNext()) { /* advance */ }
+    assert.deepEqual(events, ['promote']);
+    assert.equal(fromAudio.pauseCalls, 1, 'outgoing released at promote');
+
+    analyzer.advance(8 * 0.25 + 0.2);
+    while (await clock.runNext()) { /* drain */ }
+    await startPromise;
+    assert.deepEqual(events, ['promote', 'complete']);
+    assert.equal(engine.isActive(), false);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('cancel before the swap restores the outgoing element at the stretched position', async () => {
+  const clock = fakeClock();
+  const originalWindow = globalThis.window;
+  globalThis.window = clock.window;
+  try {
+    const analyzer = fakeAnalyzer();
+    const engine = createWsolaCrossfade({ analyzer, bridge: {} });
+    const plan = readyPlan({ transitionStart: 200, overlapSeconds: 8 });
+    const render = renderFor(plan);
+    render.stretchRatio = 1.05;
+    const fromAudio = fakeElement(199.9);
+    const toAudio = fakeElement(0);
+
+    const startPromise = engine.start({
+      fromAudio,
+      toAudio,
+      plan,
+      render,
+      volume: 1,
+      onPromote: () => {},
+      onComplete: () => {},
+      onError: () => {}
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(engine.isActive(), true);
+
+    // Three seconds into the overlap the element clock and the stretched
+    // buffer have visibly diverged; cancel must realign before unmuting.
+    analyzer.advance(0.1 + 3);
+    fromAudio.currentTime = 203;
+    engine.cancel();
+
+    assert.equal(engine.isActive(), false);
+    assert.ok(analyzer.calls.buffers[0].handle.stopped);
+    assert.ok(Math.abs(fromAudio.currentTime - (200 + 3 * 1.05)) < 0.02,
+      `expected stretched realign, got ${fromAudio.currentTime}`);
+    assert.equal(toAudio.paused, true);
+    const restored = analyzer.calls.volumes.filter((entry) => entry.element === fromAudio).pop();
+    assert.equal(restored.value, 1);
+    assert.equal(await startPromise, false);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('start refuses when called too late for a clean downbeat', async () => {
+  const analyzer = fakeAnalyzer();
+  const engine = createWsolaCrossfade({ analyzer, bridge: {} });
+  const plan = readyPlan({ transitionStart: 200 });
+  const didStart = await engine.start({
+    fromAudio: fakeElement(200.6),
+    toAudio: fakeElement(0),
+    plan,
+    render: renderFor(plan),
+    volume: 1
+  });
+  assert.equal(didStart, false);
+  assert.equal(engine.isActive(), false);
+  assert.equal(analyzer.calls.buffers.length, 0);
+});

--- a/test/wsolaCrossfade.test.js
+++ b/test/wsolaCrossfade.test.js
@@ -315,6 +315,86 @@ test('cancel before the swap restores the outgoing element at the stretched posi
   }
 });
 
+test('a cancelled transition reports its caller and the tail it discarded', async () => {
+  const clock = fakeClock();
+  const originalWindow = globalThis.window;
+  globalThis.window = clock.window;
+  try {
+    const analyzer = fakeAnalyzer();
+    const reports = [];
+    const engine = createWsolaCrossfade({
+      analyzer,
+      bridge: {},
+      report: (event, detail) => reports.push({ event, detail })
+    });
+    const plan = readyPlan({ transitionStart: 200, overlapSeconds: 8 });
+    const fromAudio = fakeElement(199.9);
+    const toAudio = fakeElement(0);
+    const startPromise = engine.start({
+      fromAudio,
+      toAudio,
+      plan,
+      render: { channels: [new Float32Array(64), new Float32Array(64)], sampleRate: 48000, stretchRatio: 1 },
+      volume: 1,
+      onPromote: () => {},
+      onComplete: () => {},
+      onError: () => {}
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    analyzer.advance(0.1 + 5);
+    engine.cancel('audio-pause-event');
+
+    const cancelled = reports.find((entry) => entry.event === 'wsola-cancelled');
+    assert.ok(cancelled, 'expected a wsola-cancelled report');
+    assert.equal(cancelled.detail.reason, 'audio-pause-event');
+    assert.ok(Math.abs(cancelled.detail.elapsedSeconds - 5) < 0.05);
+    // Three seconds of the rendered overlap never played.
+    assert.ok(Math.abs(cancelled.detail.remainingSeconds - 3) < 0.05,
+      `expected ~3s discarded, got ${cancelled.detail.remainingSeconds}`);
+    assert.equal(await startPromise, false);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('an uninstrumented cancel still names itself', async () => {
+  const clock = fakeClock();
+  const originalWindow = globalThis.window;
+  globalThis.window = clock.window;
+  try {
+    const analyzer = fakeAnalyzer();
+    const reports = [];
+    const engine = createWsolaCrossfade({
+      analyzer,
+      bridge: {},
+      report: (event, detail) => reports.push({ event, detail })
+    });
+    const startPromise = engine.start({
+      fromAudio: fakeElement(199.9),
+      toAudio: fakeElement(0),
+      plan: readyPlan({ transitionStart: 200, overlapSeconds: 8 }),
+      render: { channels: [new Float32Array(64), new Float32Array(64)], sampleRate: 48000, stretchRatio: 1 },
+      volume: 1,
+      onPromote: () => {},
+      onComplete: () => {},
+      onError: () => {}
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    engine.cancel();
+
+    assert.equal(
+      reports.find((entry) => entry.event === 'wsola-cancelled').detail.reason,
+      'unspecified'
+    );
+    assert.equal(await startPromise, false);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
 test('volume changes update master gains without replacing scheduled handoff fades', async () => {
   const clock = fakeClock();
   const originalWindow = globalThis.window;

--- a/test/wsolaCrossfade.test.js
+++ b/test/wsolaCrossfade.test.js
@@ -30,7 +30,7 @@ function fakeClock() {
 }
 
 function fakeAnalyzer({ connected = true } = {}) {
-  const calls = { fades: [], volumes: [], buffers: [] };
+  const calls = { fades: [], mixVolumes: [], resets: [], volumes: [], buffers: [] };
   let now = 100;
   return {
     calls,
@@ -41,6 +41,13 @@ function fakeAnalyzer({ connected = true } = {}) {
     resume: async () => {},
     setVolume(element, value) {
       calls.volumes.push({ element, value });
+    },
+    setMixVolume(element, value) {
+      calls.mixVolumes.push({ element, value });
+      return connected;
+    },
+    resetMixElement(element) {
+      calls.resets.push(element);
     },
     fadeVolume(element, from, to, at, seconds) {
       if (!connected) return false;
@@ -221,10 +228,10 @@ test('start schedules the overlap on the context clock and promotes at the swap'
     const bufferIn = buffer.handle.fades[0];
     assert.deepEqual(
       [outgoingFade.from, outgoingFade.to],
-      [0.8, 0],
-      'outgoing element must fade down, not mute asymptotically'
+      [1, 0],
+      'outgoing mix envelope must fade down, not mute asymptotically'
     );
-    assert.deepEqual([bufferIn.from, bufferIn.to], [0, 0.8]);
+    assert.deepEqual([bufferIn.from, bufferIn.to], [0, 1]);
     assert.ok(Math.abs(outgoingFade.at - bufferIn.at) < 1e-9, 'fades must start together');
     assert.equal(outgoingFade.seconds, bufferIn.seconds);
     assert.ok(outgoingFade.seconds <= 0.02, `handoff window too wide: ${outgoingFade.seconds}s`);
@@ -234,8 +241,8 @@ test('start schedules the overlap on the context clock and promotes at the swap'
 
     const incomingFade = analyzer.calls.fades.find((fade) => fade.element === toAudio);
     const bufferOut = buffer.handle.fades[1];
-    assert.deepEqual([incomingFade.from, incomingFade.to], [0, 0.8]);
-    assert.deepEqual([bufferOut.from, bufferOut.to], [0.8, 0]);
+    assert.deepEqual([incomingFade.from, incomingFade.to], [0, 1]);
+    assert.deepEqual([bufferOut.from, bufferOut.to], [1, 0]);
     assert.ok(Math.abs(incomingFade.at - bufferOut.at) < 1e-9, 'fades must start together');
     assert.ok(
       Math.abs(incomingFade.at + incomingFade.seconds - buffer.handle.endTime) < 1e-9,
@@ -297,11 +304,51 @@ test('cancel before the swap restores the outgoing element at the stretched posi
 
     assert.equal(engine.isActive(), false);
     assert.ok(analyzer.calls.buffers[0].handle.stopped);
-    assert.ok(Math.abs(fromAudio.currentTime - (200 + 3 * 1.05)) < 0.02,
+    assert.ok(Math.abs(fromAudio.currentTime - (200 + 3 / 1.05)) < 0.02,
       `expected stretched realign, got ${fromAudio.currentTime}`);
     assert.equal(toAudio.paused, true);
     const restored = analyzer.calls.volumes.filter((entry) => entry.element === fromAudio).pop();
     assert.equal(restored.value, 1);
+    assert.equal(await startPromise, false);
+  } finally {
+    globalThis.window = originalWindow;
+  }
+});
+
+test('volume changes update master gains without replacing scheduled handoff fades', async () => {
+  const clock = fakeClock();
+  const originalWindow = globalThis.window;
+  globalThis.window = clock.window;
+  try {
+    const analyzer = fakeAnalyzer();
+    const engine = createWsolaCrossfade({ analyzer, bridge: {} });
+    const plan = readyPlan({ transitionStart: 200, overlapSeconds: 8 });
+    const fromAudio = fakeElement(199.4);
+    const toAudio = fakeElement(0);
+
+    const startPromise = engine.start({
+      fromAudio,
+      toAudio,
+      plan,
+      render: renderFor(plan),
+      volume: 0.8
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const scheduledElementFades = [...analyzer.calls.fades];
+    const scheduledBufferFades = [...analyzer.calls.buffers[0].handle.fades];
+    engine.setTargetVolume(0.35);
+
+    assert.deepEqual(analyzer.calls.fades, scheduledElementFades);
+    assert.deepEqual(analyzer.calls.buffers[0].handle.fades, scheduledBufferFades);
+    assert.deepEqual(analyzer.calls.volumes.slice(-2), [
+      { element: fromAudio, value: 0.35 },
+      { element: toAudio, value: 0.35 }
+    ]);
+    assert.deepEqual(analyzer.calls.buffers[0].handle.volumeCalls, [0.35]);
+
+    engine.cancel();
     assert.equal(await startPromise, false);
   } finally {
     globalThis.window = originalWindow;
@@ -322,6 +369,44 @@ test('start refuses when called too late for a clean downbeat', async () => {
   assert.equal(didStart, false);
   assert.equal(engine.isActive(), false);
   assert.equal(analyzer.calls.buffers.length, 0);
+});
+
+test('rechecks media time after context resume and maps late input time onto stretched output', async () => {
+  const clock = fakeClock();
+  const originalWindow = globalThis.window;
+  globalThis.window = clock.window;
+  try {
+    const analyzer = fakeAnalyzer();
+    const engine = createWsolaCrossfade({ analyzer, bridge: {} });
+    const plan = readyPlan({ transitionStart: 200, overlapSeconds: 8 });
+    const render = renderFor(plan);
+    render.stretchRatio = 0.95;
+    const fromAudio = fakeElement(199.9);
+    const toAudio = fakeElement(0);
+    analyzer.resume = async () => {
+      analyzer.advance(0.15);
+      fromAudio.currentTime += 0.15;
+    };
+
+    const startPromise = engine.start({
+      fromAudio,
+      toAudio,
+      plan,
+      render,
+      volume: 1
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const buffer = analyzer.calls.buffers[0];
+    assert.ok(Math.abs(buffer.offset - 0.05 * 0.95) < 1e-9);
+    assert.ok(Math.abs(toAudio.currentTime - (plan.incomingCueTime + buffer.offset)) < 1e-9);
+
+    engine.cancel();
+    assert.equal(await startPromise, false);
+  } finally {
+    globalThis.window = originalWindow;
+  }
 });
 
 test('start refuses when the elements are outside the audio graph', async () => {

--- a/test/wsolaCrossfade.test.js
+++ b/test/wsolaCrossfade.test.js
@@ -29,8 +29,8 @@ function fakeClock() {
   };
 }
 
-function fakeAnalyzer() {
-  const calls = { ramps: [], volumes: [], buffers: [] };
+function fakeAnalyzer({ connected = true } = {}) {
+  const calls = { fades: [], volumes: [], buffers: [] };
   let now = 100;
   return {
     calls,
@@ -42,8 +42,10 @@ function fakeAnalyzer() {
     setVolume(element, value) {
       calls.volumes.push({ element, value });
     },
-    rampVolume(element, value, at) {
-      calls.ramps.push({ element, value, at });
+    fadeVolume(element, from, to, at, seconds) {
+      if (!connected) return false;
+      calls.fades.push({ element, from, to, at, seconds });
+      return true;
     },
     playPcmBuffer({ channels, sampleRate, when, offset, volume }) {
       const seconds = channels[0].length / sampleRate - offset;
@@ -51,9 +53,13 @@ function fakeAnalyzer() {
         startTime: Math.max(now, when),
         endTime: Math.max(now, when) + seconds,
         volumeCalls: [],
+        fades: [],
         stopped: false,
         setVolume(value) {
           this.volumeCalls.push(value);
+        },
+        fade(from, to, at, fadeSeconds) {
+          this.fades.push({ from, to, at, seconds: fadeSeconds });
         },
         stop() {
           this.stopped = true;
@@ -140,7 +146,6 @@ test('prepare slices both tracks and forwards the plan to the native bridge', as
     }
   });
 
-  // Slice windows must land inside the 60s fake decode.
   const plan = {
     ...readyPlan({ transitionStart: 40 }),
     outgoingSlice: { start: 38.5, end: 49.1, anchor: 1.5 },
@@ -205,21 +210,43 @@ test('start schedules the overlap on the context clock and promotes at the swap'
 
     assert.equal(engine.isActive(), true);
     const buffer = analyzer.calls.buffers[0];
-    // 0.6s early: the buffer is scheduled ahead, not started immediately.
     assert.ok(Math.abs(buffer.when - 100.6) < 0.01, `when=${buffer.when}`);
     assert.equal(buffer.offset, 0);
     assert.equal(buffer.volume, 0.8);
-    // The outgoing element is muted exactly at the buffer start.
-    const outgoingMute = analyzer.calls.ramps.find((ramp) => ramp.element === fromAudio && ramp.value === 0);
-    assert.ok(Math.abs(outgoingMute.at - buffer.when) < 0.01);
-    // The incoming element shadows the buffer from the mix-in point.
+    // Handing over must be complementary and simultaneous: the element fades
+    // out over exactly the window the buffer fades in. Any gap where both
+    // carry the same audio at full gain is the comb filtering that made the
+    // transition sound like static.
+    const outgoingFade = analyzer.calls.fades.find((fade) => fade.element === fromAudio);
+    const bufferIn = buffer.handle.fades[0];
+    assert.deepEqual(
+      [outgoingFade.from, outgoingFade.to],
+      [0.8, 0],
+      'outgoing element must fade down, not mute asymptotically'
+    );
+    assert.deepEqual([bufferIn.from, bufferIn.to], [0, 0.8]);
+    assert.ok(Math.abs(outgoingFade.at - bufferIn.at) < 1e-9, 'fades must start together');
+    assert.equal(outgoingFade.seconds, bufferIn.seconds);
+    assert.ok(outgoingFade.seconds <= 0.02, `handoff window too wide: ${outgoingFade.seconds}s`);
+
     assert.ok(Math.abs(toAudio.currentTime - plan.incomingCueTime) < 0.01);
     assert.equal(toAudio.paused, false);
-    // The incoming unmute is scheduled just before the buffer ends.
-    const incomingUnmute = analyzer.calls.ramps.find((ramp) => ramp.element === toAudio && ramp.value === 0.8);
-    assert.ok(Math.abs(incomingUnmute.at - (buffer.handle.endTime - 0.05)) < 0.01);
 
-    // Run: drift check, promote at the swap, final drift check, completion.
+    const incomingFade = analyzer.calls.fades.find((fade) => fade.element === toAudio);
+    const bufferOut = buffer.handle.fades[1];
+    assert.deepEqual([incomingFade.from, incomingFade.to], [0, 0.8]);
+    assert.deepEqual([bufferOut.from, bufferOut.to], [0.8, 0]);
+    assert.ok(Math.abs(incomingFade.at - bufferOut.at) < 1e-9, 'fades must start together');
+    assert.ok(
+      Math.abs(incomingFade.at + incomingFade.seconds - buffer.handle.endTime) < 1e-9,
+      'the exchange must complete exactly as the buffer ends'
+    );
+
+    // No drift-correcting seek may land near the handoff; the element needs
+    // settled playback before it becomes audible.
+    const lastCorrection = plan.overlapSeconds * 0.375;
+    assert.ok(lastCorrection < plan.overlapSeconds - 1);
+
     analyzer.advance(0.6 + 8 * 0.75);
     while (events.length === 0 && await clock.runNext()) { /* advance */ }
     assert.deepEqual(events, ['promote']);
@@ -295,4 +322,37 @@ test('start refuses when called too late for a clean downbeat', async () => {
   assert.equal(didStart, false);
   assert.equal(engine.isActive(), false);
   assert.equal(analyzer.calls.buffers.length, 0);
+});
+
+test('start refuses when the elements are outside the audio graph', async () => {
+  const clock = fakeClock();
+  const originalWindow = globalThis.window;
+  globalThis.window = clock.window;
+  try {
+    // fadeVolume returning false means the scheduled handoff would never
+    // happen, leaving the outgoing element audible under the buffer.
+    const analyzer = fakeAnalyzer({ connected: false });
+    const engine = createWsolaCrossfade({ analyzer, bridge: {} });
+    const plan = readyPlan({ transitionStart: 200, overlapSeconds: 8 });
+    const fromAudio = fakeElement(199.4);
+    const toAudio = fakeElement(0);
+    const errors = [];
+
+    const didStart = await engine.start({
+      fromAudio,
+      toAudio,
+      plan,
+      render: renderFor(plan),
+      volume: 1,
+      onError: (error) => errors.push(error.message)
+    });
+
+    assert.equal(didStart, false);
+    assert.equal(engine.isActive(), false);
+    assert.equal(errors.length, 1);
+    assert.match(errors[0], /audio graph/);
+    assert.ok(analyzer.calls.buffers[0].handle.stopped, 'the scheduled buffer must be torn down');
+  } finally {
+    globalThis.window = originalWindow;
+  }
 });

--- a/test/wsolaCrossfade.test.js
+++ b/test/wsolaCrossfade.test.js
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { createWsolaCrossfade } from '../src/audio/crossfade/wsolaCrossfade.js';
+import {
+  createWsolaCrossfade,
+  wsolaProcessingCompatible
+} from '../src/audio/crossfade/wsolaCrossfade.js';
 
 function fakeClock() {
   const timers = new Map();
@@ -132,6 +135,28 @@ function renderFor(plan, sampleRate = 44100) {
     stretchRatio: 1.05
   };
 }
+
+test('only uses raw rendered PCM when per-source processing is flat', () => {
+  assert.equal(wsolaProcessingCompatible(), true);
+  assert.equal(wsolaProcessingCompatible({ normalizationEnabled: true }), false);
+  assert.equal(wsolaProcessingCompatible({
+    audioEngineConfig: { enabled: true, eqEnabled: true }
+  }), false);
+  assert.equal(wsolaProcessingCompatible({
+    audioEngineConfig: { enabled: true, preampDb: 2 }
+  }), true);
+  assert.equal(wsolaProcessingCompatible({
+    audioEngineConfig: { enabled: true, balance: -0.2 }
+  }), false);
+  assert.equal(wsolaProcessingCompatible({
+    audioEngineConfig: { enabled: true },
+    outgoingGainDb: -3
+  }), false);
+  assert.equal(wsolaProcessingCompatible({
+    audioEngineConfig: { enabled: false, eqEnabled: true, preampDb: 2 },
+    outgoingGainDb: -3
+  }), true);
+});
 
 test('prepare slices both tracks and forwards the plan to the native bridge', async () => {
   const analyzer = fakeAnalyzer();

--- a/test/wsolaPlanner.test.js
+++ b/test/wsolaPlanner.test.js
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  alignTempoOctave,
+  incomingMixInPoint,
+  planWsolaTransition
+} from '../src/audio/crossfade/wsolaPlanner.js';
+
+function downbeats(bpm, count, offset = 0) {
+  const bar = (60 / bpm) * 4;
+  return Array.from({ length: count }, (_, index) => offset + index * bar);
+}
+
+function analysisFor({ bpm = 126, duration = 240, mixOutTime = 0, contentEndTime = 0, mixInTime = 0 } = {}) {
+  return {
+    bpm,
+    beatInterval: 60 / bpm,
+    duration,
+    mixOutTime,
+    contentEndTime: contentEndTime || duration,
+    mixInTime,
+    downbeats: downbeats(bpm, Math.floor(duration / ((60 / bpm) * 4))),
+    mixInCandidates: []
+  };
+}
+
+test('plans a sixteen-beat overlap ending at the outgoing mix-out', () => {
+  const plan = planWsolaTransition({
+    analysis: analysisFor({ bpm: 126, duration: 240, mixOutTime: 220 }),
+    nextAnalysis: analysisFor({ bpm: 126, duration: 200, mixInTime: 20 }),
+    duration: 240,
+    nextDuration: 200
+  });
+
+  assert.equal(plan.ok, true, plan.reason);
+  assert.equal(plan.beats, 16);
+  const outgoingOverlap = 16 * (60 / 126);
+  // Start lands on a downbeat at or before (mix-out - overlap), so the
+  // overlap never runs past the point where the outgoing content ends.
+  assert.ok(plan.transitionStart <= 220 - outgoingOverlap + 0.001);
+  const bar = (60 / 126) * 4;
+  assert.ok(Math.abs(plan.transitionStart % bar) < 0.01 ||
+    Math.abs((plan.transitionStart % bar) - bar) < 0.01);
+  assert.ok(Math.abs(plan.transitionEnd - plan.transitionStart - outgoingOverlap) < 1e-9);
+  assert.ok(Math.abs(plan.overlapSeconds - outgoingOverlap) < 1e-9);
+  assert.equal(plan.stretchRatio, 1);
+});
+
+test('the incoming track enters at its mix-in point, snapped to a downbeat', () => {
+  const nextAnalysis = analysisFor({ bpm: 126, duration: 200, mixInTime: 20.5 });
+  const plan = planWsolaTransition({
+    analysis: analysisFor({ bpm: 126, duration: 240 }),
+    nextAnalysis,
+    duration: 240,
+    nextDuration: 200
+  });
+
+  assert.equal(plan.ok, true, plan.reason);
+  const bar = (60 / 126) * 4;
+  assert.ok(Math.abs(plan.incomingCueTime % bar) < 0.01);
+  assert.ok(Math.abs(plan.incomingCueTime - 20.5) <= bar / 2 + 0.01);
+  assert.ok(Math.abs(plan.incomingResumeTime - plan.incomingCueTime - plan.overlapSeconds) < 1e-9);
+});
+
+test('prefers an analyzed drop over the plain mix-in time', () => {
+  const analysis = analysisFor({ bpm: 126, duration: 200, mixInTime: 12 });
+  analysis.mixInCandidates = [
+    { time: 45, score: 0.4, type: 'phrase' },
+    { time: 30.476, score: 0.2, type: 'main_drop' }
+  ];
+  const point = incomingMixInPoint(analysis);
+  assert.ok(Math.abs(point - 30.476) < 1, `expected drop-anchored mix-in, got ${point}`);
+});
+
+test('octave-doubles a half-time incoming tempo onto the shared grid', () => {
+  assert.equal(alignTempoOctave(126, 63), 126);
+  assert.equal(alignTempoOctave(126, 252), 126);
+  assert.equal(alignTempoOctave(100, 98), 98);
+
+  const plan = planWsolaTransition({
+    analysis: analysisFor({ bpm: 126, duration: 240 }),
+    nextAnalysis: analysisFor({ bpm: 63, duration: 200, mixInTime: 20 }),
+    duration: 240,
+    nextDuration: 200
+  });
+  assert.equal(plan.ok, true, plan.reason);
+  assert.equal(plan.incomingBpm, 126);
+  assert.equal(plan.stretchRatio, 1);
+});
+
+test('quantizes the bass swap onto a bar of the shared grid', () => {
+  const plan = planWsolaTransition({
+    analysis: analysisFor({ bpm: 126, duration: 240 }),
+    nextAnalysis: analysisFor({ bpm: 126, duration: 200, mixInTime: 20 }),
+    duration: 240,
+    nextDuration: 200
+  });
+  assert.equal(plan.ok, true, plan.reason);
+  // 0.7 of 16 beats is beat 11.2; the nearest bar boundary is beat 12.
+  assert.equal(plan.bassSwapFraction, 0.75);
+});
+
+test('slice anchors map media times into the sliced buffers', () => {
+  const plan = planWsolaTransition({
+    analysis: analysisFor({ bpm: 126, duration: 240, mixOutTime: 220 }),
+    nextAnalysis: analysisFor({ bpm: 126, duration: 200, mixInTime: 20 }),
+    duration: 240,
+    nextDuration: 200
+  });
+  assert.equal(plan.ok, true, plan.reason);
+  assert.ok(Math.abs(plan.outgoingSlice.start + plan.outgoingSlice.anchor - plan.transitionStart) < 1e-9);
+  assert.ok(Math.abs(plan.incomingSlice.start + plan.incomingSlice.anchor - plan.incomingCueTime) < 1e-9);
+  assert.ok(plan.outgoingSlice.end >= plan.transitionEnd);
+  assert.ok(plan.incomingSlice.end >= plan.incomingResumeTime);
+  assert.ok(plan.incomingSlice.end <= 200);
+});
+
+test('refuses pairings that cannot be rendered transparently', () => {
+  const base = analysisFor({ bpm: 126, duration: 240 });
+  const incoming = analysisFor({ bpm: 126, duration: 200, mixInTime: 20 });
+
+  assert.equal(planWsolaTransition({
+    analysis: { ...base, bpm: 0 },
+    nextAnalysis: incoming,
+    duration: 240,
+    nextDuration: 200
+  }).reason, 'outgoing-tempo');
+
+  assert.equal(planWsolaTransition({
+    analysis: base,
+    nextAnalysis: analysisFor({ bpm: 100, duration: 200, mixInTime: 20 }),
+    duration: 240,
+    nextDuration: 200
+  }).reason, 'tempo-distance');
+
+  assert.equal(planWsolaTransition({
+    analysis: base,
+    nextAnalysis: analysisFor({ bpm: 126, duration: 30, mixInTime: 20 }),
+    duration: 240,
+    nextDuration: 30
+  }).reason, 'incoming-too-short');
+
+  assert.equal(planWsolaTransition({
+    analysis: analysisFor({ bpm: 126, duration: 12 }),
+    nextAnalysis: incoming,
+    duration: 12,
+    nextDuration: 200
+  }).reason, 'outgoing-too-short');
+
+  assert.equal(planWsolaTransition({
+    analysis: base,
+    nextAnalysis: { ...incoming, mixInTime: 0, mixInCandidates: [] },
+    duration: 240,
+    nextDuration: 200
+  }).reason, 'incoming-mix-in');
+});

--- a/test/wsolaPlanner.test.js
+++ b/test/wsolaPlanner.test.js
@@ -93,6 +93,18 @@ test('caps the pre-roll when the incoming intro is very long', () => {
   assert.ok(Math.abs(plan.incomingDropTime - (plan.incomingCueTime + plan.overlapSeconds * plan.handoffFraction)) < 1e-9);
 });
 
+test('refuses slow-tempo plans whose fixed tail cannot fit the overlap ceiling', () => {
+  const plan = planWsolaTransition({
+    analysis: analysisFor({ bpm: 40, duration: 300, mixOutTime: 280 }),
+    nextAnalysis: analysisFor({ bpm: 40, duration: 300, mixInTime: 60 }),
+    duration: 300,
+    nextDuration: 300
+  });
+
+  assert.equal(plan.ok, false);
+  assert.equal(plan.reason, 'overlap-too-long');
+});
+
 test('shortens the pre-roll rather than opening on lead-in silence', () => {
   const nextAnalysis = analysisFor({ bpm: 126, duration: 200, mixInTime: 20 });
   nextAnalysis.audibleStartTime = 14;

--- a/test/wsolaPlanner.test.js
+++ b/test/wsolaPlanner.test.js
@@ -25,7 +25,7 @@ function analysisFor({ bpm = 126, duration = 240, mixOutTime = 0, contentEndTime
   };
 }
 
-test('plans a sixteen-beat overlap ending at the outgoing mix-out', () => {
+test('plans a pre-roll plus tail overlap ending at the outgoing mix-out', () => {
   const plan = planWsolaTransition({
     analysis: analysisFor({ bpm: 126, duration: 240, mixOutTime: 220 }),
     nextAnalysis: analysisFor({ bpm: 126, duration: 200, mixInTime: 20 }),
@@ -34,8 +34,13 @@ test('plans a sixteen-beat overlap ending at the outgoing mix-out', () => {
   });
 
   assert.equal(plan.ok, true, plan.reason);
-  assert.equal(plan.beats, 16);
-  const outgoingOverlap = 16 * (60 / 126);
+  // A 20s intro at 126 BPM is 42 bar-aligned beats of available pre-roll, held
+  // to the four-bar cap so the outgoing track is not bedded under for a
+  // fifteen-second run-up to its own fade.
+  assert.equal(plan.prerollBeats, 16);
+  assert.equal(plan.tailBeats, 16);
+  assert.equal(plan.beats, plan.prerollBeats + plan.tailBeats);
+  const outgoingOverlap = plan.beats * (60 / 126);
   assert.ok(plan.transitionStart <= 220 - outgoingOverlap + 0.001);
   const bar = (60 / 126) * 4;
   assert.ok(Math.abs(plan.transitionStart % bar) < 0.01 ||
@@ -45,7 +50,7 @@ test('plans a sixteen-beat overlap ending at the outgoing mix-out', () => {
   assert.equal(plan.stretchRatio, 1);
 });
 
-test('the incoming track enters at its mix-in point, snapped to a downbeat', () => {
+test('the incoming track pre-rolls its intro and hands over on its drop', () => {
   const nextAnalysis = analysisFor({ bpm: 126, duration: 200, mixInTime: 20.5 });
   const plan = planWsolaTransition({
     analysis: analysisFor({ bpm: 126, duration: 240 }),
@@ -56,9 +61,52 @@ test('the incoming track enters at its mix-in point, snapped to a downbeat', () 
 
   assert.equal(plan.ok, true, plan.reason);
   const bar = (60 / 126) * 4;
-  assert.ok(Math.abs(plan.incomingCueTime % bar) < 0.01);
-  assert.ok(Math.abs(plan.incomingCueTime - 20.5) <= bar / 2 + 0.01);
+  // The drop is what the analyzer found, snapped to a downbeat.
+  assert.ok(Math.abs(plan.incomingDropTime - 20.5) <= bar / 2 + 0.01);
+  // The incoming track starts well before it, so its intro plays underneath.
+  assert.ok(plan.incomingCueTime < plan.incomingDropTime - 1,
+    `expected a pre-roll, cue ${plan.incomingCueTime} drop ${plan.incomingDropTime}`);
+  assert.ok(plan.incomingCueTime >= 0);
+  // The handoff lands on the drop rather than the middle of the overlap.
+  const handoffTime = plan.overlapSeconds * plan.handoffFraction;
+  assert.ok(Math.abs(handoffTime - (plan.incomingDropTime - plan.incomingCueTime)) < 1e-9);
+  assert.ok(Math.abs(plan.handoffFraction - plan.prerollBeats / plan.beats) < 1e-9);
+  // The pre-roll spends only a quarter of the fade, so the outgoing track is
+  // still essentially at level when the drop arrives and does its whole
+  // audible fade over the tail.
+  assert.ok(plan.bedPosition <= 0.3, `bed ${plan.bedPosition}`);
   assert.ok(Math.abs(plan.incomingResumeTime - plan.incomingCueTime - plan.overlapSeconds) < 1e-9);
+});
+
+test('caps the pre-roll when the incoming intro is very long', () => {
+  const nextAnalysis = analysisFor({ bpm: 126, duration: 200, mixInTime: 90 });
+  const plan = planWsolaTransition({
+    analysis: analysisFor({ bpm: 126, duration: 240 }),
+    nextAnalysis,
+    duration: 240,
+    nextDuration: 200
+  });
+
+  assert.equal(plan.ok, true, plan.reason);
+  assert.ok(plan.overlapSeconds <= 20.001, `overlap ${plan.overlapSeconds}`);
+  // The drop stays put; the pre-roll shortens to fit the cap.
+  assert.ok(Math.abs(plan.incomingDropTime - (plan.incomingCueTime + plan.overlapSeconds * plan.handoffFraction)) < 1e-9);
+});
+
+test('shortens the pre-roll rather than opening on lead-in silence', () => {
+  const nextAnalysis = analysisFor({ bpm: 126, duration: 200, mixInTime: 20 });
+  nextAnalysis.audibleStartTime = 14;
+  const plan = planWsolaTransition({
+    analysis: analysisFor({ bpm: 126, duration: 240 }),
+    nextAnalysis,
+    duration: 240,
+    nextDuration: 200
+  });
+
+  assert.equal(plan.ok, true, plan.reason);
+  assert.ok(plan.incomingCueTime >= 14 - 1e-9,
+    `cue ${plan.incomingCueTime} must not precede the audible start`);
+  assert.ok(Math.abs(plan.incomingDropTime - (plan.incomingCueTime + plan.overlapSeconds * plan.handoffFraction)) < 1e-9);
 });
 
 test('prefers an analyzed drop over the plain mix-in time', () => {
@@ -87,7 +135,7 @@ test('octave-doubles a half-time incoming tempo onto the shared grid', () => {
   assert.equal(plan.stretchRatio, 1);
 });
 
-test('quantizes the bass swap onto a bar of the shared grid', () => {
+test('hands the low end over a bar after the drop', () => {
   const plan = planWsolaTransition({
     analysis: analysisFor({ bpm: 126, duration: 240 }),
     nextAnalysis: analysisFor({ bpm: 126, duration: 200, mixInTime: 20 }),
@@ -95,7 +143,10 @@ test('quantizes the bass swap onto a bar of the shared grid', () => {
     nextDuration: 200
   });
   assert.equal(plan.ok, true, plan.reason);
-  assert.equal(plan.bassSwapFraction, 0.75);
+  const swapBeat = plan.bassSwapFraction * plan.beats;
+  assert.equal(swapBeat, plan.prerollBeats + 4);
+  assert.equal(swapBeat % 4, 0);
+  assert.ok(plan.bassSwapFraction > plan.handoffFraction);
 });
 
 test('slice anchors map media times into the sliced buffers', () => {

--- a/test/wsolaPlanner.test.js
+++ b/test/wsolaPlanner.test.js
@@ -36,8 +36,6 @@ test('plans a sixteen-beat overlap ending at the outgoing mix-out', () => {
   assert.equal(plan.ok, true, plan.reason);
   assert.equal(plan.beats, 16);
   const outgoingOverlap = 16 * (60 / 126);
-  // Start lands on a downbeat at or before (mix-out - overlap), so the
-  // overlap never runs past the point where the outgoing content ends.
   assert.ok(plan.transitionStart <= 220 - outgoingOverlap + 0.001);
   const bar = (60 / 126) * 4;
   assert.ok(Math.abs(plan.transitionStart % bar) < 0.01 ||
@@ -97,7 +95,6 @@ test('quantizes the bass swap onto a bar of the shared grid', () => {
     nextDuration: 200
   });
   assert.equal(plan.ok, true, plan.reason);
-  // 0.7 of 16 beats is beat 11.2; the nearest bar boundary is beat 12.
   assert.equal(plan.bassSwapFraction, 0.75);
 });
 

--- a/test/wsolaTimeStretch.test.js
+++ b/test/wsolaTimeStretch.test.js
@@ -118,6 +118,27 @@ test('time stretch rejects malformed input', async () => {
   assert.throws(() => native.timeStretch([[1, 2, 3]], SAMPLE_RATE, 1), /Float32Array/);
 });
 
+test('glides onto the target ratio instead of stepping onto it', async () => {
+  const input = sine({ duration: 4 });
+  const [stepped] = await native.timeStretch([input], SAMPLE_RATE, 1.06);
+  const [glided] = await native.timeStretch([input], SAMPLE_RATE, 1.06, {
+    startRatio: 1,
+    glide: 0.5
+  });
+
+  // Half the input is spent easing from 1.0 up to 1.06, so the glided render
+  // is shorter than one that holds 1.06 throughout, but still longer than the
+  // untouched input.
+  assert.ok(
+    glided.length < stepped.length,
+    `glide did not shorten the render: ${glided.length} vs ${stepped.length}`
+  );
+  assert.ok(
+    glided.length > input.length,
+    `glide did not stretch at all: ${glided.length} vs ${input.length}`
+  );
+});
+
 test('binding publishes the transparent ratio limit', () => {
   assert.ok(native.maxTransparentRatioDeviation > 0.01);
   assert.ok(native.maxTransparentRatioDeviation <= 0.2);

--- a/test/wsolaTimeStretch.test.js
+++ b/test/wsolaTimeStretch.test.js
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import test from 'node:test';
+
+const require = createRequire(import.meta.url);
+const native = require('../native/build/Release/orchard_audio_analysis.node');
+
+const SAMPLE_RATE = 44100;
+
+function sine({ frequency = 440, duration = 2, amplitude = 0.5, phase = 0 } = {}) {
+  const samples = new Float32Array(Math.floor(duration * SAMPLE_RATE));
+  for (let index = 0; index < samples.length; index += 1) {
+    samples[index] = amplitude * Math.sin(2 * Math.PI * frequency * (index / SAMPLE_RATE) + phase);
+  }
+  return samples;
+}
+
+// Dominant frequency by parabolic-interpolated peak of a naive DFT restricted
+// to a musical band, which is enough to catch a pitch shift of a few percent.
+// The band is deliberately wide enough to contain where a resampling
+// implementation would land 440 Hz (415 Hz at 0.94, 466 Hz at 1.06).
+function dominantFrequency(samples, low = 380, high = 500) {
+  const length = Math.min(samples.length, SAMPLE_RATE * 0.5);
+  let best = { frequency: 0, magnitude: -1 };
+  for (let frequency = low; frequency <= high; frequency += 1) {
+    let real = 0;
+    let imaginary = 0;
+    for (let index = 0; index < length; index += 1) {
+      const angle = 2 * Math.PI * frequency * (index / SAMPLE_RATE);
+      real += samples[index] * Math.cos(angle);
+      imaginary -= samples[index] * Math.sin(angle);
+    }
+    const magnitude = Math.hypot(real, imaginary);
+    if (magnitude > best.magnitude) best = { frequency, magnitude };
+  }
+  return best.frequency;
+}
+
+function rms(samples) {
+  let total = 0;
+  for (let index = 0; index < samples.length; index += 1) total += samples[index] ** 2;
+  return Math.sqrt(total / Math.max(1, samples.length));
+}
+
+test('time stretch scales duration by the requested ratio', async () => {
+  const input = sine({ duration: 2 });
+  for (const ratio of [0.94, 1, 1.06]) {
+    const [output] = await native.timeStretch([input], SAMPLE_RATE, ratio);
+    const expected = input.length * ratio;
+    // One synthesis frame of slack: the final frame only lands if a whole
+    // window still fits inside the input.
+    assert.ok(
+      Math.abs(output.length - expected) < SAMPLE_RATE * 0.06,
+      `ratio ${ratio} produced ${output.length}, expected near ${expected}`
+    );
+  }
+});
+
+test('time stretch preserves pitch', async () => {
+  const input = sine({ frequency: 440, duration: 2 });
+  const [stretched] = await native.timeStretch([input], SAMPLE_RATE, 1.06);
+  const [compressed] = await native.timeStretch([input], SAMPLE_RATE, 0.94);
+
+  // Resampling instead of time-stretching would move 440 Hz to 415 / 468 Hz,
+  // far outside this tolerance.
+  assert.ok(
+    Math.abs(dominantFrequency(stretched) - 440) < 6,
+    `stretched pitch drifted to ${dominantFrequency(stretched)}`
+  );
+  assert.ok(
+    Math.abs(dominantFrequency(compressed) - 440) < 6,
+    `compressed pitch drifted to ${dominantFrequency(compressed)}`
+  );
+});
+
+test('time stretch holds level steady rather than amplitude-modulating', async () => {
+  const input = sine({ duration: 2 });
+  const [output] = await native.timeStretch([input], SAMPLE_RATE, 1.05);
+  const trimmed = output.subarray(SAMPLE_RATE * 0.2, output.length - SAMPLE_RATE * 0.2);
+
+  // Overlap-add without correct window normalization shows up as a periodic
+  // level ripple, so compare the quietest window against the loudest.
+  const windows = [];
+  const size = Math.floor(SAMPLE_RATE * 0.05);
+  for (let start = 0; start + size < trimmed.length; start += size) {
+    windows.push(rms(trimmed.subarray(start, start + size)));
+  }
+  const quietest = Math.min(...windows);
+  const loudest = Math.max(...windows);
+  assert.ok(
+    quietest / loudest > 0.8,
+    `level ripple across the stretch: ${quietest.toFixed(4)} vs ${loudest.toFixed(4)}`
+  );
+});
+
+test('time stretch keeps stereo channels aligned', async () => {
+  // Opposite phase on each channel: a per-channel similarity search would pick
+  // different offsets and partially cancel when summed to mono.
+  const left = sine({ duration: 2, phase: 0 });
+  const right = sine({ duration: 2, phase: Math.PI });
+  const [outLeft, outRight] = await native.timeStretch([left, right], SAMPLE_RATE, 1.05);
+
+  assert.equal(outLeft.length, outRight.length);
+  const length = Math.min(outLeft.length, outRight.length);
+  let worst = 0;
+  for (let index = SAMPLE_RATE; index < length - SAMPLE_RATE; index += 1) {
+    worst = Math.max(worst, Math.abs(outLeft[index] + outRight[index]));
+  }
+  assert.ok(worst < 0.05, `channels drifted apart, residual sum ${worst.toFixed(4)}`);
+});
+
+test('time stretch rejects malformed input', async () => {
+  const input = sine({ duration: 0.5 });
+  assert.throws(() => native.timeStretch([], SAMPLE_RATE, 1), /valid/);
+  assert.throws(() => native.timeStretch([input], SAMPLE_RATE, 0), /valid/);
+  assert.throws(() => native.timeStretch([input], 10, 1), /valid/);
+  assert.throws(() => native.timeStretch([input, sine({ duration: 0.4 })], SAMPLE_RATE, 1), /same length/);
+  assert.throws(() => native.timeStretch([[1, 2, 3]], SAMPLE_RATE, 1), /Float32Array/);
+});
+
+test('binding publishes the transparent ratio limit', () => {
+  assert.ok(native.maxTransparentRatioDeviation > 0.01);
+  assert.ok(native.maxTransparentRatioDeviation <= 0.2);
+});

--- a/test/wsolaTimeStretch.test.js
+++ b/test/wsolaTimeStretch.test.js
@@ -109,6 +109,38 @@ test('time stretch keeps stereo channels aligned', async () => {
   assert.ok(worst < 0.05, `channels drifted apart, residual sum ${worst.toFixed(4)}`);
 });
 
+test('phase-cancelling stereo does not turn correlation noise into pitch flutter', async () => {
+  const left = sine({ duration: 4 });
+  const right = new Float32Array(left.length);
+  let randomState = 123456789;
+  for (let index = 0; index < right.length; index += 1) {
+    randomState = (Math.imul(1664525, randomState) + 1013904223) >>> 0;
+    const noise = (randomState / 0x100000000 * 2 - 1) * 0.00001;
+    right[index] = -left[index] + noise;
+  }
+
+  const [output] = await native.timeStretch([left, right], SAMPLE_RATE, 1.05);
+  const window = Math.floor(SAMPLE_RATE * 0.2);
+  const frequencies = [];
+  for (let start = Math.floor(SAMPLE_RATE * 0.5);
+    start + window < output.length - SAMPLE_RATE * 0.5;
+    start += window) {
+    let positiveCrossings = 0;
+    for (let index = start + 1; index < start + window; index += 1) {
+      if (output[index - 1] <= 0 && output[index] > 0) positiveCrossings += 1;
+    }
+    frequencies.push(positiveCrossings / (window / SAMPLE_RATE));
+  }
+  const lowest = Math.min(...frequencies);
+  const highest = Math.max(...frequencies);
+  const average = frequencies.reduce((total, value) => total + value, 0) / frequencies.length;
+  assert.ok(Math.abs(average - 440) < 6, `phase-cancelled guide drifted to ${average} Hz`);
+  assert.ok(
+    highest - lowest < 2,
+    `phase-cancelled guide fluttered between ${lowest} and ${highest} Hz`
+  );
+});
+
 test('time stretch rejects malformed input', async () => {
   const input = sine({ duration: 0.5 });
   assert.throws(() => native.timeStretch([], SAMPLE_RATE, 1), /valid/);


### PR DESCRIPTION
## Summary

- add a native C++ WSOLA time-stretch engine for beat-matched playback transitions
- render deterministic stereo transition overlaps with tempo matching, low-end handoff, and equal-power fades
- expose native transition rendering through the Electron IPC and audio-analysis bridge
- add a planner that selects compatible tracks, aligns tempo grids, and calculates pre-roll, handoff, and resume points
- route eligible Smart Crossfade transitions through the WSOLA engine while retaining the legacy fallback
- prevent competing crossfade engines, queue edits, and cancellation races from corrupting active transitions
- preserve compatible audio processing and reject unsupported DSP combinations
- animate fullscreen artwork changes during track transitions
- add coverage for WSOLA stretching, planning, rendering, lifecycle behavior, and playback integration

## Testing

- WSOLA time-stretch and overlap rendering tests
- transition planning and fallback tests
- playback promotion, cancellation, and queue-mutation tests
- audio-analysis IPC tests
- lifecycle and fullscreen transition coverage