### PR TITLE
Add offline downloads (Android): network monitoring, DownloadManager, offline library synthesis

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
   xmlns:tools="http://schemas.android.com/tools">
   
   <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
   <uses-permission android:name="android.permission.CAMERA" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/OrchardGraph.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/OrchardGraph.kt
@@ -32,6 +32,7 @@ import dev.sfg.orchard.mobile.library.LibraryCache
 import dev.sfg.orchard.mobile.library.LibraryRepository
 import dev.sfg.orchard.mobile.lyrics.LyricsRepository
 import dev.sfg.orchard.mobile.settings.SettingsRepository
+import dev.sfg.orchard.mobile.download.DownloadManager
 import dev.sfg.orchard.mobile.songlinks.SongLinksRepository
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -58,6 +59,8 @@ class OrchardGraph(context: Context) {
     )
     private val innerTube: InnerTubeClient = InnerTubeClient(http, auth)
     val settings = SettingsRepository(context, applicationScope)
+    val networkMonitor = dev.sfg.orchard.mobile.network.NetworkMonitor(context)
+    val downloads = DownloadManager(context, http, auth, applicationScope)
     val spotifyCanvas = dev.sfg.orchard.mobile.spotify.SpotifyCanvasRepository(context, http, settings)
     val artwork = ArtworkRepository(http, spotifyCanvas)
     val artistImages = ArtistImageRepository(http)

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardApp.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardApp.kt
@@ -153,6 +153,12 @@ private fun OrchardNavigation(
     val discordAuth by viewModel.discordAuth.collectAsStateWithLifecycle()
     val discordConnection by viewModel.discordConnection.collectAsStateWithLifecycle()
     val libraryFilter by viewModel.libraryFilter.collectAsStateWithLifecycle()
+    val isOnline by viewModel.isOnline.collectAsStateWithLifecycle()
+    val downloads by viewModel.downloads.collectAsStateWithLifecycle()
+    val downloadsList = androidx.compose.runtime.remember(downloads) { downloads.values.toList() }
+    val downloadedTrackIds by viewModel.downloadedTrackIds.collectAsStateWithLifecycle()
+    val downloadingTrackIds by viewModel.downloadingTrackIds.collectAsStateWithLifecycle()
+    val totalBytesUsed by viewModel.totalBytesUsed.collectAsStateWithLifecycle()
     val connectMessage by viewModel.connectMessage.collectAsStateWithLifecycle()
     val connectProtocolVersion by viewModel.connectProtocolVersion.collectAsStateWithLifecycle()
     val connectAudioEngine by viewModel.connectAudioEngine.collectAsStateWithLifecycle()
@@ -184,6 +190,9 @@ private fun OrchardNavigation(
                 state = home,
                 library = library,
                 auth = auth,
+                downloads = downloadsList,
+                downloadedTrackIds = downloadedTrackIds,
+                isOffline = !isOnline,
                 onRefresh = viewModel::refreshHome,
                 onSearch = { nav.openTopLevel(Routes.SEARCH) },
                 onLibrary = { filter ->
@@ -203,9 +212,13 @@ private fun OrchardNavigation(
                 onQueryChange = viewModel::updateQuery,
                 onSubmit = viewModel::runSearch,
                 onClearHistory = viewModel::clearSearchHistory,
+                downloadedTrackIds = downloadedTrackIds,
+                downloadingTrackIds = downloadingTrackIds,
                 onPlay = { viewModel.play(it, "Search") },
                 onPlayNext = if (canControlQueue) viewModel::playNext else null,
                 onAddToQueue = if (canControlQueue) viewModel::addToQueue else null,
+                onDownloadTrack = viewModel::downloadTrack,
+                onRemoveDownloadTrack = viewModel::removeDownload,
                 onOpenDetail = { id -> viewModel.openDetail(id); nav.navigate(Routes.detail(id)) },
                 onShare = viewModel::shareTrack,
             )
@@ -215,11 +228,25 @@ private fun OrchardNavigation(
                 library = library,
                 filter = libraryFilter,
                 onFilterChange = viewModel::selectLibraryFilter,
+                downloads = downloadsList,
+                downloadedTrackIds = downloadedTrackIds,
+                downloadingTrackIds = downloadingTrackIds,
+                totalBytesUsed = totalBytesUsed,
                 onPlay = { viewModel.play(it, libraryFilter.sourceTitle()) },
                 onPlayNext = if (canControlQueue) viewModel::playNext else null,
                 onAddToQueue = if (canControlQueue) viewModel::addToQueue else null,
                 onOpenDetail = { id -> viewModel.openDetail(id); nav.navigate(Routes.detail(id)) },
+                onDownloadTrack = viewModel::downloadTrack,
+                onRemoveDownloadTrack = viewModel::removeDownload,
                 onShare = viewModel::shareTrack,
+            )
+        }
+        composable(Routes.DOWNLOADS) {
+            dev.sfg.orchard.mobile.ui.screens.DownloadsScreen(
+                downloads = downloadsList,
+                totalBytesUsed = totalBytesUsed,
+                onPlay = { viewModel.play(it, "Downloads") },
+                onRemoveDownload = viewModel::removeDownload,
             )
         }
         composable(Routes.SETTINGS) {
@@ -306,6 +333,12 @@ private fun OrchardNavigation(
                 onSave = viewModel::saveDetail,
                 onOpenDetail = { next -> viewModel.openDetail(next); nav.navigate(Routes.detail(next)) },
                 isSaved = isSaved,
+                downloadedTrackIds = downloadedTrackIds,
+                downloadingTrackIds = downloadingTrackIds,
+                onDownloadTrack = viewModel::downloadTrack,
+                onDownloadTracks = viewModel::downloadTracks,
+                onRemoveDownloadTrack = viewModel::removeDownload,
+                onRemoveDownloadTracks = viewModel::removeDownloads,
                 animatedArtworkUrl = animatedArtworkUrl,
                 artistPortraitUrl = artistImages?.portraitUrl.orEmpty(),
                 onShareTrack = viewModel::shareTrack,
@@ -341,6 +374,9 @@ private fun OrchardNavigation(
                 onRemoveQueueIndex = viewModel::removeQueueIndex,
                 onMoveQueueItem = viewModel::moveQueueItem,
                 onClearUpcoming = viewModel::clearUpcoming,
+                downloadedTrackIds = downloadedTrackIds,
+                onDownloadTrack = viewModel::downloadTrack,
+                onRemoveDownloadTrack = viewModel::removeDownload,
                 onShare = { playback.currentTrack?.let(viewModel::shareTrack) },
                 // Leaves the player so the collection is not buried underneath it.
                 onOpenCollection = { id ->
@@ -384,4 +420,5 @@ private fun LibraryFilter.sourceTitle(): String = when (this) {
     LibraryFilter.ALBUMS -> "Your albums"
     LibraryFilter.SONGS -> "Liked songs"
     LibraryFilter.RECENT -> "Recently played"
+    LibraryFilter.DOWNLOADS -> "Downloads"
 }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardViewModel.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardViewModel.kt
@@ -114,12 +114,27 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
     val discordConnection: StateFlow<dev.sfg.orchard.mobile.discord.GatewayConnectionState> = graph.discordPresence.connectionState
 
     val activeBitrate: StateFlow<Int> = graph.activeBitrate.asStateFlow()
+    val isOnline: StateFlow<Boolean> = graph.networkMonitor.isOnline
+    val downloads: StateFlow<Map<String, dev.sfg.orchard.mobile.download.DownloadItem>> = graph.downloads.downloads
+    val downloadedTrackIds: StateFlow<Set<String>> = graph.downloads.downloadedTrackIds
+    val downloadingTrackIds: StateFlow<Set<String>> = graph.downloads.downloadingTrackIds
+    val totalBytesUsed: StateFlow<Long> = downloads.map { map ->
+        map.values.filter { it.status == dev.sfg.orchard.mobile.download.DownloadStatus.COMPLETED }
+            .sumOf { it.bytesDownloaded }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), graph.downloads.totalBytesUsed())
+
+    fun downloadTrack(track: Track) = graph.downloads.downloadTrack(track)
+    fun downloadTracks(tracks: List<Track>) = graph.downloads.downloadTracks(tracks)
+    fun removeDownload(videoId: String) = graph.downloads.removeDownload(videoId)
+    fun removeDownloads(tracks: List<Track>) = graph.downloads.removeDownloads(tracks.map { it.id })
+
     private val mutableWarning = MutableStateFlow("")
     val warning: StateFlow<String> = mutableWarning.asStateFlow()
     private var warningDismissJob: Job? = null
 
     init {
         refreshHome()
+        observeNetworkState()
         observeSearch()
         observeRemoteDevice()
         observeArtwork()
@@ -130,6 +145,16 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
         observeWarnings()
     }
 
+    private fun observeNetworkState() {
+        viewModelScope.launch {
+            graph.networkMonitor.isOnline.collect { online ->
+                if (online && mutableHome.value is LoadState.Error) {
+                    refreshHome()
+                }
+            }
+        }
+    }
+
     fun refreshHome() {
         viewModelScope.launch {
             mutableHome.value = LoadState.Loading
@@ -137,8 +162,8 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
                 .fold(
                     onSuccess = { if (it.isEmpty()) LoadState.Empty("No recommendations are available yet.") else LoadState.Content(it) },
                     onFailure = {
-                        if (library.value.recentlyPlayed.isNotEmpty()) {
-                            LoadState.Error("Orchard is offline. Your recent music is still available.", true)
+                        if (downloads.value.values.any { d -> d.status == dev.sfg.orchard.mobile.download.DownloadStatus.COMPLETED } || library.value.recentlyPlayed.isNotEmpty()) {
+                            LoadState.Error("Orchard is offline. Your downloaded music is available.", true)
                         } else LoadState.Error(it.message ?: "Home could not be loaded.")
                     },
                 )
@@ -161,11 +186,36 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
         val seed = findCatalogItem(id, home.value, search.value, library.value, detail.value)
         viewModelScope.launch {
             mutableDetail.value = LoadState.Loading
-            mutableDetail.value = runCatching { graph.catalog.browse(id) }
-                .fold(
-                    onSuccess = { LoadState.Content(it.withSeed(seed)) },
-                    onFailure = { LoadState.Error(it.message ?: "This collection could not be loaded.") },
+
+            // When offline or if network is down, immediately synthesize from downloaded tracks
+            if (!graph.networkMonitor.checkIsOnline()) {
+                val offlineDetail = dev.sfg.orchard.mobile.download.OfflineDetailSynthesizer.synthesize(
+                    id = id,
+                    seed = seed,
+                    downloadedItems = downloads.value.values.toList(),
+                    library = library.value,
                 )
+                if (offlineDetail != null) {
+                    mutableDetail.value = LoadState.Content(offlineDetail)
+                    return@launch
+                }
+            }
+
+            val result = runCatching { graph.catalog.browse(id) }
+                .map { it.withSeed(seed) }
+                .recoverCatching { error ->
+                    dev.sfg.orchard.mobile.download.OfflineDetailSynthesizer.synthesize(
+                        id = id,
+                        seed = seed,
+                        downloadedItems = downloads.value.values.toList(),
+                        library = library.value,
+                    ) ?: throw error
+                }
+
+            mutableDetail.value = result.fold(
+                onSuccess = { LoadState.Content(it) },
+                onFailure = { LoadState.Error(it.message ?: "This collection could not be loaded.") },
+            )
         }
     }
 

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/DownloadManager.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/DownloadManager.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.download
+
+import android.content.Context
+import android.util.Log
+import dev.sfg.orchard.mobile.auth.YouTubeSessionProvider
+import dev.sfg.orchard.mobile.model.Track
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import okhttp3.OkHttpClient
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Application-scoped download queue controller supporting concurrent background downloads,
+ * cancellation, deletion, and reactive state flows.
+ */
+class DownloadManager(
+    context: Context,
+    http: OkHttpClient,
+    sessionProvider: YouTubeSessionProvider? = null,
+    private val scope: CoroutineScope,
+) {
+    val store: DownloadStore = DownloadStore(context)
+    private val downloader: TrackDownloader = TrackDownloader(http, sessionProvider, store)
+
+    private val mutableDownloads = MutableStateFlow<Map<String, DownloadItem>>(emptyMap())
+    val downloads: StateFlow<Map<String, DownloadItem>> = mutableDownloads.asStateFlow()
+
+    private val mutableDownloadedIds = MutableStateFlow<Set<String>>(emptySet())
+    val downloadedTrackIds: StateFlow<Set<String>> = mutableDownloadedIds.asStateFlow()
+
+    private val mutableDownloadingIds = MutableStateFlow<Set<String>>(emptySet())
+    val downloadingTrackIds: StateFlow<Set<String>> = mutableDownloadingIds.asStateFlow()
+
+    private val downloadQueue = Channel<DownloadItem>(Channel.UNLIMITED)
+    private val activeJobs = ConcurrentHashMap<String, Job>()
+
+    init {
+        // Load initial state from disk
+        val initial = store.loadAll()
+        mutableDownloads.value = initial
+        updateDerivedStates(initial)
+
+        // Start worker coroutines for queued downloads
+        repeat(MAX_CONCURRENT_DOWNLOADS) {
+            scope.launch {
+                for (item in downloadQueue) {
+                    processDownload(item)
+                }
+            }
+        }
+    }
+
+    /** Enqueue a track for downloading. */
+    fun downloadTrack(track: Track) {
+        if (track.id.isBlank()) return
+        val current = mutableDownloads.value[track.id]
+        if (current?.status == DownloadStatus.COMPLETED) {
+            Log.d(TAG, "Track ${track.id} already downloaded")
+            return
+        }
+
+        val item = DownloadItem(
+            track = track,
+            status = DownloadStatus.QUEUED,
+            progress = 0f,
+        )
+        updateItemState(item)
+        downloadQueue.trySend(item)
+    }
+
+    /** Enqueue a list of tracks for downloading (e.g. playlist or album). */
+    fun downloadTracks(tracks: List<Track>) {
+        for (track in tracks) {
+            downloadTrack(track)
+        }
+    }
+
+    /** Cancel an active or queued download. */
+    fun cancelDownload(videoId: String) {
+        val job = activeJobs.remove(videoId)
+        job?.cancel()
+        val item = mutableDownloads.value[videoId]
+        if (item != null && item.status != DownloadStatus.COMPLETED) {
+            store.remove(videoId)
+            val updated = mutableDownloads.value.toMutableMap()
+            updated.remove(videoId)
+            mutableDownloads.value = updated
+            updateDerivedStates(updated)
+        }
+    }
+
+    /** Remove a downloaded track and delete its file from disk. */
+    fun removeDownload(videoId: String) {
+        cancelDownload(videoId)
+        store.remove(videoId)
+        val updated = mutableDownloads.value.toMutableMap()
+        updated.remove(videoId)
+        mutableDownloads.value = updated
+        updateDerivedStates(updated)
+    }
+
+    /** Remove a collection of downloaded tracks (e.g. removing an album or playlist). */
+    fun removeDownloads(videoIds: List<String>) {
+        val updated = mutableDownloads.value.toMutableMap()
+        for (videoId in videoIds) {
+            val job = activeJobs.remove(videoId)
+            job?.cancel()
+            store.remove(videoId)
+            updated.remove(videoId)
+        }
+        mutableDownloads.value = updated
+        updateDerivedStates(updated)
+    }
+
+    /** Check if a track is downloaded and verified on disk. */
+    fun isDownloaded(videoId: String): Boolean = downloadedTrackIds.value.contains(videoId)
+
+    /** Check if all tracks in a list are downloaded. */
+    fun areTracksDownloaded(tracks: List<Track>): Boolean {
+        if (tracks.isEmpty()) return false
+        val downloaded = downloadedTrackIds.value
+        return tracks.all { downloaded.contains(it.id) }
+    }
+
+    /** Total storage bytes consumed by completed downloads. */
+    fun totalBytesUsed(): Long = store.totalBytesUsed()
+
+    /** Returns the local file for a downloaded track, or null if not downloaded. */
+    fun getDownloadedFile(videoId: String): File? {
+        val item = mutableDownloads.value[videoId] ?: return null
+        if (item.status != DownloadStatus.COMPLETED || item.filePath.isBlank()) return null
+        val file = File(item.filePath)
+        return if (file.exists() && file.length() > 0) file else null
+    }
+
+    private suspend fun processDownload(queuedItem: DownloadItem) {
+        val videoId = queuedItem.track.id
+        // Check if cancelled before running
+        val current = mutableDownloads.value[videoId]
+        if (current == null || current.status == DownloadStatus.COMPLETED) return
+
+        val downloadingItem = queuedItem.copy(status = DownloadStatus.DOWNLOADING)
+        updateItemState(downloadingItem)
+
+        val job = scope.coroutineContext[Job]
+        if (job != null) {
+            activeJobs[videoId] = job
+        }
+
+        try {
+            val result = downloader.download(downloadingItem) { bytesDownloaded, totalBytes, progress ->
+                val progressItem = downloadingItem.copy(
+                    bytesDownloaded = bytesDownloaded,
+                    totalBytes = totalBytes,
+                    progress = progress,
+                )
+                updateItemState(progressItem)
+            }
+
+            updateItemState(result)
+            if (result.status == DownloadStatus.COMPLETED) {
+                store.save(result)
+            }
+        } finally {
+            activeJobs.remove(videoId)
+        }
+    }
+
+    private fun updateItemState(item: DownloadItem) {
+        val map = mutableDownloads.value.toMutableMap()
+        map[item.track.id] = item
+        mutableDownloads.value = map
+        updateDerivedStates(map)
+    }
+
+    private fun updateDerivedStates(map: Map<String, DownloadItem>) {
+        mutableDownloadedIds.value = map.values
+            .filter { it.status == DownloadStatus.COMPLETED && it.filePath.isNotBlank() }
+            .map { it.track.id }
+            .toSet()
+        mutableDownloadingIds.value = map.values
+            .filter { it.isDownloading }
+            .map { it.track.id }
+            .toSet()
+    }
+
+    companion object {
+        private const val TAG = "DownloadManager"
+        private const val MAX_CONCURRENT_DOWNLOADS = 3
+    }
+}

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/DownloadModels.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/DownloadModels.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.download
+
+import dev.sfg.orchard.mobile.model.Track
+import org.json.JSONObject
+
+/** Lifecycle status for an offline download request. */
+enum class DownloadStatus {
+    QUEUED,
+    DOWNLOADING,
+    COMPLETED,
+    FAILED,
+    PAUSED,
+}
+
+/** Active or completed download task state. */
+data class DownloadItem(
+    val track: Track,
+    val status: DownloadStatus = DownloadStatus.QUEUED,
+    val progress: Float = 0f,
+    val bytesDownloaded: Long = 0L,
+    val totalBytes: Long = 0L,
+    val filePath: String = "",
+    val mimeType: String = "audio/webm",
+    val downloadedAtMs: Long = 0L,
+    val errorMessage: String = "",
+) {
+    val isFinished: Boolean get() = status == DownloadStatus.COMPLETED
+    val isDownloading: Boolean get() = status == DownloadStatus.DOWNLOADING || status == DownloadStatus.QUEUED
+
+    fun toJson(): JSONObject = JSONObject().apply {
+        put("id", track.id)
+        put("title", track.title)
+        put("artist", track.artist)
+        put("artistId", track.artistId)
+        put("album", track.album)
+        put("albumId", track.albumId)
+        put("artworkUrl", track.artworkUrl)
+        put("durationMs", track.durationMs)
+        put("status", status.name)
+        put("bytesDownloaded", bytesDownloaded)
+        put("totalBytes", totalBytes)
+        put("filePath", filePath)
+        put("mimeType", mimeType)
+        put("downloadedAtMs", downloadedAtMs)
+        put("errorMessage", errorMessage)
+    }
+
+    companion object {
+        fun fromJson(json: JSONObject): DownloadItem {
+            val track = Track(
+                id = json.optString("id"),
+                title = json.optString("title"),
+                artist = json.optString("artist"),
+                artistId = json.optString("artistId"),
+                album = json.optString("album"),
+                albumId = json.optString("albumId"),
+                artworkUrl = json.optString("artworkUrl"),
+                durationMs = json.optLong("durationMs"),
+            )
+            val statusStr = json.optString("status", DownloadStatus.COMPLETED.name)
+            val status = runCatching { DownloadStatus.valueOf(statusStr) }.getOrDefault(DownloadStatus.COMPLETED)
+            return DownloadItem(
+                track = track,
+                status = status,
+                progress = 1.0f,
+                bytesDownloaded = json.optLong("bytesDownloaded"),
+                totalBytes = json.optLong("totalBytes"),
+                filePath = json.optString("filePath"),
+                mimeType = json.optString("mimeType", "audio/webm"),
+                downloadedAtMs = json.optLong("downloadedAtMs"),
+                errorMessage = json.optString("errorMessage"),
+            )
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/DownloadPlaybackHelper.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/DownloadPlaybackHelper.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.download
+
+import android.net.Uri
+import dev.sfg.orchard.mobile.playback.ResolvedStream
+
+/** Helper for resolving downloaded audio files into playback streams. */
+object DownloadPlaybackHelper {
+    /**
+     * Resolves a local stream for [videoId] if it exists in [downloadManager].
+     *
+     * @return [ResolvedStream] pointing to `file:///...` path, or `null` if not downloaded.
+     */
+    fun resolveOfflineStream(videoId: String, downloadManager: DownloadManager): ResolvedStream? {
+        val file = downloadManager.getDownloadedFile(videoId) ?: return null
+        val item = downloadManager.downloads.value[videoId]
+        val fileUri = Uri.fromFile(file).toString()
+        val mime = item?.mimeType?.ifBlank { "audio/webm" } ?: "audio/webm"
+        
+        return ResolvedStream(
+            url = fileUri,
+            mimeType = mime,
+            expiresAtMs = Long.MAX_VALUE,
+            bitrateKbps = 320,
+        )
+    }
+}

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/DownloadStore.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/DownloadStore.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.download
+
+import android.content.Context
+import android.util.Log
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+
+/**
+ * On-disk index and file store for offline downloaded tracks.
+ */
+class DownloadStore(
+    context: Context? = null,
+    baseDir: File? = null,
+) {
+    val downloadDir: File = baseDir ?: File(
+        context?.getExternalFilesDir(null) ?: context?.filesDir ?: File(System.getProperty("java.io.tmpdir"), "orchard-downloads"),
+        DOWNLOADS_FOLDER,
+    ).apply { if (!exists()) mkdirs() }
+
+    private val indexFile: File = File(downloadDir, INDEX_FILE_NAME)
+    private val lock = Any()
+
+    /** Returns all persisted completed/failed download entries. */
+    fun loadAll(): Map<String, DownloadItem> = synchronized(lock) {
+        if (!indexFile.exists()) return emptyMap()
+        return runCatching {
+            val text = indexFile.readText()
+            val array = JSONArray(text)
+            val result = mutableMapOf<String, DownloadItem>()
+            for (i in 0 until array.length()) {
+                val json = array.optJSONObject(i) ?: continue
+                val item = DownloadItem.fromJson(json)
+                if (item.track.id.isNotBlank()) {
+                    // Check if file still exists on disk for completed downloads
+                    if (item.status == DownloadStatus.COMPLETED && item.filePath.isNotBlank()) {
+                        val file = File(item.filePath)
+                        if (file.exists() && file.length() > 0) {
+                            result[item.track.id] = item
+                        }
+                    } else if (item.status == DownloadStatus.FAILED) {
+                        result[item.track.id] = item
+                    }
+                }
+            }
+            result
+        }.onFailure {
+            Log.w(TAG, "Failed to load downloads index", it)
+        }.getOrDefault(emptyMap())
+    }
+
+    /** Save or update a download record. */
+    fun save(item: DownloadItem) = synchronized(lock) {
+        val current = loadAll().toMutableMap()
+        current[item.track.id] = item
+        writeIndex(current.values.toList())
+    }
+
+    /** Save multiple download records. */
+    fun saveAll(items: List<DownloadItem>) = synchronized(lock) {
+        val current = loadAll().toMutableMap()
+        for (item in items) {
+            current[item.track.id] = item
+        }
+        writeIndex(current.values.toList())
+    }
+
+    /** Remove a download entry and delete its file from disk. */
+    fun remove(videoId: String): Boolean = synchronized(lock) {
+        val current = loadAll().toMutableMap()
+        val removed = current.remove(videoId)
+        if (removed != null) {
+            writeIndex(current.values.toList())
+            if (removed.filePath.isNotBlank()) {
+                val file = File(removed.filePath)
+                if (file.exists()) {
+                    file.delete()
+                }
+            }
+            return true
+        }
+        return false
+    }
+
+    /** Gets target file path for a track. */
+    fun getTargetFile(videoId: String, extension: String): File {
+        val safeName = videoId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
+        return File(downloadDir, "$safeName.$extension")
+    }
+
+    /** Gets temp download file path for a track. */
+    fun getTempFile(videoId: String): File {
+        val safeName = videoId.replace(Regex("[^a-zA-Z0-9_-]"), "_")
+        return File(downloadDir, "$safeName.tmp")
+    }
+
+    /** Calculate total bytes used by downloaded tracks. */
+    fun totalBytesUsed(): Long = synchronized(lock) {
+        loadAll().values
+            .filter { it.status == DownloadStatus.COMPLETED }
+            .sumOf { it.bytesDownloaded.coerceAtLeast(0L) }
+    }
+
+    private fun writeIndex(items: List<DownloadItem>) {
+        runCatching {
+            val array = JSONArray()
+            for (item in items) {
+                array.put(item.toJson())
+            }
+            val tempIndex = File(downloadDir, "$INDEX_FILE_NAME.tmp")
+            tempIndex.writeText(array.toString(2))
+            tempIndex.renameTo(indexFile)
+        }.onFailure {
+            Log.e(TAG, "Failed to write downloads index", it)
+        }
+    }
+
+    companion object {
+        private const val TAG = "DownloadStore"
+        private const val DOWNLOADS_FOLDER = "offline_downloads"
+        private const val INDEX_FILE_NAME = "downloads.json"
+    }
+}

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/OfflineDetailSynthesizer.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/OfflineDetailSynthesizer.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.download
+
+import dev.sfg.orchard.mobile.model.BrowseDetail
+import dev.sfg.orchard.mobile.model.CatalogItem
+import dev.sfg.orchard.mobile.model.CatalogKind
+import dev.sfg.orchard.mobile.model.LibrarySnapshot
+
+/**
+ * Builds offline [BrowseDetail] models from downloaded tracks and local library metadata when
+ * remote network endpoints (such as music.youtube.com) are unreachable.
+ */
+object OfflineDetailSynthesizer {
+
+    /**
+     * Synthesizes a [BrowseDetail] for the given [id] and optional [seed] using downloaded tracks.
+     *
+     * For artists, this includes ONLY the tracks that are downloaded.
+     */
+    fun synthesize(
+        id: String,
+        seed: CatalogItem?,
+        downloadedItems: List<DownloadItem>,
+        library: LibrarySnapshot,
+    ): BrowseDetail? {
+        val completedTracks =
+            downloadedItems
+                .filter { it.status == DownloadStatus.COMPLETED && it.filePath.isNotBlank() }
+                .map { it.track }
+
+        if (completedTracks.isEmpty()) return null
+
+        // 1. Is it a saved playlist?
+        val savedPlaylist = library.savedPlaylists.firstOrNull { it.id == id }
+        if (savedPlaylist != null) {
+            val playlistTrackIds = savedPlaylist.tracks.map { it.id }.toSet()
+            val matchedTracks =
+                if (playlistTrackIds.isNotEmpty()) {
+                    completedTracks.filter { it.id in playlistTrackIds }
+                } else {
+                    completedTracks
+                }
+            if (matchedTracks.isNotEmpty()) {
+                return BrowseDetail(
+                    id = savedPlaylist.id,
+                    title = savedPlaylist.title,
+                    subtitle =
+                        "${matchedTracks.size} downloaded ${if (matchedTracks.size == 1) "song" else "songs"}",
+                    artworkUrl =
+                        savedPlaylist.artworkUrl.ifBlank {
+                            matchedTracks.firstOrNull()?.artworkUrl.orEmpty()
+                        },
+                    kind = CatalogKind.PLAYLIST,
+                    tracks = matchedTracks,
+                    description = savedPlaylist.description,
+                )
+            }
+        }
+
+        // 2. Liked songs or generic offline downloads playlist
+        if (
+            id == "FEmusic_liked_videos" ||
+                id == "offline_downloads" ||
+                id == "downloads" ||
+                id == "local_downloads"
+        ) {
+            val title = if (id == "FEmusic_liked_videos") "Liked Songs" else "Downloaded Music"
+            return BrowseDetail(
+                id = id,
+                title = title,
+                subtitle =
+                    "${completedTracks.size} downloaded ${if (completedTracks.size == 1) "song" else "songs"}",
+                artworkUrl =
+                    completedTracks
+                        .firstOrNull { it.artworkUrl.isNotBlank() }
+                        ?.artworkUrl
+                        .orEmpty(),
+                kind = CatalogKind.PLAYLIST,
+                tracks = completedTracks,
+            )
+        }
+
+        // 3. Artist: Matches artist ID, artist name, or Performer seed
+        val candidateArtistName =
+            when (seed) {
+                is CatalogItem.Performer -> seed.artist.name
+                else -> library.savedArtists.firstOrNull { it.id == id }?.name
+            }
+
+        val artistTracks = completedTracks.filter { track ->
+            (track.artistId.isNotBlank() && track.artistId == id) ||
+                (candidateArtistName != null &&
+                    track.artist.equals(candidateArtistName, ignoreCase = true)) ||
+                (track.artist.equals(id, ignoreCase = true))
+        }
+
+        if (
+            artistTracks.isNotEmpty() ||
+                (seed is CatalogItem.Performer && completedTracks.isNotEmpty())
+        ) {
+            val tracksToShow =
+                if (artistTracks.isNotEmpty()) artistTracks
+                else {
+                    val name = seed?.title.orEmpty()
+                    completedTracks
+                        .filter { it.artist.contains(name, ignoreCase = true) }
+                        .ifEmpty { completedTracks }
+                }
+            val finalArtistName =
+                candidateArtistName ?: tracksToShow.firstOrNull()?.artist ?: seed?.title ?: "Artist"
+            val artistArt =
+                seed?.artworkUrl?.ifBlank { null }
+                    ?: library.savedArtists
+                        .firstOrNull { it.name.equals(finalArtistName, ignoreCase = true) }
+                        ?.artworkUrl
+                    ?: tracksToShow.firstOrNull { it.artworkUrl.isNotBlank() }?.artworkUrl.orEmpty()
+
+            return BrowseDetail(
+                id = id,
+                title = finalArtistName,
+                subtitle =
+                    "${tracksToShow.size} downloaded ${if (tracksToShow.size == 1) "song" else "songs"}",
+                artworkUrl = artistArt,
+                kind = CatalogKind.ARTIST,
+                tracks = tracksToShow, // ONLY the songs that are downloaded!
+                artist = finalArtistName,
+            )
+        }
+
+        // 4. Album: Matches album ID, album name, or Record seed
+        val savedAlbum = library.savedAlbums.firstOrNull { it.id == id }
+        val candidateAlbumTitle =
+            savedAlbum?.title ?: (seed as? CatalogItem.Record)?.album?.title ?: seed?.title
+
+        val albumTracks = completedTracks.filter { track ->
+            (track.albumId.isNotBlank() && track.albumId == id) ||
+                (candidateAlbumTitle != null &&
+                    track.album.equals(candidateAlbumTitle, ignoreCase = true))
+        }
+
+        if (albumTracks.isNotEmpty()) {
+            val finalAlbumTitle = candidateAlbumTitle ?: albumTracks.first().album
+            val artistName = savedAlbum?.artist ?: albumTracks.first().artist
+            val art =
+                savedAlbum?.artworkUrl?.ifBlank { null }
+                    ?: seed?.artworkUrl?.ifBlank { null }
+                    ?: albumTracks.firstOrNull { it.artworkUrl.isNotBlank() }?.artworkUrl.orEmpty()
+
+            return BrowseDetail(
+                id = id,
+                title = finalAlbumTitle,
+                subtitle = artistName,
+                artist = artistName,
+                artworkUrl = art,
+                kind = CatalogKind.ALBUM,
+                tracks = albumTracks, // ONLY the songs that are downloaded
+                year = savedAlbum?.year ?: "",
+            )
+        }
+
+        // 5. Seed fallback: If seed exists, build detail with matching tracks or all downloaded
+        // tracks
+        if (seed != null) {
+            val matchingSeedTracks =
+                completedTracks
+                    .filter { track ->
+                        track.artist.contains(seed.title, ignoreCase = true) ||
+                            track.album.contains(seed.title, ignoreCase = true) ||
+                            track.title.contains(seed.title, ignoreCase = true)
+                    }
+                    .ifEmpty { completedTracks }
+
+            val (kind, subtitle, artistName) =
+                when (seed) {
+                    is CatalogItem.Performer ->
+                        Triple(CatalogKind.ARTIST, seed.artist.subtitle, seed.artist.name)
+                    is CatalogItem.Record ->
+                        Triple(CatalogKind.ALBUM, seed.album.artist, seed.album.artist)
+                    is CatalogItem.Collection ->
+                        Triple(CatalogKind.PLAYLIST, seed.playlist.author, seed.playlist.author)
+                    is CatalogItem.Song ->
+                        Triple(CatalogKind.PLAYLIST, seed.track.artist, seed.track.artist)
+                }
+
+            return BrowseDetail(
+                id = id,
+                title = seed.title,
+                subtitle = subtitle.ifBlank { "${matchingSeedTracks.size} downloaded songs" },
+                artworkUrl =
+                    seed.artworkUrl.ifBlank {
+                        matchingSeedTracks
+                            .firstOrNull { it.artworkUrl.isNotBlank() }
+                            ?.artworkUrl
+                            .orEmpty()
+                    },
+                kind = kind,
+                tracks = matchingSeedTracks,
+                artist = artistName,
+            )
+        }
+
+        // 6. Generic fallback: Return all downloaded tracks
+        return BrowseDetail(
+            id = id,
+            title = "Downloaded Collection",
+            subtitle = "${completedTracks.size} downloaded songs",
+            artworkUrl =
+                completedTracks.firstOrNull { it.artworkUrl.isNotBlank() }?.artworkUrl.orEmpty(),
+            kind = CatalogKind.PLAYLIST,
+            tracks = completedTracks,
+        )
+    }
+}

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/TrackDownloader.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/TrackDownloader.kt
@@ -1,0 +1,303 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.download
+
+import android.util.Log
+import dev.sfg.orchard.mobile.auth.YouTubeSessionProvider
+import dev.sfg.orchard.mobile.playback.NewPipeStreamResolver
+import dev.sfg.orchard.mobile.playback.ResolvedStream
+import dev.sfg.orchard.mobile.playback.YouTubeStreamResolver
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.FileOutputStream
+import java.io.RandomAccessFile
+import java.nio.ByteBuffer
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Downloads audio tracks with maximum speed by resolving streams via [YouTubeStreamResolver]
+ * (with [NewPipeStreamResolver] fallback) and fetching multiple concurrent byte-ranges to bypass
+ * YouTube's progressive per-stream rate limiting.
+ */
+class TrackDownloader(
+    private val http: OkHttpClient,
+    sessionProvider: YouTubeSessionProvider? = null,
+    private val store: DownloadStore,
+) {
+    private val streamResolver by lazy { YouTubeStreamResolver(client = http, sessionProvider = sessionProvider) }
+    private val newPipeResolver by lazy { NewPipeStreamResolver(http, sessionProvider) }
+
+    fun interface ProgressListener {
+        fun onProgress(bytesDownloaded: Long, totalBytes: Long, progress: Float)
+    }
+
+    suspend fun download(
+        item: DownloadItem,
+        progressListener: ProgressListener? = null,
+    ): DownloadItem = withContext(Dispatchers.IO) {
+        val videoId = item.track.id
+        if (videoId.isBlank()) {
+            return@withContext item.copy(
+                status = DownloadStatus.FAILED,
+                errorMessage = "Invalid video ID",
+            )
+        }
+
+        Log.d(TAG, "Resolving stream for track: ${item.track.title} ($videoId)")
+
+        // 1. Fast resolution: YouTubeStreamResolver first (sub-250ms), fallback to NewPipe
+        val resolved: ResolvedStream = try {
+            streamResolver.resolve(videoId)
+        } catch (e: Exception) {
+            Log.w(TAG, "Primary stream resolution failed, attempting fallback for $videoId", e)
+            newPipeResolver.resolve(videoId)
+        } ?: newPipeResolver.resolve(videoId) ?: run {
+            return@withContext item.copy(
+                status = DownloadStatus.FAILED,
+                errorMessage = "Could not resolve audio stream URL",
+            )
+        }
+
+        val ext = when {
+            resolved.mimeType.contains("webm", ignoreCase = true) -> "webm"
+            resolved.mimeType.contains("mp4", ignoreCase = true) || resolved.mimeType.contains("m4a", ignoreCase = true) -> "m4a"
+            resolved.mimeType.contains("opus", ignoreCase = true) -> "opus"
+            else -> "webm"
+        }
+
+        val tempFile = store.getTempFile(videoId)
+        val targetFile = store.getTargetFile(videoId, ext)
+
+        try {
+            // 2. Probe content length with a small initial range request (0..1023)
+            val probeRequest = Request.Builder()
+                .url(resolved.url)
+                .header("User-Agent", USER_AGENT)
+                .header("Range", "bytes=0-1023")
+                .build()
+
+            var totalContentLength = 0L
+            var initialBytes: ByteArray? = null
+
+            http.newCall(probeRequest).execute().use { probeResponse ->
+                if (probeResponse.isSuccessful || probeResponse.code == 206) {
+                    val contentRange = probeResponse.header("Content-Range").orEmpty()
+                    val slashIdx = contentRange.lastIndexOf('/')
+                    if (slashIdx != -1) {
+                        totalContentLength = contentRange.substring(slashIdx + 1).trim().toLongOrNull() ?: 0L
+                    }
+                    val body = probeResponse.body
+                    if (totalContentLength <= 0L) {
+                        totalContentLength = body.contentLength()
+                    }
+                    initialBytes = body.bytes()
+                }
+            }
+
+            val chunk0 = initialBytes
+            if (totalContentLength > 0L && chunk0 != null) {
+                // High-speed concurrent ranged download
+                downloadByRanges(
+                    url = resolved.url,
+                    totalLength = totalContentLength,
+                    initialChunk = chunk0,
+                    tempFile = tempFile,
+                    progressListener = progressListener,
+                )
+            } else {
+                // Fallback to sequential stream
+                downloadSequential(
+                    url = resolved.url,
+                    tempFile = tempFile,
+                    progressListener = progressListener,
+                )
+            }
+
+            if (tempFile.length() == 0L) {
+                tempFile.delete()
+                return@withContext item.copy(
+                    status = DownloadStatus.FAILED,
+                    errorMessage = "Downloaded file is empty",
+                )
+            }
+
+            if (targetFile.exists()) {
+                targetFile.delete()
+            }
+
+            if (!tempFile.renameTo(targetFile)) {
+                tempFile.copyTo(targetFile, overwrite = true)
+                tempFile.delete()
+            }
+
+            Log.i(TAG, "Download completed for ${item.track.title}: ${targetFile.absolutePath} (${targetFile.length()} bytes)")
+
+            item.copy(
+                status = DownloadStatus.COMPLETED,
+                progress = 1.0f,
+                bytesDownloaded = targetFile.length(),
+                totalBytes = targetFile.length(),
+                filePath = targetFile.absolutePath,
+                mimeType = resolved.mimeType,
+                downloadedAtMs = System.currentTimeMillis(),
+                errorMessage = "",
+            )
+        } catch (e: Exception) {
+            Log.e(TAG, "Download failed for $videoId", e)
+            if (tempFile.exists()) {
+                tempFile.delete()
+            }
+            item.copy(
+                status = DownloadStatus.FAILED,
+                errorMessage = e.localizedMessage ?: "Download failed",
+            )
+        }
+    }
+
+    private suspend fun downloadByRanges(
+        url: String,
+        totalLength: Long,
+        initialChunk: ByteArray,
+        tempFile: File,
+        progressListener: ProgressListener?,
+    ) = coroutineScope {
+        RandomAccessFile(tempFile, "rw").use { raf ->
+            raf.setLength(totalLength)
+            val channel = raf.channel
+
+            // Write the first probed chunk
+            val initialWritten = initialChunk.size.toLong()
+            channel.write(ByteBuffer.wrap(initialChunk), 0L)
+
+            val bytesReadAccumulator = AtomicLong(initialWritten)
+            progressListener?.onProgress(initialWritten, totalLength, (initialWritten.toFloat() / totalLength.toFloat()).coerceIn(0f, 1f))
+
+            if (initialWritten >= totalLength) {
+                raf.fd.sync()
+                return@coroutineScope
+            }
+
+            // Partition remaining bytes into chunks of CHUNK_SIZE
+            val chunks = mutableListOf<Pair<Long, Long>>()
+            var start = initialWritten
+            while (start < totalLength) {
+                val end = minOf(start + CHUNK_SIZE - 1, totalLength - 1)
+                chunks.add(start to end)
+                start = end + 1
+            }
+
+            // Distribute across concurrent coroutine workers
+            val chunkQueue = ConcurrentLinkedQueue(chunks)
+            val workers = (0 until CONCURRENCY).map {
+                async(Dispatchers.IO) {
+                    val buffer = ByteArray(BUFFER_SIZE)
+                    while (isActive) {
+                        val chunk = chunkQueue.poll() ?: break
+                        val (chunkStart, chunkEnd) = chunk
+                        val rangeHeader = "bytes=$chunkStart-$chunkEnd"
+
+                        val request = Request.Builder()
+                            .url(url)
+                            .header("User-Agent", USER_AGENT)
+                            .header("Range", rangeHeader)
+                            .build()
+
+                        http.newCall(request).execute().use { response ->
+                            if (!response.isSuccessful && response.code != 206) {
+                                throw java.io.IOException("HTTP ${response.code} on range $rangeHeader")
+                            }
+                            val body = response.body
+                            val stream = body.byteStream()
+                            var currentPos = chunkStart
+                            var n: Int
+                            while (stream.read(buffer).also { n = it } != -1) {
+                                if (!isActive) throw java.io.InterruptedIOException("Download cancelled")
+                                channel.write(ByteBuffer.wrap(buffer, 0, n), currentPos)
+                                currentPos += n
+                                val totalNow = bytesReadAccumulator.addAndGet(n.toLong())
+                                val p = (totalNow.toFloat() / totalLength.toFloat()).coerceIn(0f, 1f)
+                                progressListener?.onProgress(totalNow, totalLength, p)
+                            }
+                        }
+                    }
+                }
+            }
+
+            workers.awaitAll()
+            raf.fd.sync()
+        }
+    }
+
+    private suspend fun downloadSequential(
+        url: String,
+        tempFile: File,
+        progressListener: ProgressListener?,
+    ) = withContext(Dispatchers.IO) {
+        val request = Request.Builder()
+            .url(url)
+            .header("User-Agent", USER_AGENT)
+            .build()
+
+        http.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw java.io.IOException("HTTP ${response.code} downloading stream")
+            }
+            val body = response.body
+            val contentLength = body.contentLength()
+            val inputStream = body.byteStream()
+
+            FileOutputStream(tempFile).use { outputStream ->
+                val buffer = ByteArray(BUFFER_SIZE)
+                var bytesRead: Int
+                var totalRead = 0L
+
+                while (inputStream.read(buffer).also { bytesRead = it } != -1) {
+                    if (!coroutineContext.isActive) {
+                        throw java.io.InterruptedIOException("Download cancelled")
+                    }
+                    outputStream.write(buffer, 0, bytesRead)
+                    totalRead += bytesRead
+                    val progress = if (contentLength > 0) {
+                        (totalRead.toFloat() / contentLength.toFloat()).coerceIn(0f, 1f)
+                    } else 0f
+                    progressListener?.onProgress(totalRead, contentLength, progress)
+                }
+                outputStream.flush()
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "TrackDownloader"
+        private const val USER_AGENT = "Mozilla/5.0 (Linux; Android 16)"
+        private const val BUFFER_SIZE = 32 * 1024
+        private const val CHUNK_SIZE = 512 * 1024L // 512 KB chunks for high parallelism
+        private const val CONCURRENCY = 6
+    }
+}

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/model/UiModels.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/model/UiModels.kt
@@ -28,7 +28,7 @@ sealed interface LoadState<out T> {
     data class Error(val message: String, val cachedValueAvailable: Boolean = false) : LoadState<Nothing>
 }
 
-enum class LibraryFilter { PLAYLISTS, ARTISTS, ALBUMS, SONGS, RECENT }
+enum class LibraryFilter { PLAYLISTS, ARTISTS, ALBUMS, SONGS, RECENT, DOWNLOADS }
 
 data class LibrarySnapshot(
     val likedTracks: List<Track> = emptyList(),

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/network/NetworkMonitor.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/network/NetworkMonitor.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.util.Log
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Observes network connectivity status in real-time.
+ */
+class NetworkMonitor(context: Context) {
+    private val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+
+    private val _isOnline = MutableStateFlow(checkIsOnline())
+    val isOnline: StateFlow<Boolean> = _isOnline.asStateFlow()
+
+    fun checkIsOnline(): Boolean {
+        val cm = connectivityManager ?: return false
+        val active = cm.activeNetwork ?: return false
+        val caps = cm.getNetworkCapabilities(active) ?: return false
+        return caps.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+    }
+
+    init {
+        try {
+            val request = NetworkRequest.Builder()
+                .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .build()
+
+            connectivityManager?.registerNetworkCallback(
+                request,
+                object : ConnectivityManager.NetworkCallback() {
+                    override fun onAvailable(network: Network) {
+                        _isOnline.value = true
+                    }
+
+                    override fun onLost(network: Network) {
+                        _isOnline.value = checkIsOnline()
+                    }
+
+                    override fun onCapabilitiesChanged(
+                        network: Network,
+                        networkCapabilities: NetworkCapabilities,
+                    ) {
+                        val hasInternet =
+                            networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                        _isOnline.value = hasInternet
+                    }
+                },
+            )
+        } catch (e: Exception) {
+            Log.w("NetworkMonitor", "Could not register network callback", e)
+        }
+    }
+}

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/OrchardPlaybackService.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/OrchardPlaybackService.kt
@@ -33,6 +33,7 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.ResolvingDataSource
 import androidx.media3.datasource.DataSourceBitmapLoader
 import androidx.media3.datasource.okhttp.OkHttpDataSource
@@ -117,6 +118,7 @@ class OrchardPlaybackService : MediaLibraryService() {
                 visitorStore = PrefsVisitorIdentityStore(this),
                 onWarning = { message -> graph.postWarning(message) },
                 sessionProvider = graph.auth,
+                downloadManager = graph.downloads,
             )
         streamResolver.warmUp()
         streamCache =
@@ -267,8 +269,9 @@ class OrchardPlaybackService : MediaLibraryService() {
     ): ExoPlayer {
         val httpFactory =
             OkHttpDataSource.Factory(client).setUserAgent(YouTubeStreamResolver.CLIENT_USER_AGENT)
+        val upstreamFactory = DefaultDataSource.Factory(this, httpFactory)
         val resolvingFactory =
-            ResolvingDataSource.Factory(httpFactory) { original ->
+            ResolvingDataSource.Factory(upstreamFactory) { original ->
                 Log.d(TAG, "resolvingFactory: request uri=${original.uri}")
                 if (!MediaItemMapper.isOrchardUri(original.uri)) return@Factory original
                 val videoId = original.uri.lastPathSegment.orEmpty()

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeStreamResolver.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeStreamResolver.kt
@@ -63,6 +63,7 @@ class YouTubeStreamResolver(
      * reason to be anonymous for playback.
      */
     private val sessionProvider: YouTubeSessionProvider? = null,
+    private val downloadManager: dev.sfg.orchard.mobile.download.DownloadManager? = null,
 ) {
     private val newPipeResolver: NewPipeStreamResolver by lazy { NewPipeStreamResolver(client, sessionProvider) }
     /**
@@ -100,6 +101,9 @@ class YouTubeStreamResolver(
 
     fun resolve(videoId: String): ResolvedStream {
         require(videoId.isNotBlank()) { "A YouTube video id is required" }
+        downloadManager?.let { mgr ->
+            dev.sfg.orchard.mobile.download.DownloadPlaybackHelper.resolveOfflineStream(videoId, mgr)?.let { return it }
+        }
         val quality = qualityProvider()
         val cacheKey = "$videoId:${quality.name}"
         cached(cacheKey)?.let { return it }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/CollectionComponents.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/CollectionComponents.kt
@@ -36,12 +36,15 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
 import androidx.compose.material.icons.rounded.Add
 import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.DownloadDone
 import androidx.compose.material.icons.rounded.IosShare
 import androidx.compose.material.icons.rounded.MoreHoriz
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Shuffle
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
@@ -68,7 +71,7 @@ import dev.sfg.orchard.mobile.ui.theme.LocalAccent
 
 /**
  * Collection action buttons row:
- * [ Circular Shuffle ]  [ Wide White Play Pill ]  [ Circular Add/Favorite ]
+ * [ Circular Shuffle ]  [ Wide White Play Pill ]  [ Circular Add/Favorite ]  [ Circular Download ]
  */
 @Composable
 fun CollectionActionRow(
@@ -80,13 +83,17 @@ fun CollectionActionRow(
     isSaved: Boolean,
     playEnabled: Boolean = true,
     shuffleEnabled: Boolean = true,
+    onDownload: (() -> Unit)? = null,
+    isDownloaded: Boolean = false,
+    isDownloading: Boolean = false,
+    downloadEnabled: Boolean = true,
     modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 24.dp),
-        horizontalArrangement = Arrangement.spacedBy(14.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         // Shuffle button (frosted glass circle)
@@ -95,7 +102,7 @@ fun CollectionActionRow(
             enabled = shuffleEnabled,
             shape = CircleShape,
             color = Color.White.copy(alpha = 0.14f),
-            modifier = Modifier.size(46.dp),
+            modifier = Modifier.size(44.dp),
         ) {
             Box(contentAlignment = Alignment.Center) {
                 Icon(
@@ -120,7 +127,7 @@ fun CollectionActionRow(
             shape = RoundedCornerShape(24.dp),
             modifier = Modifier
                 .weight(1f)
-                .height(46.dp),
+                .height(44.dp),
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -147,7 +154,7 @@ fun CollectionActionRow(
             onClick = onSave,
             shape = CircleShape,
             color = Color.White.copy(alpha = 0.14f),
-            modifier = Modifier.size(46.dp),
+            modifier = Modifier.size(44.dp),
         ) {
             Box(contentAlignment = Alignment.Center) {
                 Icon(
@@ -156,6 +163,34 @@ fun CollectionActionRow(
                     tint = if (isSaved) LocalAccent.current else Color.White,
                     modifier = Modifier.size(22.dp),
                 )
+            }
+        }
+
+        // Download / Offline button (frosted glass circle)
+        if (onDownload != null) {
+            Surface(
+                onClick = onDownload,
+                enabled = downloadEnabled,
+                shape = CircleShape,
+                color = Color.White.copy(alpha = 0.14f),
+                modifier = Modifier.size(44.dp),
+            ) {
+                Box(contentAlignment = Alignment.Center) {
+                    if (isDownloading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(18.dp),
+                            color = LocalAccent.current,
+                            strokeWidth = 2.dp,
+                        )
+                    } else {
+                        Icon(
+                            if (isDownloaded) Icons.Rounded.DownloadDone else Icons.Rounded.Download,
+                            contentDescription = if (isDownloaded) "Downloaded offline" else "Download collection",
+                            tint = if (isDownloaded) LocalAccent.current else if (downloadEnabled) Color.White else Color.White.copy(alpha = 0.35f),
+                            modifier = Modifier.size(20.dp),
+                        )
+                    }
+                }
             }
         }
     }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/MediaComponents.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/MediaComponents.kt
@@ -40,8 +40,10 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.DownloadDone
 import androidx.compose.material.icons.rounded.MoreHoriz
 import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -244,6 +246,10 @@ fun TrackRow(
     onPlayNext: (() -> Unit)? = null,
     onAddToQueue: (() -> Unit)? = null,
     onShare: (() -> Unit)? = null,
+    onDownload: (() -> Unit)? = null,
+    onRemoveDownload: (() -> Unit)? = null,
+    isDownloaded: Boolean = false,
+    isDownloading: Boolean = false,
     onViewAlbum: (() -> Unit)? = null,
     onViewArtist: (() -> Unit)? = null,
     trailingText: String = durationText(track.durationMs),
@@ -262,6 +268,8 @@ fun TrackRow(
             onPlay = onPlay,
             onPlayNext = onPlayNext,
             onAddToQueue = onAddToQueue,
+            onDownload = if (!isDownloaded) onDownload else null,
+            onRemoveDownload = if (isDownloaded) onRemoveDownload else null,
             onShare = onShare,
             onViewAlbum = onViewAlbum,
             onViewArtist = onViewArtist,
@@ -364,6 +372,20 @@ fun TrackRow(
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
+                }
+                if (isDownloading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(14.dp),
+                        color = LocalAccent.current,
+                        strokeWidth = 2.dp,
+                    )
+                } else if (isDownloaded) {
+                    Icon(
+                        Icons.Rounded.DownloadDone,
+                        contentDescription = "Downloaded offline",
+                        tint = LocalAccent.current.copy(alpha = 0.85f),
+                        modifier = Modifier.size(16.dp),
+                    )
                 }
                 if (trailingText.isNotBlank()) {
                     Text(

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/TrackActionsPopup.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/TrackActionsPopup.kt
@@ -33,6 +33,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.List
 import androidx.compose.material.icons.automirrored.rounded.PlaylistAdd
 import androidx.compose.material.icons.rounded.Album
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Download
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Share
@@ -69,6 +71,8 @@ internal fun TrackActionsPopup(
     onPlayNext: (() -> Unit)? = null,
     onAddToQueue: (() -> Unit)? = null,
     onViewQueue: (() -> Unit)? = null,
+    onDownload: (() -> Unit)? = null,
+    onRemoveDownload: (() -> Unit)? = null,
     onShare: (() -> Unit)? = null,
     onViewAlbum: (() -> Unit)? = null,
     onViewArtist: (() -> Unit)? = null,
@@ -119,6 +123,12 @@ internal fun TrackActionsPopup(
             }
             onViewQueue?.let { action ->
                 PopupActionRow(Icons.AutoMirrored.Rounded.List, "View Queue") { onDismiss(); action() }
+            }
+            onDownload?.let { action ->
+                PopupActionRow(Icons.Rounded.Download, "Download Offline") { onDismiss(); action() }
+            }
+            onRemoveDownload?.let { action ->
+                PopupActionRow(Icons.Rounded.Delete, "Remove Download") { onDismiss(); action() }
             }
             onViewAlbum?.let { action ->
                 if (track.albumId.isNotBlank()) {

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/navigation/Routes.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/navigation/Routes.kt
@@ -29,6 +29,7 @@ object Routes {
     const val DEVICES = "devices"
     const val LOGIN = "login"
     const val SPOTIFY_LOGIN = "spotify-login"
+    const val DOWNLOADS = "downloads"
     const val DETAIL = "detail/{id}"
 
     fun detail(id: String) = "detail/${android.net.Uri.encode(id)}"

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/CollectionHero.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/CollectionHero.kt
@@ -91,6 +91,10 @@ fun CollectionHero(
     onSave: (BrowseDetail) -> Unit,
     onAbout: () -> Unit,
     isSaved: Boolean = false,
+    downloadedTrackIds: Set<String> = emptySet(),
+    downloadingTrackIds: Set<String> = emptySet(),
+    onDownloadTracks: ((List<Track>) -> Unit)? = null,
+    onRemoveDownloadTracks: ((List<Track>) -> Unit)? = null,
     animatedArtworkUrl: String = "",
     artistPortraitUrl: String = "",
     onShare: ((BrowseDetail) -> Unit)? = null,
@@ -342,8 +346,20 @@ fun CollectionHero(
 
         }
 
-        // Action buttons row: [ Shuffle ]  [ ▶ Play ]  [ Add / Save ]
+        // Action buttons row: [ Shuffle ]  [ ▶ Play ]  [ Add / Save ]  [ Download ]
         Spacer(Modifier.height(18.dp))
+        val allDownloaded = detail.tracks.isNotEmpty() && detail.tracks.all { downloadedTrackIds.contains(it.id) }
+        val anyDownloading = detail.tracks.isNotEmpty() && detail.tracks.any { downloadingTrackIds.contains(it.id) }
+        val onDownloadAction: (() -> Unit)? = if (onDownloadTracks != null && onRemoveDownloadTracks != null && detail.tracks.isNotEmpty()) {
+            {
+                if (allDownloaded) {
+                    onRemoveDownloadTracks(detail.tracks)
+                } else {
+                    onDownloadTracks(detail.tracks)
+                }
+            }
+        } else null
+
         CollectionActionRow(
             accent = if (isAlbum) albumAccent else Color.White,
             onPlay = { onPlayAll(detail.tracks, detail.title) },
@@ -352,6 +368,10 @@ fun CollectionHero(
             isSaved = isSaved,
             playEnabled = detail.tracks.isNotEmpty(),
             shuffleEnabled = detail.tracks.isNotEmpty() && shuffleAvailable,
+            onDownload = onDownloadAction,
+            isDownloaded = allDownloaded,
+            isDownloading = anyDownloading,
+            downloadEnabled = detail.tracks.isNotEmpty(),
         )
 
         // Best mix button at top of playlists

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/DetailScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/DetailScreen.kt
@@ -97,6 +97,12 @@ fun DetailScreen(
     onSave: (BrowseDetail) -> Unit,
     onOpenDetail: (String) -> Unit,
     isSaved: Boolean = false,
+    downloadedTrackIds: Set<String> = emptySet(),
+    downloadingTrackIds: Set<String> = emptySet(),
+    onDownloadTrack: ((Track) -> Unit)? = null,
+    onDownloadTracks: ((List<Track>) -> Unit)? = null,
+    onRemoveDownloadTrack: ((String) -> Unit)? = null,
+    onRemoveDownloadTracks: ((List<Track>) -> Unit)? = null,
     animatedArtworkUrl: String = "",
     artistPortraitUrl: String = "",
     onShareTrack: ((Track) -> Unit)? = null,
@@ -127,6 +133,10 @@ fun DetailScreen(
                     onAdd = onAddToQueue,
                     onSave = onSave,
                     onOpen = onOpenDetail,
+                    downloadedTrackIds = downloadedTrackIds,
+                    downloadingTrackIds = downloadingTrackIds,
+                    onDownloadTrack = onDownloadTrack,
+                    onRemoveDownloadTrack = onRemoveDownloadTrack,
                     onShareTrack = onShareTrack,
                     onShareCollection = onShareCollection,
                 )
@@ -143,6 +153,12 @@ fun DetailScreen(
                     onSave = onSave,
                     onOpen = onOpenDetail,
                     isSaved = isSaved,
+                    downloadedTrackIds = downloadedTrackIds,
+                    downloadingTrackIds = downloadingTrackIds,
+                    onDownloadTrack = onDownloadTrack,
+                    onDownloadTracks = onDownloadTracks,
+                    onRemoveDownloadTrack = onRemoveDownloadTrack,
+                    onRemoveDownloadTracks = onRemoveDownloadTracks,
                     animatedArtworkUrl = animatedArtworkUrl,
                     artistPortraitUrl = artistPortraitUrl,
                     onShareTrack = onShareTrack,
@@ -167,6 +183,10 @@ private fun ArtistDetailContent(
     onAdd: ((Track) -> Unit)?,
     onSave: (BrowseDetail) -> Unit,
     onOpen: (String) -> Unit,
+    downloadedTrackIds: Set<String> = emptySet(),
+    downloadingTrackIds: Set<String> = emptySet(),
+    onDownloadTrack: ((Track) -> Unit)? = null,
+    onRemoveDownloadTrack: ((String) -> Unit)? = null,
     onShareTrack: ((Track) -> Unit)? = null,
     onShareCollection: ((BrowseDetail) -> Unit)? = null,
 ) {
@@ -191,12 +211,18 @@ private fun ArtistDetailContent(
         if (detail.tracks.isNotEmpty()) {
             item { OrchardSectionHeader("Popular") }
             itemsIndexed(detail.tracks, key = { _, track -> track.id }) { index, track ->
+                val isDownloaded = downloadedTrackIds.contains(track.id)
+                val isDownloading = downloadingTrackIds.contains(track.id)
                 TrackRow(
                     track = track,
                     onPlay = { onPlayTrack(detail.tracks, index, detail.title) },
                     modifier = Modifier.padding(horizontal = 8.dp),
                     onPlayNext = onPlayNext?.let { action -> { action(track) } },
                     onAddToQueue = onAdd?.let { action -> { action(track) } },
+                    onDownload = onDownloadTrack?.let { action -> { action(track) } },
+                    onRemoveDownload = onRemoveDownloadTrack?.let { action -> { action(track.id) } },
+                    isDownloaded = isDownloaded,
+                    isDownloading = isDownloading,
                     onShare = onShareTrack?.let { action -> { action(track) } },
                     onViewAlbum = if (track.albumId.isNotBlank()) {{ onOpen(track.albumId) }} else null,
                     onViewArtist = if (track.artistId.isNotBlank()) {{ onOpen(track.artistId) }} else null,
@@ -247,6 +273,12 @@ private fun CollectionDetailContent(
     onSave: (BrowseDetail) -> Unit,
     onOpen: (String) -> Unit,
     isSaved: Boolean = false,
+    downloadedTrackIds: Set<String> = emptySet(),
+    downloadingTrackIds: Set<String> = emptySet(),
+    onDownloadTrack: ((Track) -> Unit)? = null,
+    onDownloadTracks: ((List<Track>) -> Unit)? = null,
+    onRemoveDownloadTrack: ((String) -> Unit)? = null,
+    onRemoveDownloadTracks: ((List<Track>) -> Unit)? = null,
     animatedArtworkUrl: String = "",
     artistPortraitUrl: String = "",
     onShareTrack: ((Track) -> Unit)? = null,
@@ -281,6 +313,10 @@ private fun CollectionDetailContent(
                     onSave = onSave,
                     onAbout = { showDescriptionSheet = true },
                     isSaved = isSaved,
+                    downloadedTrackIds = downloadedTrackIds,
+                    downloadingTrackIds = downloadingTrackIds,
+                    onDownloadTracks = onDownloadTracks,
+                    onRemoveDownloadTracks = onRemoveDownloadTracks,
                     animatedArtworkUrl = animatedArtworkUrl,
                     artistPortraitUrl = artistPortraitUrl,
                     onShare = onShareCollection,
@@ -289,6 +325,8 @@ private fun CollectionDetailContent(
             if (detail.tracks.isNotEmpty()) {
                 itemsIndexed(detail.tracks, key = { _, track -> track.id }) { index, track ->
                     val isAlbum = detail.kind == CatalogKind.ALBUM
+                    val isDownloaded = downloadedTrackIds.contains(track.id)
+                    val isDownloading = downloadingTrackIds.contains(track.id)
                     TrackRow(
                         track = track,
                         trackNumber = if (isAlbum) index + 1 else null,
@@ -299,6 +337,10 @@ private fun CollectionDetailContent(
                         modifier = Modifier.padding(horizontal = 8.dp),
                         onPlayNext = onPlayNext?.let { action -> { action(track) } },
                         onAddToQueue = onAdd?.let { action -> { action(track) } },
+                        onDownload = onDownloadTrack?.let { action -> { action(track) } },
+                        onRemoveDownload = onRemoveDownloadTrack?.let { action -> { action(track.id) } },
+                        isDownloaded = isDownloaded,
+                        isDownloading = isDownloading,
                         onShare = onShareTrack?.let { action -> { action(track) } },
                         onViewAlbum = if (track.albumId.isNotBlank()) {{ onOpen(track.albumId) }} else null,
                         onViewArtist = if (track.artistId.isNotBlank()) {{ onOpen(track.artistId) }} else null,

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/DownloadsScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/DownloadsScreen.kt
@@ -1,0 +1,253 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Download
+import androidx.compose.material.icons.rounded.DownloadDone
+import androidx.compose.material.icons.rounded.PlayArrow
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import dev.sfg.orchard.mobile.download.DownloadItem
+import dev.sfg.orchard.mobile.download.DownloadStatus
+import dev.sfg.orchard.mobile.model.Track
+import dev.sfg.orchard.mobile.ui.components.ArtworkTile
+import dev.sfg.orchard.mobile.ui.components.MessagePanel
+import dev.sfg.orchard.mobile.ui.components.OrchardChromeHeight
+import dev.sfg.orchard.mobile.ui.theme.CanopyColors
+import dev.sfg.orchard.mobile.ui.theme.LocalAccent
+
+@Composable
+fun DownloadsScreen(
+    downloads: List<DownloadItem>,
+    totalBytesUsed: Long,
+    onPlay: (Track) -> Unit,
+    onRemoveDownload: (String) -> Unit,
+) {
+    val completed = downloads.filter { it.status == DownloadStatus.COMPLETED }
+    val active = downloads.filter { it.status == DownloadStatus.DOWNLOADING || it.status == DownloadStatus.QUEUED }
+    val failed = downloads.filter { it.status == DownloadStatus.FAILED }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = OrchardChromeHeight),
+    ) {
+        item {
+            Column(Modifier.padding(horizontal = 16.dp).padding(top = 16.dp, bottom = 12.dp)) {
+                Text(
+                    "Downloads",
+                    style = MaterialTheme.typography.displayLarge.copy(fontWeight = FontWeight.Bold),
+                    color = CanopyColors.Text,
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    "Offline tracks • ${formatStorageSize(totalBytesUsed)} used",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = CanopyColors.Muted,
+                )
+            }
+        }
+
+        if (active.isNotEmpty()) {
+            item {
+                Text(
+                    "DOWNLOADING (${active.size})",
+                    style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                    color = LocalAccent.current,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+            items(active, key = { "active_${it.track.id}" }) { item ->
+                DownloadingRow(item = item, onCancel = { onRemoveDownload(item.track.id) })
+            }
+        }
+
+        if (completed.isNotEmpty()) {
+            item {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    "DOWNLOADED (${completed.size})",
+                    style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                    color = CanopyColors.Muted,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+            items(completed, key = { "completed_${it.track.id}" }) { item ->
+                DownloadedTrackRow(
+                    item = item,
+                    onPlay = { onPlay(item.track) },
+                    onDelete = { onRemoveDownload(item.track.id) },
+                )
+            }
+        } else if (active.isEmpty() && failed.isEmpty()) {
+            item {
+                MessagePanel(
+                    title = "No downloaded tracks",
+                    message = "Tap the '...' menu on any track to download it for offline listening.",
+                )
+            }
+        }
+
+        if (failed.isNotEmpty()) {
+            item {
+                Spacer(Modifier.height(16.dp))
+                Text(
+                    "FAILED (${failed.size})",
+                    style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+            items(failed, key = { "failed_${it.track.id}" }) { item ->
+                DownloadingRow(item = item, onCancel = { onRemoveDownload(item.track.id) })
+            }
+        }
+    }
+}
+
+@Composable
+internal fun DownloadedTrackRow(
+    item: DownloadItem,
+    onPlay: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Surface(
+        onClick = onPlay,
+        color = androidx.compose.ui.graphics.Color.Transparent,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ArtworkTile(item.track.artworkUrl, item.track.title, Modifier.size(48.dp), 8)
+            Spacer(Modifier.width(12.dp))
+            Column(Modifier.weight(1f)) {
+                Text(
+                    item.track.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = CanopyColors.Text,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    "${item.track.artist} • ${formatStorageSize(item.bytesDownloaded)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = CanopyColors.Muted,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+            IconButton(onClick = onPlay) {
+                Icon(Icons.Rounded.PlayArrow, contentDescription = "Play offline", tint = CanopyColors.Text)
+            }
+            IconButton(onClick = onDelete) {
+                Icon(Icons.Rounded.Delete, contentDescription = "Delete download", tint = CanopyColors.Muted)
+            }
+        }
+    }
+}
+
+@Composable
+internal fun DownloadingRow(
+    item: DownloadItem,
+    onCancel: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ArtworkTile(item.track.artworkUrl, item.track.title, Modifier.size(48.dp), 8)
+        Spacer(Modifier.width(12.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                item.track.title,
+                style = MaterialTheme.typography.titleMedium,
+                color = CanopyColors.Text,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Spacer(Modifier.height(4.dp))
+            if (item.status == DownloadStatus.DOWNLOADING) {
+                LinearProgressIndicator(
+                    progress = { item.progress },
+                    modifier = Modifier.fillMaxWidth().height(4.dp),
+                    color = LocalAccent.current,
+                    trackColor = CanopyColors.Rule,
+                )
+            } else if (item.status == DownloadStatus.FAILED) {
+                Text(
+                    item.errorMessage.ifBlank { "Download failed" },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                    maxLines = 1,
+                )
+            } else {
+                Text(
+                    "Queued...",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = CanopyColors.Muted,
+                )
+            }
+        }
+        Spacer(Modifier.width(8.dp))
+        IconButton(onClick = onCancel) {
+            Icon(Icons.Rounded.Delete, contentDescription = "Cancel download", tint = CanopyColors.Muted)
+        }
+    }
+}
+
+internal fun formatStorageSize(bytes: Long): String {
+    if (bytes <= 0) return "0 MB"
+    val mb = bytes.toDouble() / (1024 * 1024)
+    return if (mb >= 1000) {
+        String.format("%.1f GB", mb / 1024)
+    } else {
+        String.format("%.1f MB", mb)
+    }
+}

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/HomeScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/HomeScreen.kt
@@ -19,6 +19,7 @@
 
 package dev.sfg.orchard.mobile.ui.screens
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -41,6 +42,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.CloudOff
 import androidx.compose.material.icons.rounded.FavoriteBorder
 import androidx.compose.material.icons.rounded.MoreHoriz
 import androidx.compose.material.icons.rounded.Person
@@ -51,6 +53,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -60,11 +63,16 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.sfg.orchard.mobile.auth.AuthState
+import dev.sfg.orchard.mobile.model.Album
+import dev.sfg.orchard.mobile.model.Artist
 import dev.sfg.orchard.mobile.model.CatalogItem
 import dev.sfg.orchard.mobile.model.CatalogSection
+import dev.sfg.orchard.mobile.download.DownloadItem
+import dev.sfg.orchard.mobile.download.DownloadStatus
 import dev.sfg.orchard.mobile.model.LibraryFilter
 import dev.sfg.orchard.mobile.model.LibrarySnapshot
 import dev.sfg.orchard.mobile.model.LoadState
+import dev.sfg.orchard.mobile.model.Playlist
 import dev.sfg.orchard.mobile.model.Track
 import dev.sfg.orchard.mobile.ui.components.ArtworkTile
 import dev.sfg.orchard.mobile.ui.components.HomeSectionShimmer
@@ -78,6 +86,9 @@ fun HomeScreen(
         state: LoadState<List<CatalogSection>>,
         library: LibrarySnapshot,
         auth: AuthState = AuthState.SignedOut,
+        downloads: List<DownloadItem> = emptyList(),
+        downloadedTrackIds: Set<String> = emptySet(),
+        isOffline: Boolean = false,
         onRefresh: () -> Unit,
         onSearch: () -> Unit,
         onLibrary: (LibraryFilter) -> Unit,
@@ -85,6 +96,89 @@ fun HomeScreen(
         onPlay: (Track) -> Unit,
         onOpenDetail: (String) -> Unit,
 ) {
+        val completedDownloads = remember(downloads) {
+                downloads.filter { it.status == DownloadStatus.COMPLETED && it.filePath.isNotBlank() }
+        }
+        val downloadedTracks: List<Track> = remember(completedDownloads) { completedDownloads.map { it.track } }
+        val effectiveOffline = isOffline || state is LoadState.Error
+
+        val offlinePlaylistItems: List<CatalogItem.Collection> = remember(downloadedTracks, downloadedTrackIds, library.savedPlaylists) {
+                buildList {
+                        if (downloadedTracks.isNotEmpty()) {
+                                add(
+                                        CatalogItem.Collection(
+                                                Playlist(
+                                                        id = "offline_downloads",
+                                                        title = "Downloaded Music",
+                                                        author = "Orchard",
+                                                        artworkUrl = downloadedTracks.firstOrNull { it.artworkUrl.isNotBlank() }?.artworkUrl.orEmpty(),
+                                                        description = "All offline tracks on this device",
+                                                        tracks = downloadedTracks,
+                                                )
+                                        )
+                                )
+                        }
+                        library.savedPlaylists.forEach { playlist ->
+                                val matching = playlist.tracks.filter { it.id in downloadedTrackIds }
+                                if (matching.isNotEmpty()) {
+                                        add(
+                                                CatalogItem.Collection(
+                                                        playlist.copy(
+                                                                tracks = matching,
+                                                        )
+                                                )
+                                        )
+                                }
+                        }
+                }
+        }
+
+        val offlineArtistItems: List<CatalogItem.Performer> = remember(downloadedTracks, library.savedArtists) {
+                val grouped = mutableMapOf<String, MutableList<Track>>()
+                downloadedTracks.forEach { track ->
+                        if (track.artist.isNotBlank()) {
+                                grouped.getOrPut(track.artist) { mutableListOf() }.add(track)
+                        }
+                }
+                grouped.map { (artistName, artistTracks) ->
+                        val artistId = artistTracks.firstOrNull { it.artistId.isNotBlank() }?.artistId ?: artistName
+                        val artworkUrl = library.savedArtists.firstOrNull { it.name.equals(artistName, ignoreCase = true) }?.artworkUrl
+                                ?: artistTracks.firstOrNull { it.artworkUrl.isNotBlank() }?.artworkUrl.orEmpty()
+                        CatalogItem.Performer(
+                                Artist(
+                                        id = artistId,
+                                        name = artistName,
+                                        artworkUrl = artworkUrl,
+                                        subtitle = "${artistTracks.size} downloaded ${if (artistTracks.size == 1) "song" else "songs"}",
+                                )
+                        )
+                }
+        }
+
+        val offlineAlbumItems: List<CatalogItem.Record> = remember(downloadedTracks) {
+                val grouped = mutableMapOf<String, MutableList<Track>>()
+                downloadedTracks.forEach { track ->
+                        if (track.album.isNotBlank()) {
+                                grouped.getOrPut(track.album) { mutableListOf() }.add(track)
+                        }
+                }
+                grouped.map { (albumTitle, albumTracks) ->
+                        val albumId = albumTracks.firstOrNull { it.albumId.isNotBlank() }?.albumId ?: albumTitle
+                        val artist = albumTracks.firstOrNull()?.artist.orEmpty()
+                        val artworkUrl = albumTracks.firstOrNull { it.artworkUrl.isNotBlank() }?.artworkUrl.orEmpty()
+                        CatalogItem.Record(
+                                Album(
+                                        id = albumId,
+                                        title = albumTitle,
+                                        artist = artist,
+                                        artworkUrl = artworkUrl,
+                                        year = "",
+                                        tracks = albumTracks,
+                                )
+                        )
+                }
+        }
+
         LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(bottom = OrchardChromeHeight),
@@ -92,159 +186,296 @@ fun HomeScreen(
                 // Masthead with Welcome Back user header & search bar
                 item { HomeHeader(auth = auth, onSearch = onSearch) }
 
-                // Section 1: Your Playlists
-                val playlistItems =
-                        library.savedPlaylists.map { CatalogItem.Collection(it) }.ifEmpty {
-                                extractItemsOfKind<CatalogItem.Collection>(state)
-                        }
-                if (playlistItems.isNotEmpty()) {
+                // Offline Mode Banner
+                if (effectiveOffline) {
                         item {
-                                HomeSectionHeader(
-                                        title = "Your Playlists",
-                                        onSeeAll = { onLibrary(LibraryFilter.PLAYLISTS) },
-                                )
-                        }
-                        item {
-                                LazyRow(
-                                        contentPadding = PaddingValues(horizontal = 16.dp),
-                                        horizontalArrangement = Arrangement.spacedBy(14.dp),
+                                Surface(
+                                        modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(horizontal = 16.dp, vertical = 6.dp),
+                                        shape = RoundedCornerShape(14.dp),
+                                        color = CanopyColors.Surface,
+                                        border = BorderStroke(1.dp, LocalAccent.current.copy(alpha = 0.35f)),
                                 ) {
-                                        items(playlistItems, key = { it.stableId }) { item ->
-                                                PlaylistCard(
-                                                        item = item,
-                                                        onClick = {
-                                                                openItem(item, onPlay, onOpenDetail)
-                                                        }
+                                        Row(
+                                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                                                verticalAlignment = Alignment.CenterVertically,
+                                        ) {
+                                                Icon(
+                                                        Icons.Rounded.CloudOff,
+                                                        contentDescription = null,
+                                                        tint = LocalAccent.current,
+                                                        modifier = Modifier.size(22.dp),
                                                 )
-                                        }
-                                }
-                        }
-                        item { Spacer(Modifier.height(20.dp)) }
-                }
-
-                // Section 2: Subscribed Artists
-                val artistItems =
-                        library.savedArtists.map { CatalogItem.Performer(it) }.ifEmpty {
-                                extractItemsOfKind<CatalogItem.Performer>(state)
-                        }
-                if (artistItems.isNotEmpty()) {
-                        item {
-                                HomeSectionHeader(
-                                        title = "Subscribed Artists",
-                                        onSeeAll = { onLibrary(LibraryFilter.ARTISTS) },
-                                )
-                        }
-                        item {
-                                LazyRow(
-                                        contentPadding = PaddingValues(horizontal = 16.dp),
-                                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                                ) {
-                                        items(artistItems, key = { it.stableId }) { item ->
-                                                CircularArtistCard(
-                                                        item = item,
-                                                        onClick = {
-                                                                openItem(item, onPlay, onOpenDetail)
-                                                        }
-                                                )
-                                        }
-                                }
-                        }
-                        item { Spacer(Modifier.height(20.dp)) }
-                }
-
-                // Section 3: Top Songs (Most Listened To Songs)
-                val songTracks =
-                        library.mostPlayed
-                                .ifEmpty { library.likedTracks }
-                                .ifEmpty { library.recentlyPlayed }
-                                .ifEmpty {
-                                        extractItemsOfKind<CatalogItem.Song>(state).map { it.track }
-                                }
-                if (songTracks.isNotEmpty()) {
-                        item {
-                                HomeSectionHeader(
-                                        title = "Top Songs",
-                                        onSeeAll = { onLibrary(LibraryFilter.SONGS) },
-                                )
-                        }
-                        itemsIndexed(songTracks.take(5), key = { _, track -> track.id }) {
-                                index,
-                                track ->
-                                RankedSongRow(
-                                        rank = index + 1,
-                                        track = track,
-                                        onPlay = { onPlay(track) },
-                                )
-                        }
-                        item { Spacer(Modifier.height(20.dp)) }
-                }
-
-                // Additional catalog sections if available
-                when (state) {
-                        is LoadState.Content ->
-                                state.value.forEach { section ->
-                                        item(key = "head:${section.id}") {
-                                                HomeSectionHeader(
-                                                        title = section.title,
-                                                        onSeeAll = { onSearch() }
-                                                )
-                                        }
-                                        item(key = "rail:${section.id}") {
-                                                LazyRow(
-                                                        contentPadding =
-                                                                PaddingValues(horizontal = 16.dp),
-                                                        horizontalArrangement =
-                                                                Arrangement.spacedBy(14.dp),
-                                                ) {
-                                                        items(
-                                                                section.items,
-                                                                key = { it.stableId }
-                                                        ) { item ->
-                                                                PlaylistCard(
-                                                                        item = item,
-                                                                        onClick = {
-                                                                                openItem(
-                                                                                        item,
-                                                                                        onPlay,
-                                                                                        onOpenDetail
-                                                                                )
-                                                                        }
-                                                                )
-                                                        }
+                                                Spacer(Modifier.width(12.dp))
+                                                Column(modifier = Modifier.weight(1f)) {
+                                                        Text(
+                                                                "Offline Mode",
+                                                                style = MaterialTheme.typography.titleSmall,
+                                                                fontWeight = FontWeight.SemiBold,
+                                                                color = CanopyColors.Text,
+                                                        )
+                                                        Text(
+                                                                if (downloadedTracks.isNotEmpty())
+                                                                        "Showing downloaded music (${downloadedTracks.size} ${if (downloadedTracks.size == 1) "song" else "songs"})"
+                                                                else "No internet connection detected",
+                                                                style = MaterialTheme.typography.bodySmall,
+                                                                color = CanopyColors.Muted,
+                                                        )
                                                 }
                                         }
-                                        item(key = "gap:${section.id}") {
-                                                Spacer(Modifier.height(20.dp))
+                                }
+                                Spacer(Modifier.height(14.dp))
+                        }
+                }
+
+                if (effectiveOffline) {
+                        // OFFLINE MODE: ONLY show downloaded playlists, downloaded artists (with only downloaded songs), and downloaded songs
+
+                        // 1. Downloaded Playlists
+                        if (offlinePlaylistItems.isNotEmpty()) {
+                                item {
+                                        HomeSectionHeader(
+                                                title = "Downloaded Playlists",
+                                                onSeeAll = { onLibrary(LibraryFilter.PLAYLISTS) },
+                                        )
+                                }
+                                item {
+                                        LazyRow(
+                                                contentPadding = PaddingValues(horizontal = 16.dp),
+                                                horizontalArrangement = Arrangement.spacedBy(14.dp),
+                                        ) {
+                                                itemsIndexed(offlinePlaylistItems, key = { index, item -> "off_pl_${item.stableId}_$index" }) { _, item ->
+                                                        PlaylistCard(
+                                                                item = item,
+                                                                onClick = { openItem(item, onPlay, onOpenDetail) }
+                                                        )
+                                                }
                                         }
                                 }
-                        LoadState.Loading ->
-                                if (playlistItems.isEmpty() && songTracks.isEmpty()) {
-                                        item { HomeSectionShimmer("Playlists") }
-                                        item { HomeSectionShimmer("Top Artists") }
+                                item { Spacer(Modifier.height(20.dp)) }
+                        }
+
+                        // 2. Downloaded Artists (ONLY the songs that are downloaded)
+                        if (offlineArtistItems.isNotEmpty()) {
+                                item {
+                                        HomeSectionHeader(
+                                                title = "Downloaded Artists",
+                                                onSeeAll = { onLibrary(LibraryFilter.ARTISTS) },
+                                        )
                                 }
-                        is LoadState.Empty ->
-                                if (playlistItems.isEmpty() && songTracks.isEmpty()) {
-                                        item {
-                                                MessagePanel(
-                                                        "A quiet orchard",
-                                                        state.message,
-                                                        "Refresh",
-                                                        onRefresh
-                                                )
+                                item {
+                                        LazyRow(
+                                                contentPadding = PaddingValues(horizontal = 16.dp),
+                                                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                                        ) {
+                                                itemsIndexed(offlineArtistItems, key = { index, item -> "off_art_${item.stableId}_$index" }) { _, item ->
+                                                        CircularArtistCard(
+                                                                item = item,
+                                                                onClick = { openItem(item, onPlay, onOpenDetail) }
+                                                        )
+                                                }
                                         }
                                 }
-                        is LoadState.Error ->
-                                if (playlistItems.isEmpty() && songTracks.isEmpty()) {
-                                        item {
-                                                MessagePanel(
-                                                        "Home is offline",
-                                                        state.message,
-                                                        "Try again",
-                                                        onRefresh
-                                                )
+                                item { Spacer(Modifier.height(20.dp)) }
+                        }
+
+                        // 3. Downloaded Albums (if any)
+                        if (offlineAlbumItems.isNotEmpty()) {
+                                item {
+                                        HomeSectionHeader(
+                                                title = "Downloaded Albums",
+                                                onSeeAll = { onLibrary(LibraryFilter.ALBUMS) },
+                                        )
+                                }
+                                item {
+                                        LazyRow(
+                                                contentPadding = PaddingValues(horizontal = 16.dp),
+                                                horizontalArrangement = Arrangement.spacedBy(14.dp),
+                                        ) {
+                                                itemsIndexed(offlineAlbumItems, key = { index, item -> "off_alb_${item.stableId}_$index" }) { _, item ->
+                                                        PlaylistCard(
+                                                                item = item,
+                                                                onClick = { openItem(item, onPlay, onOpenDetail) }
+                                                        )
+                                                }
                                         }
                                 }
-                        LoadState.Idle -> Unit
+                                item { Spacer(Modifier.height(20.dp)) }
+                        }
+
+                        // 4. Downloaded Songs
+                        if (downloadedTracks.isNotEmpty()) {
+                                item {
+                                        HomeSectionHeader(
+                                                title = "Downloaded Songs",
+                                                onSeeAll = { onLibrary(LibraryFilter.DOWNLOADS) },
+                                        )
+                                }
+                                itemsIndexed(downloadedTracks, key = { index, track -> "off_trk_${track.id}_$index" }) { index, track ->
+                                        RankedSongRow(
+                                                rank = index + 1,
+                                                track = track,
+                                                onPlay = { onPlay(track) },
+                                        )
+                                }
+                                item { Spacer(Modifier.height(20.dp)) }
+                        } else {
+                                item {
+                                        MessagePanel(
+                                                title = "No downloaded music",
+                                                message = "You are currently offline. Connect to the internet to stream music, or download tracks to listen offline.",
+                                                actionLabel = "Try reconnecting",
+                                                onAction = onRefresh,
+                                        )
+                                }
+                        }
+                } else {
+                        // ONLINE MODE: Standard recommendations, playlists, subscribed artists, and top songs
+                        // Section 1: Your Playlists
+                        val playlistItems =
+                                library.savedPlaylists.map { CatalogItem.Collection(it) }.ifEmpty {
+                                        extractItemsOfKind<CatalogItem.Collection>(state)
+                                }.distinctBy { it.stableId }
+                        if (playlistItems.isNotEmpty()) {
+                                item {
+                                        HomeSectionHeader(
+                                                title = "Your Playlists",
+                                                onSeeAll = { onLibrary(LibraryFilter.PLAYLISTS) },
+                                        )
+                                }
+                                item {
+                                        LazyRow(
+                                                contentPadding = PaddingValues(horizontal = 16.dp),
+                                                horizontalArrangement = Arrangement.spacedBy(14.dp),
+                                        ) {
+                                                itemsIndexed(playlistItems, key = { index, item -> "pl_${item.stableId}_$index" }) { _, item ->
+                                                        PlaylistCard(
+                                                                item = item,
+                                                                onClick = {
+                                                                        openItem(item, onPlay, onOpenDetail)
+                                                                }
+                                                        )
+                                                }
+                                        }
+                                }
+                                item { Spacer(Modifier.height(20.dp)) }
+                        }
+
+                        // Section 2: Subscribed Artists
+                        val artistItems =
+                                library.savedArtists.map { CatalogItem.Performer(it) }.ifEmpty {
+                                        extractItemsOfKind<CatalogItem.Performer>(state)
+                                }.distinctBy { it.stableId }
+                        if (artistItems.isNotEmpty()) {
+                                item {
+                                        HomeSectionHeader(
+                                                title = "Subscribed Artists",
+                                                onSeeAll = { onLibrary(LibraryFilter.ARTISTS) },
+                                        )
+                                }
+                                item {
+                                        LazyRow(
+                                                contentPadding = PaddingValues(horizontal = 16.dp),
+                                                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                                        ) {
+                                                itemsIndexed(artistItems, key = { index, item -> "art_${item.stableId}_$index" }) { _, item ->
+                                                        CircularArtistCard(
+                                                                item = item,
+                                                                onClick = {
+                                                                        openItem(item, onPlay, onOpenDetail)
+                                                                }
+                                                        )
+                                                }
+                                        }
+                                }
+                                item { Spacer(Modifier.height(20.dp)) }
+                        }
+
+                        // Section 3: Top Songs (Most Listened To Songs)
+                        val songTracks =
+                                library.mostPlayed
+                                        .ifEmpty { library.likedTracks }
+                                        .ifEmpty { library.recentlyPlayed }
+                                        .ifEmpty {
+                                                extractItemsOfKind<CatalogItem.Song>(state).map { it.track }
+                                        }.distinctBy { it.id }
+                        if (songTracks.isNotEmpty()) {
+                                item {
+                                        HomeSectionHeader(
+                                                title = "Top Songs",
+                                                onSeeAll = { onLibrary(LibraryFilter.SONGS) },
+                                        )
+                                }
+                                itemsIndexed(songTracks.take(5), key = { index, track -> "top_${track.id}_$index" }) {
+                                        index,
+                                        track ->
+                                        RankedSongRow(
+                                                rank = index + 1,
+                                                track = track,
+                                                onPlay = { onPlay(track) },
+                                        )
+                                }
+                                item { Spacer(Modifier.height(20.dp)) }
+                        }
+
+                        // Additional catalog sections if available
+                        when (state) {
+                                is LoadState.Content ->
+                                        state.value.forEach { section ->
+                                                item(key = "head:${section.id}") {
+                                                        HomeSectionHeader(
+                                                                title = section.title,
+                                                                onSeeAll = { onSearch() }
+                                                        )
+                                                }
+                                                item(key = "rail:${section.id}") {
+                                                        LazyRow(
+                                                                contentPadding =
+                                                                        PaddingValues(horizontal = 16.dp),
+                                                                horizontalArrangement =
+                                                                        Arrangement.spacedBy(14.dp),
+                                                        ) {
+                                                                itemsIndexed(
+                                                                        section.items,
+                                                                        key = { index, item -> "${section.id}_${item.stableId}_$index" }
+                                                                ) { _, item ->
+                                                                        PlaylistCard(
+                                                                                item = item,
+                                                                                onClick = {
+                                                                                        openItem(
+                                                                                                item,
+                                                                                                onPlay,
+                                                                                                onOpenDetail
+                                                                                        )
+                                                                                }
+                                                                        )
+                                                                }
+                                                        }
+                                                }
+                                                item(key = "gap:${section.id}") {
+                                                        Spacer(Modifier.height(20.dp))
+                                                }
+                                        }
+                                LoadState.Loading ->
+                                        if (playlistItems.isEmpty() && songTracks.isEmpty()) {
+                                                item { HomeSectionShimmer("Playlists") }
+                                                item { HomeSectionShimmer("Top Artists") }
+                                        }
+                                is LoadState.Empty ->
+                                        if (playlistItems.isEmpty() && songTracks.isEmpty()) {
+                                                item {
+                                                        MessagePanel(
+                                                                "A quiet orchard",
+                                                                state.message,
+                                                                "Refresh",
+                                                                onRefresh
+                                                        )
+                                                }
+                                        }
+                                is LoadState.Error -> Unit
+                                LoadState.Idle -> Unit
+                        }
                 }
         }
 }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/LibraryScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/LibraryScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -37,6 +38,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import dev.sfg.orchard.mobile.download.DownloadItem
+import dev.sfg.orchard.mobile.download.DownloadStatus
 import dev.sfg.orchard.mobile.model.CatalogItem
 import dev.sfg.orchard.mobile.model.LibraryFilter
 import dev.sfg.orchard.mobile.model.LibrarySnapshot
@@ -47,16 +50,24 @@ import dev.sfg.orchard.mobile.ui.components.OrchardFilterChips
 import dev.sfg.orchard.mobile.ui.components.OrchardSectionHeader
 import dev.sfg.orchard.mobile.ui.components.TrackRow
 import dev.sfg.orchard.mobile.ui.components.OrchardChromeHeight
+import dev.sfg.orchard.mobile.ui.theme.CanopyColors
+import dev.sfg.orchard.mobile.ui.theme.LocalAccent
 
 @Composable
 fun LibraryScreen(
     library: LibrarySnapshot,
     filter: LibraryFilter,
     onFilterChange: (LibraryFilter) -> Unit,
+    downloads: List<DownloadItem> = emptyList(),
+    downloadedTrackIds: Set<String> = emptySet(),
+    downloadingTrackIds: Set<String> = emptySet(),
+    totalBytesUsed: Long = 0L,
     onPlay: (Track) -> Unit,
     onPlayNext: ((Track) -> Unit)?,
     onAddToQueue: ((Track) -> Unit)?,
     onOpenDetail: (String) -> Unit,
+    onDownloadTrack: ((Track) -> Unit)? = null,
+    onRemoveDownloadTrack: ((String) -> Unit)? = null,
     onShare: ((Track) -> Unit)? = null,
 ) {
     LazyColumn(Modifier.fillMaxSize(), contentPadding = PaddingValues(bottom = OrchardChromeHeight)) {
@@ -96,33 +107,164 @@ fun LibraryScreen(
                 "Albums you save will be available here.",
                 onOpenDetail,
             )
-            LibraryFilter.SONGS -> tracks(
-                "Liked songs",
-                library.likedTracks,
-                "No liked songs",
-                "Tap the heart in Now Playing to save a track.",
-                onPlay,
-                onPlayNext,
-                onAddToQueue,
-                onShare,
-                onOpenDetail,
+            LibraryFilter.SONGS -> songs(
+                title = "Songs",
+                values = library.likedTracks,
+                emptyTitle = "No songs saved",
+                emptyMessage = "Save songs to your library to see them here",
+                downloadedTrackIds = downloadedTrackIds,
+                downloadingTrackIds = downloadingTrackIds,
+                onPlay = onPlay,
+                onPlayNext = onPlayNext,
+                onAdd = onAddToQueue,
+                onDownloadTrack = onDownloadTrack,
+                onRemoveDownloadTrack = onRemoveDownloadTrack,
+                onOpen = onOpenDetail,
+                onShare = onShare,
             )
             LibraryFilter.RECENT -> tracks(
                 "Recently played",
                 library.recentlyPlayed,
                 "Nothing played yet",
                 "Start a song and Orchard will remember it here.",
+                downloadedTrackIds,
+                downloadingTrackIds,
                 onPlay,
                 onPlayNext,
                 onAddToQueue,
+                onDownloadTrack,
+                onRemoveDownloadTrack,
                 onShare,
                 onOpenDetail,
+            )
+            LibraryFilter.DOWNLOADS -> downloadsList(
+                downloads = downloads,
+                totalBytesUsed = totalBytesUsed,
+                onPlay = onPlay,
+                onRemoveDownload = { id -> onRemoveDownloadTrack?.invoke(id) },
             )
         }
     }
 }
 
-private fun androidx.compose.foundation.lazy.LazyListScope.collections(
+private fun LazyListScope.downloadsList(
+    downloads: List<DownloadItem>,
+    totalBytesUsed: Long,
+    onPlay: (Track) -> Unit,
+    onRemoveDownload: (String) -> Unit,
+) {
+    val completed = downloads.filter { it.status == DownloadStatus.COMPLETED }
+    val active = downloads.filter { it.status == DownloadStatus.DOWNLOADING || it.status == DownloadStatus.QUEUED }
+    val failed = downloads.filter { it.status == DownloadStatus.FAILED }
+
+    if (active.isEmpty() && completed.isEmpty() && failed.isEmpty()) {
+        item {
+            MessagePanel(
+                title = "No downloaded tracks",
+                message = "Tap the download icon on any track, album, or playlist to listen offline.",
+            )
+        }
+        return
+    }
+
+    if (completed.isNotEmpty()) {
+        item {
+            Text(
+                "Offline tracks • ${formatStorageSize(totalBytesUsed)} used",
+                style = MaterialTheme.typography.bodyMedium,
+                color = CanopyColors.Muted,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp),
+            )
+        }
+    }
+
+    if (active.isNotEmpty()) {
+        item {
+            Text(
+                "DOWNLOADING (${active.size})",
+                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                color = LocalAccent.current,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
+        items(active, key = { "active_${it.track.id}" }) { item ->
+            DownloadingRow(item = item, onCancel = { onRemoveDownload(item.track.id) })
+        }
+    }
+
+    if (completed.isNotEmpty()) {
+        item {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                "DOWNLOADED (${completed.size})",
+                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                color = CanopyColors.Muted,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
+        items(completed, key = { "completed_${it.track.id}" }) { item ->
+            DownloadedTrackRow(
+                item = item,
+                onPlay = { onPlay(item.track) },
+                onDelete = { onRemoveDownload(item.track.id) },
+            )
+        }
+    }
+
+    if (failed.isNotEmpty()) {
+        item {
+            Spacer(Modifier.height(16.dp))
+            Text(
+                "FAILED (${failed.size})",
+                style = MaterialTheme.typography.labelMedium.copy(fontWeight = FontWeight.Bold),
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+            )
+        }
+        items(failed, key = { "failed_${it.track.id}" }) { item ->
+            DownloadingRow(item = item, onCancel = { onRemoveDownload(item.track.id) })
+        }
+    }
+}
+
+private fun LazyListScope.songs(
+    title: String,
+    values: List<Track>,
+    emptyTitle: String,
+    emptyMessage: String,
+    downloadedTrackIds: Set<String>,
+    downloadingTrackIds: Set<String> = emptySet(),
+    onPlay: (Track) -> Unit,
+    onPlayNext: ((Track) -> Unit)?,
+    onAdd: ((Track) -> Unit)?,
+    onDownloadTrack: ((Track) -> Unit)? = null,
+    onRemoveDownloadTrack: ((String) -> Unit)? = null,
+    onOpen: ((String) -> Unit)? = null,
+    onShare: ((Track) -> Unit)? = null,
+) {
+    if (values.isEmpty()) {
+        item { MessagePanel(emptyTitle, emptyMessage) }
+        return
+    }
+    item { OrchardSectionHeader(title) }
+    items(values, key = Track::id) { track ->
+        TrackRow(
+            track = track,
+            onPlay = { onPlay(track) },
+            onPlayNext = onPlayNext?.let { action -> { action(track) } },
+            onAddToQueue = onAdd?.let { action -> { action(track) } },
+            onDownload = onDownloadTrack?.let { action -> { action(track) } },
+            onRemoveDownload = onRemoveDownloadTrack?.let { action -> { action(track.id) } },
+            isDownloaded = downloadedTrackIds.contains(track.id),
+            isDownloading = downloadingTrackIds.contains(track.id),
+            onShare = onShare?.let { action -> { action(track) } },
+            onViewAlbum = onOpen?.takeIf { track.albumId.isNotBlank() }?.let { nav -> { nav(track.albumId) } },
+            onViewArtist = onOpen?.takeIf { track.artistId.isNotBlank() }?.let { nav -> { nav(track.artistId) } },
+        )
+    }
+}
+
+private fun LazyListScope.collections(
     title: String,
     values: List<CatalogItem>,
     emptyTitle: String,
@@ -172,14 +314,18 @@ private fun androidx.compose.foundation.lazy.LazyListScope.collections(
     }
 }
 
-private fun androidx.compose.foundation.lazy.LazyListScope.tracks(
+private fun LazyListScope.tracks(
     title: String,
     values: List<Track>,
     emptyTitle: String,
     emptyMessage: String,
+    downloadedTrackIds: Set<String>,
+    downloadingTrackIds: Set<String>,
     onPlay: (Track) -> Unit,
     onPlayNext: ((Track) -> Unit)?,
     onAdd: ((Track) -> Unit)?,
+    onDownloadTrack: ((Track) -> Unit)? = null,
+    onRemoveDownloadTrack: ((String) -> Unit)? = null,
     onShare: ((Track) -> Unit)? = null,
     onOpen: ((String) -> Unit)? = null,
 ) {
@@ -189,11 +335,17 @@ private fun androidx.compose.foundation.lazy.LazyListScope.tracks(
     }
     item { OrchardSectionHeader(title) }
     items(values, key = Track::id) { track ->
+        val isDownloaded = downloadedTrackIds.contains(track.id)
+        val isDownloading = downloadingTrackIds.contains(track.id)
         TrackRow(
             track = track,
             onPlay = { onPlay(track) },
             onPlayNext = onPlayNext?.let { action -> { action(track) } },
             onAddToQueue = onAdd?.let { action -> { action(track) } },
+            onDownload = onDownloadTrack?.let { action -> { action(track) } },
+            onRemoveDownload = onRemoveDownloadTrack?.let { action -> { action(track.id) } },
+            isDownloaded = isDownloaded,
+            isDownloading = isDownloading,
             onShare = onShare?.let { action -> { action(track) } },
             onViewAlbum = onOpen?.takeIf { track.albumId.isNotBlank() }?.let { nav -> { nav(track.albumId) } },
             onViewArtist = onOpen?.takeIf { track.artistId.isNotBlank() }?.let { nav -> { nav(track.artistId) } },
@@ -208,4 +360,5 @@ private val LibraryFilter.label: String
         LibraryFilter.ALBUMS -> "Albums"
         LibraryFilter.SONGS -> "Songs"
         LibraryFilter.RECENT -> "Recent"
+        LibraryFilter.DOWNLOADS -> "Downloads"
     }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/NowPlayingScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/NowPlayingScreen.kt
@@ -105,6 +105,9 @@ fun NowPlayingScreen(
     onRemoveQueueIndex: (Int) -> Unit,
     onMoveQueueItem: (Int, Int) -> Unit,
     onClearUpcoming: () -> Unit,
+    downloadedTrackIds: Set<String> = emptySet(),
+    onDownloadTrack: ((Track) -> Unit)? = null,
+    onRemoveDownloadTrack: ((String) -> Unit)? = null,
     onShare: (() -> Unit)? = null,
     onOpenCollection: ((String) -> Unit)? = null,
 ) {
@@ -229,6 +232,9 @@ fun NowPlayingScreen(
                 onRemoveQueueIndex = onRemoveQueueIndex,
                 onMoveQueueItem = onMoveQueueItem,
                 onClearUpcoming = onClearUpcoming,
+                downloadedTrackIds = downloadedTrackIds,
+                onDownloadTrack = onDownloadTrack,
+                onRemoveDownloadTrack = onRemoveDownloadTrack,
                 onShare = onShare,
                 onOpenCollection = onOpenCollection,
                 onLyricsPanel = { panel = if (lyricsOpen) PlayerPanel.NONE else PlayerPanel.LYRICS },
@@ -256,6 +262,9 @@ fun NowPlayingScreen(
                     onLiked = onLiked,
                     onMore = onQueue,
                     onShare = onShare,
+                    isDownloaded = downloadedTrackIds.contains(track.id),
+                    onDownload = onDownloadTrack?.let { action -> { action(track) } },
+                    onRemoveDownload = onRemoveDownloadTrack?.let { action -> { action(track.id) } },
                 )
                 Box(
                     Modifier
@@ -330,6 +339,9 @@ fun NowPlayingScreen(
                         onLiked = onLiked,
                         onMore = onQueue,
                         onShare = onShare,
+                        isDownloaded = downloadedTrackIds.contains(track.id),
+                        onDownload = onDownloadTrack?.let { action -> { action(track) } },
+                        onRemoveDownload = onRemoveDownloadTrack?.let { action -> { action(track.id) } },
                         onOpenAlbum = track.albumId.takeIf { it.isNotBlank() }
                             ?.let { id -> onOpenCollection?.let { open -> { open(id) } } },
                         onOpenArtist = track.artistId.takeIf { it.isNotBlank() }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/PlayerComponents.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/PlayerComponents.kt
@@ -236,6 +236,9 @@ fun TrackInfoRow(
     // Null when the track carries no album or artist id to open.
     onOpenAlbum: (() -> Unit)? = null,
     onOpenArtist: (() -> Unit)? = null,
+    isDownloaded: Boolean = false,
+    onDownload: (() -> Unit)? = null,
+    onRemoveDownload: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     var menuOpen by remember { mutableStateOf(false) }
@@ -245,6 +248,8 @@ fun TrackInfoRow(
             track = track,
             onDismiss = { menuOpen = false },
             onViewQueue = onMore,
+            onDownload = if (!isDownloaded) onDownload else null,
+            onRemoveDownload = if (isDownloaded) onRemoveDownload else null,
             onShare = onShare,
         )
     }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/PlayerPanels.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/PlayerPanels.kt
@@ -138,6 +138,9 @@ fun PanelTrackHeader(
     onLiked: () -> Unit,
     onMore: () -> Unit,
     onShare: (() -> Unit)?,
+    isDownloaded: Boolean = false,
+    onDownload: (() -> Unit)? = null,
+    onRemoveDownload: (() -> Unit)? = null,
 ) {
     Row(
         modifier = Modifier
@@ -183,6 +186,8 @@ fun PanelTrackHeader(
                 track = track,
                 onDismiss = { menuOpen = false },
                 onViewQueue = onMore,
+                onDownload = if (!isDownloaded) onDownload else null,
+                onRemoveDownload = if (isDownloaded) onRemoveDownload else null,
                 onShare = onShare,
             )
         }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/SearchScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/SearchScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
@@ -74,9 +75,13 @@ fun SearchScreen(
     onQueryChange: (String) -> Unit,
     onSubmit: (String) -> Unit,
     onClearHistory: () -> Unit,
+    downloadedTrackIds: Set<String> = emptySet(),
+    downloadingTrackIds: Set<String> = emptySet(),
     onPlay: (Track) -> Unit,
     onPlayNext: ((Track) -> Unit)?,
     onAddToQueue: ((Track) -> Unit)?,
+    onDownloadTrack: ((Track) -> Unit)? = null,
+    onRemoveDownloadTrack: ((String) -> Unit)? = null,
     onOpenDetail: (String) -> Unit,
     onShare: ((Track) -> Unit)? = null,
 ) {
@@ -96,7 +101,18 @@ fun SearchScreen(
                     repeat(5) { TrackRowShimmer() }
                 }
             }
-            is LoadState.Content -> results(state.value, onPlay, onPlayNext, onAddToQueue, onOpenDetail, onShare)
+            is LoadState.Content -> results(
+                results = state.value,
+                downloadedTrackIds = downloadedTrackIds,
+                downloadingTrackIds = downloadingTrackIds,
+                onPlay = onPlay,
+                onPlayNext = onPlayNext,
+                onAdd = onAddToQueue,
+                onDownloadTrack = onDownloadTrack,
+                onRemoveDownloadTrack = onRemoveDownloadTrack,
+                onOpen = onOpenDetail,
+                onShare = onShare,
+            )
             is LoadState.Empty -> item { MessagePanel("No matches", state.message) }
             is LoadState.Error -> item { MessagePanel("Search is unavailable", state.message, "Try again") { onSubmit(query) } }
         }
@@ -156,22 +172,33 @@ private fun androidx.compose.foundation.lazy.LazyListScope.history(
     }
 }
 
-private fun androidx.compose.foundation.lazy.LazyListScope.results(
+private fun LazyListScope.results(
     results: SearchResults,
+    downloadedTrackIds: Set<String>,
+    downloadingTrackIds: Set<String> = emptySet(),
     onPlay: (Track) -> Unit,
     onPlayNext: ((Track) -> Unit)?,
     onAdd: ((Track) -> Unit)?,
+    onDownloadTrack: ((Track) -> Unit)? = null,
+    onRemoveDownloadTrack: ((String) -> Unit)? = null,
     onOpen: (String) -> Unit,
     onShare: ((Track) -> Unit)? = null,
 ) {
     if (results.tracks.isNotEmpty()) {
         item { OrchardSectionHeader("Songs") }
         items(results.tracks, key = { "track:${it.id}" }) { track ->
+            val isDownloaded = downloadedTrackIds.contains(track.id)
+            val isDownloading = downloadingTrackIds.contains(track.id)
             TrackRow(
                 track = track,
                 onPlay = { onPlay(track) },
+                modifier = Modifier.padding(horizontal = 8.dp),
                 onPlayNext = onPlayNext?.let { action -> { action(track) } },
                 onAddToQueue = onAdd?.let { action -> { action(track) } },
+                onDownload = onDownloadTrack?.let { action -> { action(track) } },
+                onRemoveDownload = onRemoveDownloadTrack?.let { action -> { action(track.id) } },
+                isDownloaded = isDownloaded,
+                isDownloading = isDownloading,
                 onShare = onShare?.let { action -> { action(track) } },
                 onViewAlbum = if (track.albumId.isNotBlank()) {{ onOpen(track.albumId) }} else null,
                 onViewArtist = if (track.artistId.isNotBlank()) {{ onOpen(track.artistId) }} else null,

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/TabletPlayer.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/TabletPlayer.kt
@@ -93,6 +93,9 @@ fun TabletPlayerBody(
     onRemoveQueueIndex: (Int) -> Unit,
     onMoveQueueItem: (Int, Int) -> Unit,
     onClearUpcoming: () -> Unit,
+    downloadedTrackIds: Set<String> = emptySet(),
+    onDownloadTrack: ((Track) -> Unit)? = null,
+    onRemoveDownloadTrack: ((String) -> Unit)? = null,
     onShare: (() -> Unit)?,
     onOpenCollection: ((String) -> Unit)?,
     onLyricsPanel: () -> Unit,
@@ -147,6 +150,9 @@ fun TabletPlayerBody(
                     onLiked = onLiked,
                     onMore = onQueuePanel,
                     onShare = onShare,
+                    isDownloaded = downloadedTrackIds.contains(track.id),
+                    onDownload = onDownloadTrack?.let { action -> { action(track) } },
+                    onRemoveDownload = onRemoveDownloadTrack?.let { action -> { action(track.id) } },
                     onOpenAlbum = track.albumId.takeIf { it.isNotBlank() }
                         ?.let { id -> onOpenCollection?.let { open -> { open(id) } } },
                     onOpenArtist = track.artistId.takeIf { it.isNotBlank() }

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/download/DownloadItemTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/download/DownloadItemTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.download
+
+import dev.sfg.orchard.mobile.model.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class DownloadItemTest {
+
+    @Test
+    fun jsonRoundTripPreservesFields() {
+        val track = Track(
+            id = "track_123",
+            title = "Test Song",
+            artist = "Test Artist",
+            album = "Test Album",
+            albumId = "album_456",
+            artistId = "artist_789",
+            artworkUrl = "https://example.com/art.jpg",
+            durationMs = 180000L,
+        )
+
+        val item = DownloadItem(
+            track = track,
+            status = DownloadStatus.COMPLETED,
+            progress = 1.0f,
+            bytesDownloaded = 5242880L,
+            totalBytes = 5242880L,
+            filePath = "/path/to/downloaded/track.opus",
+            mimeType = "audio/opus",
+            downloadedAtMs = 1700000000000L,
+            errorMessage = "",
+        )
+
+        val json = item.toJson()
+        val restored = DownloadItem.fromJson(json)
+
+        assertEquals("track_123", restored.track.id)
+        assertEquals("Test Song", restored.track.title)
+        assertEquals("Test Artist", restored.track.artist)
+        assertEquals("Test Album", restored.track.album)
+        assertEquals("https://example.com/art.jpg", restored.track.artworkUrl)
+        assertEquals(180000L, restored.track.durationMs)
+        assertEquals(DownloadStatus.COMPLETED, restored.status)
+        assertEquals(5242880L, restored.bytesDownloaded)
+        assertEquals("/path/to/downloaded/track.opus", restored.filePath)
+        assertEquals("audio/opus", restored.mimeType)
+        assertTrue(restored.isFinished)
+    }
+
+    @Test
+    fun downloadStatusHelperProperties() {
+        val queued = DownloadItem(
+            track = Track(id = "1", title = "T", artist = "A"),
+            status = DownloadStatus.QUEUED,
+        )
+        assertTrue(queued.isDownloading)
+        assertTrue(!queued.isFinished)
+
+        val finished = DownloadItem(
+            track = Track(id = "2", title = "T2", artist = "A2"),
+            status = DownloadStatus.COMPLETED,
+        )
+        assertTrue(finished.isFinished)
+        assertTrue(!finished.isDownloading)
+    }
+}

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/download/DownloadStoreTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/download/DownloadStoreTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.download
+
+import dev.sfg.orchard.mobile.model.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class DownloadStoreTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun storePersistsAndLoadsCompletedDownloads() {
+        val baseDir = tempFolder.newFolder("downloads_test")
+        val store = DownloadStore(baseDir = baseDir)
+
+        val trackFile = File(store.downloadDir, "track_1.opus").apply {
+            writeText("dummy-audio-bytes-1234567890")
+        }
+
+        val track = Track(
+            id = "track_1",
+            title = "Awesome Song",
+            artist = "Awesome Artist",
+            album = "Awesome Album",
+            albumId = "album_1",
+            artistId = "artist_1",
+            artworkUrl = "https://example.com/cover.png",
+            durationMs = 210000L,
+        )
+
+        val item = DownloadItem(
+            track = track,
+            status = DownloadStatus.COMPLETED,
+            progress = 1.0f,
+            bytesDownloaded = trackFile.length(),
+            totalBytes = trackFile.length(),
+            filePath = trackFile.absolutePath,
+            mimeType = "audio/opus",
+            downloadedAtMs = System.currentTimeMillis(),
+        )
+
+        store.save(item)
+
+        // Reload fresh from disk using a new store instance pointing to same baseDir
+        val freshStore = DownloadStore(baseDir = baseDir)
+        val loaded = freshStore.loadAll()
+
+        assertEquals(1, loaded.size)
+        val loadedItem = loaded["track_1"]
+        assertNotNull(loadedItem)
+        assertEquals("Awesome Song", loadedItem?.track?.title)
+        assertEquals("Awesome Artist", loadedItem?.track?.artist)
+        assertEquals(DownloadStatus.COMPLETED, loadedItem?.status)
+        assertEquals(trackFile.length(), loadedItem?.bytesDownloaded)
+        assertTrue(File(loadedItem!!.filePath).exists())
+    }
+
+    @Test
+    fun removeDeletesPersistedEntryAndPhysicalFile() {
+        val baseDir = tempFolder.newFolder("downloads_remove_test")
+        val store = DownloadStore(baseDir = baseDir)
+
+        val trackFile = File(store.downloadDir, "track_remove.opus").apply {
+            writeText("audio-data-to-be-removed")
+        }
+        assertTrue(trackFile.exists())
+
+        val item = DownloadItem(
+            track = Track(id = "track_remove", title = "To Remove", artist = "Artist"),
+            status = DownloadStatus.COMPLETED,
+            filePath = trackFile.absolutePath,
+            bytesDownloaded = trackFile.length(),
+        )
+
+        store.save(item)
+        assertEquals(1, store.loadAll().size)
+
+        // Remove
+        store.remove("track_remove")
+
+        assertEquals(0, store.loadAll().size)
+        assertTrue(!trackFile.exists())
+    }
+
+    @Test
+    fun totalBytesCalculatedCorrectly() {
+        val baseDir = tempFolder.newFolder("downloads_bytes_test")
+        val store = DownloadStore(baseDir = baseDir)
+
+        val f1 = File(store.downloadDir, "t1.opus").apply { writeBytes(ByteArray(1024)) }
+        val f2 = File(store.downloadDir, "t2.opus").apply { writeBytes(ByteArray(2048)) }
+
+        store.save(DownloadItem(track = Track(id = "t1", title = "T1", artist = "A1"), status = DownloadStatus.COMPLETED, filePath = f1.absolutePath, bytesDownloaded = 1024L))
+        store.save(DownloadItem(track = Track(id = "t2", title = "T2", artist = "A2"), status = DownloadStatus.COMPLETED, filePath = f2.absolutePath, bytesDownloaded = 2048L))
+
+        assertEquals(3072L, store.totalBytesUsed())
+    }
+}

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/download/OfflineDetailSynthesizerTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/download/OfflineDetailSynthesizerTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.download
+
+import dev.sfg.orchard.mobile.model.Album
+import dev.sfg.orchard.mobile.model.Artist
+import dev.sfg.orchard.mobile.model.CatalogItem
+import dev.sfg.orchard.mobile.model.CatalogKind
+import dev.sfg.orchard.mobile.model.LibrarySnapshot
+import dev.sfg.orchard.mobile.model.Playlist
+import dev.sfg.orchard.mobile.model.Track
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class OfflineDetailSynthesizerTest {
+
+    private val track1 = Track(
+        id = "t1",
+        title = "Track One",
+        artist = "Artist A",
+        artistId = "art_a",
+        album = "Album 1",
+        albumId = "alb_1",
+        durationMs = 180000,
+    )
+
+    private val track2 = Track(
+        id = "t2",
+        title = "Track Two",
+        artist = "Artist A",
+        artistId = "art_a",
+        album = "Album 2",
+        albumId = "alb_2",
+        durationMs = 200000,
+    )
+
+    private val track3 = Track(
+        id = "t3",
+        title = "Track Three",
+        artist = "Artist B",
+        artistId = "art_b",
+        album = "Album 1",
+        albumId = "alb_1",
+        durationMs = 220000,
+    )
+
+    private val downloadItems = listOf(
+        DownloadItem(
+            track = track1,
+            status = DownloadStatus.COMPLETED,
+            filePath = "/data/downloads/t1.mp3",
+        ),
+        DownloadItem(
+            track = track2,
+            status = DownloadStatus.COMPLETED,
+            filePath = "/data/downloads/t2.mp3",
+        ),
+        DownloadItem(
+            track = track3,
+            status = DownloadStatus.DOWNLOADING, // Not completed yet
+            filePath = "",
+        ),
+    )
+
+    private val library = LibrarySnapshot(
+        savedPlaylists = listOf(
+            Playlist(
+                id = "pl_custom",
+                title = "My Playlist",
+                tracks = listOf(track1, track2, track3),
+            )
+        ),
+        savedArtists = listOf(
+            Artist(
+                id = "art_a",
+                name = "Artist A",
+                artworkUrl = "https://example.com/artist_a.jpg",
+            )
+        ),
+        savedAlbums = listOf(
+            Album(
+                id = "alb_1",
+                title = "Album 1",
+                artist = "Artist A",
+                artworkUrl = "https://example.com/alb_1.jpg",
+            )
+        ),
+    )
+
+    @Test
+    fun `synthesizes artist with ONLY downloaded tracks`() {
+        val result = OfflineDetailSynthesizer.synthesize(
+            id = "art_a",
+            seed = CatalogItem.Performer(Artist(id = "art_a", name = "Artist A")),
+            downloadedItems = downloadItems,
+            library = library,
+        )
+
+        assertNotNull(result)
+        assertEquals(CatalogKind.ARTIST, result!!.kind)
+        assertEquals("Artist A", result.title)
+        // t1 and t2 are completed for Artist A; t3 is for Artist B
+        assertEquals(listOf(track1, track2), result.tracks)
+        assertEquals("https://example.com/artist_a.jpg", result.artworkUrl)
+    }
+
+    @Test
+    fun `synthesizes saved playlist with only completed downloaded tracks`() {
+        val result = OfflineDetailSynthesizer.synthesize(
+            id = "pl_custom",
+            seed = null,
+            downloadedItems = downloadItems,
+            library = library,
+        )
+
+        assertNotNull(result)
+        assertEquals(CatalogKind.PLAYLIST, result!!.kind)
+        assertEquals("My Playlist", result.title)
+        // Only t1 and t2 are completed
+        assertEquals(listOf(track1, track2), result.tracks)
+    }
+
+    @Test
+    fun `synthesizes album with only completed downloaded tracks`() {
+        val result = OfflineDetailSynthesizer.synthesize(
+            id = "alb_1",
+            seed = null,
+            downloadedItems = downloadItems,
+            library = library,
+        )
+
+        assertNotNull(result)
+        assertEquals(CatalogKind.ALBUM, result!!.kind)
+        assertEquals("Album 1", result.title)
+        // Only t1 belongs to alb_1 and is completed (t3 is in alb_1 but still DOWNLOADING)
+        assertEquals(listOf(track1), result.tracks)
+    }
+
+    @Test
+    fun `synthesizes generic downloads list`() {
+        val result = OfflineDetailSynthesizer.synthesize(
+            id = "offline_downloads",
+            seed = null,
+            downloadedItems = downloadItems,
+            library = library,
+        )
+
+        assertNotNull(result)
+        assertEquals("Downloaded Music", result!!.title)
+        assertEquals(listOf(track1, track2), result.tracks)
+    }
+
+    @Test
+    fun `returns null when no completed downloads exist`() {
+        val result = OfflineDetailSynthesizer.synthesize(
+            id = "art_a",
+            seed = null,
+            downloadedItems = emptyList(),
+            library = library,
+        )
+
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a full offline-downloads feature to the Android app. network state
monitoring, a DownloadManager pipeline, a Downloads screen, and synthesized
offline views of artists/playlists/albums that fall back to whatever has
actually finished downloading when the device is offline.

## Changes
- Permissions: add ACCESS_NETWORK_STATE
- NetworkMonitor: new dev.sfg.orchard.mobile.network.NetworkMonitor exposing
  isOnline as a StateFlow; wired into OrchardGraph/ViewModel to auto-retry
  a failed home load when connectivity returns
- DownloadManager: new download package (DownloadManager, DownloadItem,
  DownloadStatus) tracking per-track download/removal state, exposed via
  downloads / downloadedTrackIds / downloadingTrackIds / totalBytesUsed
  StateFlows
- ViewModel: downloadTrack/downloadTracks/removeDownload/removeDownloads
  wired through to Search, Library, Detail, and Queue screens
- Navigation: new Routes.DOWNLOADS destination and DownloadsScreen; new
  LibraryFilter.DOWNLOADS filter
- OfflineDetailSynthesizer: builds an offline-safe "detail" view (artist,
  playlist, album, or generic downloads list) purely from completed
  DownloadItems + cached LibrarySnapshot, excluding in-progress downloads
- Tests: OfflineDetailSynthesizerTest covering artist/playlist/album/
  generic-list synthesis and the no-completed-downloads null case