### PR TITLE
fix: add Windows SMTC media session support

### DIFF
--- a/electron/platform/systemMedia.js
+++ b/electron/platform/systemMedia.js
@@ -270,13 +270,36 @@ function configureMprisInterfaces(dbus) {
 export function createSystemMediaService({
   emitCommand,
   loadDbus = () => require('@particle/dbus-next'),
+  loadSmtc = async () => (await import('node-smtc')).default,
   platform = process.platform
 }) {
   let bus = null;
   let player = null;
   let startPromise = null;
+  let smtc = null;
 
   async function start(initialState = {}) {
+    if (platform === 'win32') {
+      if (startPromise) return startPromise;
+      startPromise = (async () => {
+        const SMTCPlayer = await loadSmtc();
+        smtc = new SMTCPlayer();
+        smtc.on('play', () => emitCommand({ type: 'play' }));
+        smtc.on('pause', () => emitCommand({ type: 'pause' }));
+        smtc.on('next', () => emitCommand({ type: 'next' }));
+        smtc.on('previous', () => emitCommand({ type: 'previous' }));
+        smtc.on('positionchange', (value) => emitCommand({ type: 'seek', value: Number(value) / 1000 }));
+        smtc.on('shuffle', (value) => emitCommand({ type: 'set-shuffle', value: Boolean(value) }));
+        smtc.on('repeat', (value) => emitCommand({ type: 'set-repeat-mode', value: value === 'track' ? 'one' : value === 'list' ? 'queue' : 'off' }));
+        smtc.start();
+        return true;
+      })().catch((error) => {
+        console.warn(`Windows media integration disabled: ${error.message}`);
+        smtc = null;
+        return false;
+      });
+      return startPromise;
+    }
     if (platform !== 'linux') return false;
     if (startPromise) return startPromise;
 
@@ -307,10 +330,31 @@ export function createSystemMediaService({
   return {
     async publish(state) {
       if (!await start(state)) return false;
+      if (platform === 'win32') {
+        const track = state.track || {};
+        smtc?.setArtist(track.artist || track.artists?.[0] || '');
+        smtc?.setAlbumArtist(track.artist || track.artists?.[0] || '');
+        smtc?.setTitle(track.title || 'Orchard');
+        smtc?.setAlbumTitle(track.album || '');
+        smtc?.setPlaybackStatus(state.isPlaying ? 'playing' : track.id ? 'paused' : 'stopped');
+        smtc?.setShuffle(Boolean(state.shuffleEnabled));
+        smtc?.setAutoRepeat(state.repeatMode === 'one' ? 'track' : state.repeatMode === 'queue' ? 'list' : 'none');
+        const duration = Math.max(0, Number(state.durationSeconds) || 0) * 1000;
+        smtc?.setStartTime(0);
+        smtc?.setMinSeekTime(0);
+        smtc?.setPosition(Math.max(0, Number(state.currentTime) || 0) * 1000);
+        smtc?.setMaxSeekTime(duration);
+        smtc?.setEndTime(duration);
+        return Boolean(smtc);
+      }
       player?.update(state);
       return Boolean(player);
     },
     stop() {
+      if (smtc) {
+        try { smtc.stop(); } catch {}
+      }
+      smtc = null;
       try {
         if (bus) bus.unexport(OBJECT_PATH);
         bus?.disconnect();

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,8 @@
         "sass-embedded": "^1.100.0"
       },
       "optionalDependencies": {
-        "@particle/dbus-next": "^0.11.4"
+        "@particle/dbus-next": "^0.11.4",
+        "node-smtc": "github:michei69/node-smtc"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "ml-kmeans": "^7.0.1",
         "music-tempo": "^1.0.3",
         "node-addon-api": "^8.9.1",
+        "node-smtc": "https://github.com/michei69/node-smtc.git#master",
         "onnxruntime-node": "^1.27.0",
         "qrcode": "^1.5.4",
         "quasar": "^2.24.0",
@@ -55,7 +56,22 @@
       },
       "optionalDependencies": {
         "@particle/dbus-next": "^0.11.4",
-        "node-smtc": "github:michei69/node-smtc"
+        "node-smtc": "git+https://github.com/michei69/node-smtc.git#master"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT"
+    },
+    "node_modules/node-smtc": {
+      "version": "1.0.0",
+      "resolved": "git+https://github.com/michei69/node-smtc.git#6894d2a2b7cc31f953e4dd0d605282e81993d16b",
+      "license": "ISC",
+      "dependencies": {
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.8.4"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     }
   },
   "optionalDependencies": {
-    "@particle/dbus-next": "^0.11.4"
+    "@particle/dbus-next": "^0.11.4",
+    "node-smtc": "github:michei69/node-smtc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
   },
   "optionalDependencies": {
     "@particle/dbus-next": "^0.11.4",
-    "node-smtc": "github:michei69/node-smtc"
+    "node-smtc": "git+https://github.com/michei69/node-smtc.git#master"
   }
 }


### PR DESCRIPTION
## Summary
- Adds Windows System Media Transport Controls (SMTC) support using node-smtc, bringing native OS media control integration (taskbar/action center media overlays, keyboard media keys) to Windows platforms alongside the existing Linux MPRIS implementation. 

testers needed, as I removed my windows install a few weeks ago.