### PR TITLE
Orchard Mobile 1.2.0 "Synopses Brusquely"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ on:
         required: false
         default: false
         type: boolean
+      mobile_only:
+        description: Build and publish the Android APK alone, skipping every desktop platform
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: release-${{ inputs.tag || github.ref }}
@@ -37,6 +42,7 @@ jobs:
       tag: ${{ steps.release.outputs.tag }}
       version: ${{ steps.release.outputs.version }}
       is_beta: ${{ steps.release.outputs.is_beta }}
+      mobile_only: ${{ steps.release.outputs.mobile_only }}
     steps:
       - name: Check out release tag
         uses: actions/checkout@v6
@@ -55,18 +61,43 @@ jobs:
         env:
           RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
           BUILD_ONLY: ${{ inputs.build_only || false }}
+          MOBILE_ONLY_INPUT: ${{ inputs.mobile_only || false }}
         run: |
           set -euo pipefail
-          version="$(node -p "require('./package.json').version")"
+
+          # A `-mobile` tag suffix ships the Android APK on its own, so a mobile-side fix
+          # does not have to drag a whole desktop release behind it. The suffix is not part
+          # of any version number: it is stripped here, and what is left has to be a valid
+          # release tag on its own terms.
+          mobile_only="$MOBILE_ONLY_INPUT"
+          version_tag="$RELEASE_TAG"
+          case "$RELEASE_TAG" in
+            *-mobile)
+              mobile_only="true"
+              version_tag="${RELEASE_TAG%-mobile}"
+              ;;
+          esac
+
+          # Desktop and mobile version independently -- desktop is on 4.x while mobile is on
+          # 1.x -- so each validates against the file that actually declares its version.
+          if [[ "$mobile_only" == "true" ]]; then
+            version="$(sed -n "s/^[[:space:]]*versionName[[:space:]]*=[[:space:]]*['\"]\([^'\"]*\)['\"].*/\1/p" mobile/android/app/build.gradle)"
+            version_source="mobile/android/app/build.gradle"
+          else
+            version="$(node -p "require('./package.json').version")"
+            version_source="package.json"
+          fi
+          test -n "$version"
+
           if [[ "${BUILD_ONLY:-false}" == "true" ]]; then
             echo "Build-only run: skipping release tag validation."
           else
-            case "$RELEASE_TAG" in
+            case "$version_tag" in
               v[0-9]*) ;;
               *) echo "Release tag must start with v followed by a number." >&2; exit 1 ;;
             esac
-            if [[ "$RELEASE_TAG" != "v$version" ]]; then
-              echo "Tag $RELEASE_TAG does not match package.json version $version." >&2
+            if [[ "$version_tag" != "v$version" ]]; then
+              echo "Tag $RELEASE_TAG does not match $version_source version $version." >&2
               exit 1
             fi
             git rev-parse --verify "refs/tags/$RELEASE_TAG^{commit}"
@@ -74,7 +105,10 @@ jobs:
 
           echo "tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "mobile_only=$mobile_only" >> "$GITHUB_OUTPUT"
 
+          # Read off the version rather than the tag, so the `-mobile` marker is never
+          # mistaken for a prerelease qualifier.
           is_beta="false"
           case "$version" in
             *-*) is_beta="true" ;;
@@ -82,17 +116,38 @@ jobs:
           echo "is_beta=$is_beta" >> "$GITHUB_OUTPUT"
 
       - name: Install dependencies
+        if: steps.release.outputs.mobile_only != 'true'
         run: npm ci
 
       - name: Build native audio analyzer
+        if: steps.release.outputs.mobile_only != 'true'
         run: npm run build:native
 
       - name: Run tests
+        if: steps.release.outputs.mobile_only != 'true'
         run: npm test
+
+      - name: Set up JDK 17
+        if: steps.release.outputs.mobile_only == 'true'
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Run mobile tests
+        if: steps.release.outputs.mobile_only == 'true'
+        working-directory: mobile/android
+        run: |
+          chmod +x gradlew
+          # The debug variant deliberately: any task with "release" in its name trips the
+          # signing-environment guard in app/build.gradle, and unit tests need no keystore.
+          ./gradlew --no-daemon testDebugUnitTest
 
   build-linux:
     name: Linux packages
     needs: prepare
+    if: needs.prepare.outputs.mobile_only != 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Check out release tag
@@ -145,6 +200,7 @@ jobs:
   build-arch:
     name: Arch Linux package
     needs: prepare
+    if: needs.prepare.outputs.mobile_only != 'true'
     runs-on: ubuntu-24.04
     container: archlinux:base-devel
     steps:
@@ -189,6 +245,7 @@ jobs:
   build-windows:
     name: Windows installer
     needs: prepare
+    if: needs.prepare.outputs.mobile_only != 'true'
     runs-on: windows-2025
     env:
       CSC_IDENTITY_AUTO_DISCOVERY: 'false'
@@ -239,6 +296,7 @@ jobs:
   build-macos:
     name: macOS ${{ matrix.arch }} ZIP
     needs: prepare
+    if: needs.prepare.outputs.mobile_only != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -388,7 +446,17 @@ jobs:
       - build-windows
       - build-macos
       - build-android
-    if: needs.prepare.outputs.is_beta != 'true' && inputs.build_only != true
+    # A mobile-only run skips every desktop build job, and a skipped dependency would
+    # otherwise skip this one too -- hence always() plus explicit result checks, which
+    # still refuse to publish if anything actually failed or was cancelled.
+    if: >-
+      always()
+      && needs.prepare.result == 'success'
+      && needs.build-android.result == 'success'
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
+      && needs.prepare.outputs.is_beta != 'true'
+      && inputs.build_only != true
     runs-on: ubuntu-24.04
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -415,6 +483,7 @@ jobs:
           merge-multiple: true
 
       - name: Merge macOS update metadata
+        if: needs.prepare.outputs.mobile_only != 'true'
         run: |
           set -euo pipefail
           node scripts/merge-macos-update-metadata.mjs \
@@ -424,16 +493,26 @@ jobs:
           rm release-assets/latest-mac-x64.yml release-assets/latest-mac-arm64.yml
 
       - name: Generate checksums
+        env:
+          MOBILE_ONLY: ${{ needs.prepare.outputs.mobile_only }}
         run: |
           set -euo pipefail
           test -n "$(find release-assets -maxdepth 1 -type f -print -quit)"
+          # SHA256SUMS.txt has a fixed name in the bucket, so a mobile-only run publishing
+          # under it would replace the desktop checksum list with a single APK line. Mobile
+          # gets its own file instead, leaving the desktop manifest from the last full
+          # release intact.
+          sums="SHA256SUMS.txt"
+          if [[ "$MOBILE_ONLY" == "true" ]]; then
+            sums="SHA256SUMS-mobile.txt"
+          fi
           (
             cd release-assets
-            find . -maxdepth 1 -type f ! -name SHA256SUMS.txt -print0 \
+            find . -maxdepth 1 -type f ! -name 'SHA256SUMS*.txt' -print0 \
               | sort -z \
-              | xargs -0 sha256sum > SHA256SUMS.txt
+              | xargs -0 sha256sum > "$sums"
           )
-          cat release-assets/SHA256SUMS.txt
+          cat "release-assets/$sums"
 
       - name: Upload versioned release artifacts
         run: |
@@ -445,10 +524,11 @@ jobs:
             --exclude 'latest*.json' \
             --recursive
 
-      - name: Publish updater manifests
+      - name: Publish desktop updater manifests
+        if: needs.prepare.outputs.mobile_only != 'true'
         run: |
           set -euo pipefail
-          
+
           # Upload YAML manifests
           for manifest in latest.yml latest-linux.yml latest-mac.yml; do
             test -f "release-assets/$manifest"
@@ -457,8 +537,12 @@ jobs:
               --content-type application/yaml \
               --cache-control no-cache
           done
-          
-          # Upload Android JSON manifest separately for correct content-type
+
+      - name: Publish Android updater manifest
+        run: |
+          set -euo pipefail
+
+          # Uploaded separately from the YAML manifests for the correct content-type
           test -f "release-assets/latest-android.json"
           aws s3 cp "release-assets/latest-android.json" "s3://$R2_BUCKET/orchard/latest-android.json" \
             --endpoint-url "$R2_ENDPOINT" \
@@ -474,7 +558,15 @@ jobs:
       - build-windows
       - build-macos
       - build-android
-    if: needs.prepare.outputs.is_beta == 'true' && inputs.build_only != true
+    # See the publish job: skipped desktop builds must not skip this one.
+    if: >-
+      always()
+      && needs.prepare.result == 'success'
+      && needs.build-android.result == 'success'
+      && !contains(needs.*.result, 'failure')
+      && !contains(needs.*.result, 'cancelled')
+      && needs.prepare.outputs.is_beta == 'true'
+      && inputs.build_only != true
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -494,6 +586,7 @@ jobs:
           merge-multiple: true
 
       - name: Merge macOS update metadata
+        if: needs.prepare.outputs.mobile_only != 'true'
         run: |
           set -euo pipefail
           node scripts/merge-macos-update-metadata.mjs \
@@ -515,11 +608,24 @@ jobs:
           cat release-assets/SHA256SUMS.txt
 
       - name: Create GitHub prerelease
+        env:
+          MOBILE_ONLY: ${{ needs.prepare.outputs.mobile_only }}
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           set -euo pipefail
           test -n "$(find release-assets -maxdepth 1 -type f -print -quit)"
+
+          # A mobile-only prerelease carries the mobile version and mobile notes; the
+          # desktop ones describe a build this run never produced.
+          notes="build/release-notes.md"
+          title="Orchard $VERSION (beta)"
+          if [[ "$MOBILE_ONLY" == "true" ]]; then
+            notes="mobile/release-notes.md"
+            title="Orchard Mobile $VERSION (beta)"
+          fi
+
           gh release create "${{ needs.prepare.outputs.tag }}" release-assets/* \
             --repo "${{ github.repository }}" \
-            --title "Orchard ${{ needs.prepare.outputs.version }} (beta)" \
-            --notes-file build/release-notes.md \
+            --title "$title" \
+            --notes-file "$notes" \
             --prerelease

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId = 'dev.sfg.orchard.mobile'
         minSdk = 31
         targetSdk = 36
-        versionCode = 10100
-        versionName = '1.1.0'
+        versionCode = 10101
+        versionName = '1.1.1'
         buildConfigField 'String', 'CODENAME', '"Fiancee Batches"'
         testInstrumentationRunner = 'androidx.test.runner.AndroidJUnitRunner'
         ndk {

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -17,7 +17,7 @@ android {
         targetSdk = 36
         versionCode = 10101
         versionName = '1.1.1'
-        buildConfigField 'String', 'CODENAME', '"Fiancee Batches"'
+        buildConfigField 'String', 'CODENAME', '"Minuses Entangle"'
         testInstrumentationRunner = 'androidx.test.runner.AndroidJUnitRunner'
         ndk {
             // 64-bit only. minSdk 31 predates the 64-bit requirement by years, and a 32-bit

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -15,9 +15,9 @@ android {
         applicationId = 'dev.sfg.orchard.mobile'
         minSdk = 31
         targetSdk = 36
-        versionCode = 10101
-        versionName = '1.1.1'
-        buildConfigField 'String', 'CODENAME', '"Minuses Entangle"'
+        versionCode = 10200
+        versionName = '1.2.0'
+        buildConfigField 'String', 'CODENAME', '"Synopses Brusquely"'
         testInstrumentationRunner = 'androidx.test.runner.AndroidJUnitRunner'
         ndk {
             // 64-bit only. minSdk 31 predates the 64-bit requirement by years, and a 32-bit

--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -113,6 +113,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2'
     implementation 'com.squareup.okhttp3:okhttp:5.4.0'
     implementation 'androidx.core:core:1.13.1'
+    implementation 'androidx.webkit:webkit:1.14.0'
     implementation 'com.journeyapps:zxing-android-embedded:4.3.0'
     implementation 'eu.buney.kopus:kopus:1.6.1.3'
     implementation 'com.github.TeamNewPipe:NewPipeExtractor:v0.26.4'

--- a/mobile/android/app/proguard-rules.pro
+++ b/mobile/android/app/proguard-rules.pro
@@ -1,6 +1,15 @@
 # Keep enough source information for useful release crash reports.
 -keepattributes SourceFile,LineNumberTable
 
+# ONNX Runtime's JNI layer resolves its Java classes, fields and constructors by
+# hardcoded name from native code (FindClass/GetMethodID/GetFieldID). R8 renaming
+# or stripping any of them turns into `java_class == null` and a SIGABRT inside
+# convertToTensorInfo the first time a model runs, so the whole package must
+# survive shrinking untouched.
+-keep class ai.onnxruntime.** { *; }
+-keep class ai.onnxruntime.providers.** { *; }
+-dontwarn ai.onnxruntime.**
+
 # NewPipeExtractor embeds Mozilla Rhino for YouTube cipher evaluation.
 -keep class org.mozilla.javascript.** { *; }
 -keep class org.mozilla.classfile.ClassFileWriter

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/OrchardGraph.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/OrchardGraph.kt
@@ -108,9 +108,11 @@ class OrchardGraph(context: Context) {
         warningEvent.tryEmit(message)
     }
 
+    val updates = UpdateManager(context)
+
     init {
         applicationScope.launch { auth.restore() }
-        UpdateManager(context).checkForUpdates()
+        updates.checkForUpdates()
     }
 
     companion object {

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/UpdateManager.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/UpdateManager.kt
@@ -5,14 +5,20 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.database.Cursor
 import android.net.Uri
-import android.os.Build
 import android.os.Environment
+import android.util.Log
 import androidx.core.content.FileProvider
+import dev.sfg.orchard.connect.BuildConfig
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import org.json.JSONObject
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
+import java.security.MessageDigest
 import kotlin.concurrent.thread
 
 data class MobileUpdateMetadata(
@@ -25,12 +31,28 @@ data class MobileUpdateMetadata(
     val releaseNotes: String = "",
 )
 
+/** What the update flow is currently doing, for the in-app prompt to render. */
+sealed interface UpdateState {
+    data object Idle : UpdateState
+    data class Available(val metadata: MobileUpdateMetadata) : UpdateState
+    data class Downloading(val version: String) : UpdateState
+    data class Failed(val version: String, val reason: String) : UpdateState
+    data class ReadyToInstall(val version: String) : UpdateState
+}
+
 class UpdateManager(private val context: Context) {
 
     private val baseUrl = "https://downloads.sfg545.dev/orchard"
     private val jsonUrl = "$baseUrl/latest-android.json"
 
+    private val mutableState = MutableStateFlow<UpdateState>(UpdateState.Idle)
+    val state: StateFlow<UpdateState> = mutableState.asStateFlow()
+
     fun checkForUpdates() {
+        // Debug builds carry a "-debug" versionNameSuffix and a different applicationId; the
+        // published release APK is neither an upgrade nor installable over them.
+        if (BuildConfig.DEBUG) return
+
         thread {
             try {
                 val connection = URL(jsonUrl).openConnection() as HttpURLConnection
@@ -46,16 +68,24 @@ class UpdateManager(private val context: Context) {
                     val currentVersion = packageInfo.versionName
 
                     if (compareVersions(metadata.version, currentVersion) > 0) {
-                        downloadAndInstallUpdate(metadata.version)
+                        // Surface it and let the user decide; downloading and firing the system
+                        // installer unprompted is what made this feel like a random intrusion.
+                        mutableState.value = UpdateState.Available(metadata)
                     }
                 }
             } catch (e: Exception) {
-                e.printStackTrace()
+                Log.w(TAG, "Update check failed: ${e.message}")
             }
         }
     }
 
+    fun dismiss() {
+        mutableState.value = UpdateState.Idle
+    }
+
     companion object {
+        private const val TAG = "UpdateManager"
+
         fun parseUpdateMetadata(jsonString: String): MobileUpdateMetadata {
             val json = JSONObject(jsonString)
             return MobileUpdateMetadata(
@@ -71,8 +101,13 @@ class UpdateManager(private val context: Context) {
 
         fun compareVersions(latest: String, current: String?): Int {
             if (current == null) return 1
-            val lParts = latest.split(".").map { it.toIntOrNull() ?: 0 }
-            val cParts = current.split(".").map { it.toIntOrNull() ?: 0 }
+            // Version names carry build suffixes ("1.1.1-debug", "1.2.0-rc1"). Comparing the raw
+            // segment made "1-debug" parse as 0, so every suffixed build looked out of date.
+            fun parts(value: String) = value.trim().split(".")
+                .map { segment -> segment.takeWhile(Char::isDigit).toIntOrNull() ?: 0 }
+
+            val lParts = parts(latest)
+            val cParts = parts(current)
 
             val length = maxOf(lParts.size, cParts.size)
             for (i in 0 until length) {
@@ -85,12 +120,18 @@ class UpdateManager(private val context: Context) {
         }
     }
 
-    private fun downloadAndInstallUpdate(version: String) {
-        val apkUrl = "$baseUrl/orchard-$version.apk"
-        val fileName = "orchard-$version.apk"
+    fun downloadAndInstallUpdate(metadata: MobileUpdateMetadata) {
+        val version = metadata.version
+        // The published asset is not always named the way we would guess (it is "Orchard-x.y.z.apk",
+        // not "orchard-x.y.z.apk"), so honour the URL the manifest gives us. Guessing produced a 404
+        // whose HTML body got saved as the .apk, which is why installs failed to parse.
+        val apkUrl = metadata.apkUrl.ifBlank { "$baseUrl/Orchard-$version.apk" }
+        val fileName = "Orchard-$version.apk"
         val destination = File(context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS), fileName)
 
         if (destination.exists()) destination.delete()
+
+        mutableState.value = UpdateState.Downloading(version)
 
         val request = DownloadManager.Request(Uri.parse(apkUrl))
             .setTitle("Orchard Update")
@@ -106,15 +147,55 @@ class UpdateManager(private val context: Context) {
         val onComplete = object : BroadcastReceiver() {
             override fun onReceive(ctxt: Context, intent: Intent) {
                 val id = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1)
-                if (id == downloadId) {
-                    context.unregisterReceiver(this)
-                    installApk(destination)
+                if (id != downloadId) return
+                context.unregisterReceiver(this)
+
+                // ACTION_DOWNLOAD_COMPLETE fires for failures too. Handing a failed download to
+                // the installer is what produced "problem parsing the package".
+                val status = downloadManager.query(DownloadManager.Query().setFilterById(downloadId))
+                    ?.use { cursor -> if (cursor.moveToFirst()) cursor.statusOf() else null }
+
+                if (status != DownloadManager.STATUS_SUCCESSFUL) {
+                    Log.w(TAG, "Update download failed for $version (status=$status)")
+                    destination.delete()
+                    mutableState.value = UpdateState.Failed(version, "The download did not complete.")
+                    return
                 }
+
+                if (metadata.sha256.isNotBlank()) {
+                    val actual = sha256Of(destination)
+                    if (!actual.equals(metadata.sha256, ignoreCase = true)) {
+                        Log.w(TAG, "Update checksum mismatch for $version: expected ${metadata.sha256}, got $actual")
+                        destination.delete()
+                        mutableState.value =
+                            UpdateState.Failed(version, "The downloaded file did not match its checksum.")
+                        return
+                    }
+                }
+
+                mutableState.value = UpdateState.ReadyToInstall(version)
+                installApk(destination)
             }
         }
-        
+
         context.registerReceiver(onComplete, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE), Context.RECEIVER_EXPORTED)
     }
+
+    private fun Cursor.statusOf(): Int =
+        getInt(getColumnIndexOrThrow(DownloadManager.COLUMN_STATUS))
+
+    private fun sha256Of(file: File): String = runCatching {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { stream ->
+            val buffer = ByteArray(64 * 1024)
+            while (true) {
+                val read = stream.read(buffer)
+                if (read <= 0) break
+                digest.update(buffer, 0, read)
+            }
+        }
+        digest.digest().joinToString("") { "%02x".format(it) }
+    }.getOrDefault("")
 
     private fun installApk(apkFile: File) {
         val uri = FileProvider.getUriForFile(context, "${context.packageName}.provider", apkFile)

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardApp.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardApp.kt
@@ -269,6 +269,7 @@ private fun OrchardNavigation(
                 discordAuth = discordAuth,
                 discordConnection = discordConnection,
                 onSettings = viewModel::updateSettings,
+                onAutoplayEnabled = viewModel::setAutoplayEnabled,
                 onSignIn = { nav.navigate(Routes.LOGIN) },
                 onSwitchAccount = { nav.navigate(Routes.ACCOUNT_SWITCH) },
                 onSignOut = viewModel::signOut,
@@ -376,7 +377,13 @@ private fun OrchardNavigation(
             val liked = playback.currentTrack?.let { track -> library.likedTracks.any { it.id == track.id } } == true
             val transition by viewModel.transitionMarker.collectAsStateWithLifecycle()
             val activeBitrate by viewModel.activeBitrate.collectAsStateWithLifecycle()
+            val autoplayLoading by viewModel.autoplayLoading.collectAsStateWithLifecycle()
+            val autoplayError by viewModel.autoplayError.collectAsStateWithLifecycle()
             NowPlayingScreen(
+                autoplayEnabled = settings.autoplayEnabled,
+                autoplayLoading = autoplayLoading,
+                autoplayError = autoplayError,
+                onAutoplayEnabled = viewModel::setAutoplayEnabled,
                 playback = playback,
                 transition = transition,
                 targets = targets,

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardApp.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardApp.kt
@@ -74,6 +74,7 @@ fun OrchardApp(viewModel: OrchardViewModel) {
     val settings by viewModel.settings.collectAsStateWithLifecycle()
     val shareState by viewModel.shareState.collectAsStateWithLifecycle()
     val warning by viewModel.warning.collectAsStateWithLifecycle()
+    val updateState by viewModel.updateState.collectAsStateWithLifecycle()
     val transitionMarker by viewModel.transitionMarker.collectAsStateWithLifecycle()
     val fullPlayer = route == Routes.NOW_PLAYING
     val chromeHidden = fullPlayer || route == Routes.DEVICES || route == Routes.LOGIN || route == Routes.ACCOUNT_SWITCH || route == Routes.WELCOME
@@ -124,6 +125,12 @@ fun OrchardApp(viewModel: OrchardViewModel) {
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .zIndex(100f),
+            )
+
+            dev.sfg.orchard.mobile.ui.components.UpdateDialog(
+                state = updateState,
+                onInstall = viewModel::installUpdate,
+                onDismiss = viewModel::dismissUpdate,
             )
         }
     }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardViewModel.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardViewModel.kt
@@ -175,6 +175,30 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
         if (id.isNotBlank()) removeTrackFromPlaylist(id, track)
     }
 
+    /**
+     * Autoplay: once the queue is nearly out, ask YouTube Music what would come next after the last
+     * queued track and append it. Only the local player is refilled, because a Connect device owns
+     * its own queue and would fight us for it.
+     */
+    private val mutableAutoplayLoading = MutableStateFlow(false)
+    val autoplayLoading: StateFlow<Boolean> = mutableAutoplayLoading.asStateFlow()
+    private val mutableAutoplayError = MutableStateFlow("")
+    val autoplayError: StateFlow<String> = mutableAutoplayError.asStateFlow()
+
+    /** Seed of the request in flight, so a burst of queue updates cannot fan out into duplicates. */
+    private var autoplaySeedInFlight = ""
+
+    /** Seed that already came back with nothing usable; retrying it would fail the same way. */
+    private var autoplayExhaustedSeed = ""
+
+    /**
+     * Whether refills are allowed, tracked separately from the persisted setting because DataStore
+     * writes land asynchronously. Reading the setting here would let the refill observer see a
+     * stale `true` in the moment after switching off — emptying the queue and immediately refilling
+     * it from the same radio.
+     */
+    private val autoplayGate = MutableStateFlow(settings.value.autoplayEnabled)
+
     private val mutableWarning = MutableStateFlow("")
     val warning: StateFlow<String> = mutableWarning.asStateFlow()
     private var warningDismissJob: Job? = null
@@ -197,6 +221,7 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
         observeAuthentication()
         observeDiscordPresence()
         observeWarnings()
+        observeAutoplay()
     }
 
     private fun observeNetworkState() {
@@ -410,6 +435,88 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
         { if (connectProtocolVersion.value >= 2) graph.connect.clearUpcoming() },
         local::clearUpcoming,
     )
+
+    fun setAutoplayEnabled(enabled: Boolean) {
+        autoplayGate.value = enabled
+        graph.settings.updateSettings(settings.value.copy(autoplayEnabled = enabled))
+        if (enabled) return
+        // Turning it off should undo what it added, not leave the queue full of unasked-for music.
+        mutableAutoplayError.value = ""
+        autoplayExhaustedSeed = ""
+        if (targets.value.selected !is PlaybackTarget.LocalPhone) return
+        val upcoming = playback.value.upcoming
+        val kept = upcoming.filterNot(Track::autoplayGenerated)
+        if (kept.size != upcoming.size) local.replaceUpcoming(kept)
+    }
+
+    private data class AutoplayTrigger(
+        val seedId: String,
+        val remaining: Int,
+        val enabled: Boolean,
+        val isLocal: Boolean,
+    )
+
+    private fun observeAutoplay() {
+        // Persisted changes from anywhere else (the Settings screen, the first DataStore read)
+        // still have to reach the gate.
+        viewModelScope.launch {
+            settings.map { it.autoplayEnabled }
+                .distinctUntilChanged()
+                .collect { autoplayGate.value = it }
+        }
+        viewModelScope.launch {
+            combine(playback, autoplayGate, targets) { snapshot, enabled, target ->
+                val upcoming = snapshot.upcoming
+                AutoplayTrigger(
+                    // The tail of the queue is the seed: recommendations should follow the music the
+                    // listener will actually reach, not the track playing several songs earlier.
+                    seedId = upcoming.lastOrNull()?.id.orEmpty().ifBlank { snapshot.currentTrack?.id.orEmpty() },
+                    remaining = upcoming.size,
+                    enabled = enabled,
+                    isLocal = target.selected is PlaybackTarget.LocalPhone,
+                )
+            }
+                // Playback ticks every second; without this the refill check would run with it.
+                .distinctUntilChanged()
+                .collect(::refillAutoplay)
+        }
+    }
+
+    private fun refillAutoplay(trigger: AutoplayTrigger) {
+        if (!trigger.enabled || !trigger.isLocal) return
+        if (trigger.remaining > AUTOPLAY_REFILL_THRESHOLD) return
+        if (trigger.seedId.isBlank() || !isOnline.value) return
+        if (trigger.seedId == autoplaySeedInFlight || trigger.seedId == autoplayExhaustedSeed) return
+
+        autoplaySeedInFlight = trigger.seedId
+        mutableAutoplayLoading.value = true
+        mutableAutoplayError.value = ""
+        viewModelScope.launch {
+            runCatching { graph.catalog.upNext(trigger.seedId) }
+                .onSuccess { candidates -> appendAutoplayTracks(trigger.seedId, candidates) }
+                .onFailure { mutableAutoplayError.value = it.message ?: "Could not load Autoplay recommendations." }
+            mutableAutoplayLoading.value = false
+            autoplaySeedInFlight = ""
+        }
+    }
+
+    private fun appendAutoplayTracks(seedId: String, candidates: List<Track>) {
+        // Re-read the queue rather than trusting the trigger: the listener may have queued
+        // something, or skipped, while the request was in the air.
+        val snapshot = playback.value
+        val known = snapshot.queue.mapTo(mutableSetOf(), Track::id)
+        snapshot.currentTrack?.id?.let(known::add)
+        val additions = candidates
+            .filter { it.id.isNotBlank() && known.add(it.id) }
+            .take(AUTOPLAY_QUEUE_LIMIT)
+            .map { it.copy(autoplayGenerated = true) }
+        if (additions.isEmpty()) {
+            autoplayExhaustedSeed = seedId
+            mutableAutoplayError.value = "No more recommendations were found."
+            return
+        }
+        local.replaceUpcoming((snapshot.upcoming + additions).take(AUTOPLAY_TOTAL_LIMIT))
+    }
 
     fun setRemoteVolume(volume: Float) = graph.connect.setVolume(volume)
     fun setAudioEnginePreset(preset: String) = graph.connect.setAudioEnginePreset(preset)
@@ -641,5 +748,10 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
 
     private companion object {
         const val TAG = "OrchardViewModel"
+
+        /** Refill once the queue is this short, so the fetch lands well before the music stops. */
+        const val AUTOPLAY_REFILL_THRESHOLD = 3
+        const val AUTOPLAY_QUEUE_LIMIT = 20
+        const val AUTOPLAY_TOTAL_LIMIT = 100
     }
 }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardViewModel.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardViewModel.kt
@@ -179,6 +179,13 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
     val warning: StateFlow<String> = mutableWarning.asStateFlow()
     private var warningDismissJob: Job? = null
 
+    val updateState: StateFlow<dev.sfg.orchard.mobile.UpdateState> = graph.updates.state
+
+    fun installUpdate(metadata: dev.sfg.orchard.mobile.MobileUpdateMetadata) =
+        graph.updates.downloadAndInstallUpdate(metadata)
+
+    fun dismissUpdate() = graph.updates.dismiss()
+
     init {
         refreshHome()
         observeNetworkState()

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/artwork/ArtworkRepository.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/artwork/ArtworkRepository.kt
@@ -88,7 +88,9 @@ class ArtworkRepository(
                 canvas?.cancel()
                 fromProviders
             } else {
-                canvas?.await() ?: fromProviders
+                // The canvas repo stamps Spotify's own track id; consumers match artwork to the
+                // playing track by *our* id, so re-stamp it or the result is silently discarded.
+                canvas?.await()?.copy(trackId = track.id) ?: fromProviders
             }
         }
         synchronized(cache) { cache[key] = resolved }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/CatalogParser.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/CatalogParser.kt
@@ -59,6 +59,35 @@ object CatalogParser {
         return if (fallback.isEmpty()) emptyList() else listOf(CatalogSection("listen-now", "Listen now", fallback))
     }
 
+    /**
+     * Radio rows out of a `next` response. These ride a panel renderer of their own rather than the
+     * shelf renderers everything else uses, and the byline is one string ("SZA • SOS • 3:02")
+     * instead of separate columns, so it is split back apart for [track] to read.
+     */
+    fun upNext(root: JSONObject): List<Track> =
+        JsonTraversal.renderers(root, "playlistPanelVideoRenderer").mapNotNull { renderer ->
+            val endpoint = JsonTraversal.navigation(renderer)
+            val videoId = renderer.optString("videoId").ifBlank { JsonTraversal.videoId(endpoint) }
+            val title = JsonTraversal.text(renderer.optJSONObject("title"))
+            if (videoId.isBlank() || title.isBlank()) return@mapNotNull null
+            val byline = JsonTraversal.text(renderer.optJSONObject("longBylineText"))
+                .ifBlank { JsonTraversal.text(renderer.optJSONObject("shortBylineText")) }
+            val length = JsonTraversal.text(renderer.optJSONObject("lengthText"))
+            val texts = buildList {
+                add(title)
+                byline.split(" • ", "•").map(String::trim).filterTo(this, String::isNotBlank)
+                if (length.isNotBlank()) add(length)
+            }
+            track(
+                videoId = videoId,
+                title = title,
+                texts = texts,
+                art = JsonTraversal.largestThumbnail(renderer),
+                renderer = renderer,
+                musicVideoType = JsonTraversal.musicVideoType(endpoint),
+            )
+        }
+
     fun sectionItems(root: JSONObject, defaultArtist: String = ""): List<CatalogItem> {
         return allItems(root, defaultArtist).distinctBy(CatalogItem::stableId)
     }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/CatalogRepository.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/CatalogRepository.kt
@@ -58,6 +58,11 @@ class CatalogRepository(private val client: InnerTubeClient) {
         detail.copy(tracks = tracks)
     }
 
+    /** Radio continuation for a seed track, used to keep the queue from running dry. */
+    suspend fun upNext(videoId: String): List<Track> = withContext(Dispatchers.IO) {
+        if (videoId.isBlank()) emptyList() else CatalogParser.upNext(client.upNext(videoId))
+    }
+
     suspend fun likedSongs(): BrowseDetail = browse("FEmusic_liked_videos")
 
     suspend fun sectionItems(browseId: String, params: String = ""): List<dev.sfg.orchard.mobile.model.CatalogItem> = withContext(Dispatchers.IO) {

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/InnerTubeClient.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/InnerTubeClient.kt
@@ -57,6 +57,21 @@ class InnerTubeClient(
         return post("browse", body)
     }
 
+    /**
+     * The radio YouTube Music would roll into after [videoId] finishes.
+     *
+     * `RDAMVM<videoId>` is the mix the web player seeds from a single song, so the result reads as
+     * a continuation of what was just playing rather than a generic recommendation shelf. Audio
+     * only, because Autoplay feeds a music queue and the video cuts run long against the album ones.
+     */
+    fun upNext(videoId: String): JSONObject = post(
+        "next",
+        JSONObject()
+            .put("videoId", videoId)
+            .put("playlistId", "RDAMVM$videoId")
+            .put("isAudioOnly", true),
+    )
+
     fun browseContinuation(token: String): JSONObject =
         post("browse", JSONObject().put("continuation", token))
 

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/model/CatalogJson.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/model/CatalogJson.kt
@@ -36,6 +36,7 @@ object CatalogJson {
         .put("animatedArtworkVerticalUrl", value.animatedArtworkVerticalUrl)
         .put("durationMs", value.durationMs)
         .put("explicit", value.explicit)
+        .put("autoplayGenerated", value.autoplayGenerated)
 
     fun track(value: JSONObject): Track = Track(
         id = value.cleanString("id"),
@@ -49,6 +50,7 @@ object CatalogJson {
         animatedArtworkVerticalUrl = value.cleanString("animatedArtworkVerticalUrl"),
         durationMs = value.optLong("durationMs"),
         explicit = value.optBoolean("explicit"),
+        autoplayGenerated = value.optBoolean("autoplayGenerated"),
     )
 
     fun tracks(values: List<Track>): JSONArray = JSONArray().also { output ->

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/model/CatalogModels.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/model/CatalogModels.kt
@@ -46,6 +46,11 @@ data class Track(
      * user upload. Blank when the payload omitted it.
      */
     val musicVideoType: String = "",
+    /**
+     * True for a track Autoplay appended rather than one the listener queued. Turning Autoplay off
+     * strips exactly these, so the queue returns to what was actually chosen.
+     */
+    val autoplayGenerated: Boolean = false,
 ) {
     /** True for album audio, which is the version a listener expects from an album or search. */
     val isAudioOnly: Boolean

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/model/UiModels.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/model/UiModels.kt
@@ -83,6 +83,8 @@ data class OrchardSettings(
     val spotifyCanvasEnabled: Boolean = true,
     /** Whether to even out volume levels across played tracks. */
     val volumeNormalizationEnabled: Boolean = false,
+    /** Keep playing related music once the queue runs out, matching desktop's default of on. */
+    val autoplayEnabled: Boolean = true,
 ) {
     /** Clamped, because a persisted value from an older build must not size the cache absurdly. */
     val cacheSizeBytes: Long

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/LocalPlaybackController.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/LocalPlaybackController.kt
@@ -139,7 +139,9 @@ class LocalPlaybackController(
         val current = player.currentMediaItemIndex
         val total = player.mediaItemCount
         val from = (current + 1).coerceAtLeast(0)
-        if (from >= total) return@withController
+        // from == total means nothing follows the current track. That is not a no-op case: Autoplay
+        // refills exactly then, and the removal below is empty while the insert still appends.
+        if (from > total) return@withController
         val newMediaItems = tracks.map(MediaItemMapper::toMediaItem)
         player.removeMediaItems(from, total)
         player.addMediaItems(from, newMediaItems)

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/settings/SettingsRepository.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/settings/SettingsRepository.kt
@@ -63,6 +63,7 @@ class SettingsRepository(context: Context, private val scope: CoroutineScope) {
                 spotifySpdc = values[SPOTIFY_SPDC] ?: "",
                 spotifyCanvasEnabled = values[SPOTIFY_CANVAS_ENABLED] ?: true,
                 volumeNormalizationEnabled = values[VOLUME_NORMALIZATION_ENABLED] ?: false,
+                autoplayEnabled = values[AUTOPLAY_ENABLED] ?: true,
             )
         }
         .stateIn(scope, SharingStarted.Eagerly, OrchardSettings())
@@ -90,6 +91,7 @@ class SettingsRepository(context: Context, private val scope: CoroutineScope) {
                 it[SPOTIFY_SPDC] = value.spotifySpdc
                 it[SPOTIFY_CANVAS_ENABLED] = value.spotifyCanvasEnabled
                 it[VOLUME_NORMALIZATION_ENABLED] = value.volumeNormalizationEnabled
+                it[AUTOPLAY_ENABLED] = value.autoplayEnabled
             }
         }
     }
@@ -134,6 +136,7 @@ class SettingsRepository(context: Context, private val scope: CoroutineScope) {
         val SPOTIFY_SPDC = stringPreferencesKey("spotify_spdc")
         val SPOTIFY_CANVAS_ENABLED = booleanPreferencesKey("spotify_canvas_enabled")
         val VOLUME_NORMALIZATION_ENABLED = booleanPreferencesKey("volume_normalization_enabled")
+        val AUTOPLAY_ENABLED = booleanPreferencesKey("autoplay_enabled")
         val SEARCH_HISTORY = stringPreferencesKey("search_history")
     }
 }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/spotify/SpotifyCanvasRepository.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/spotify/SpotifyCanvasRepository.kt
@@ -24,6 +24,8 @@ import android.util.Log
 import dev.sfg.orchard.mobile.artwork.TrackArtwork
 import dev.sfg.orchard.mobile.settings.SettingsRepository
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
@@ -45,6 +47,7 @@ class SpotifyCanvasRepository(
     private val harvester = SpotifyTokenHarvester(context)
     private var cachedAccessToken: String? = null
     private var accessTokenExpiresAt: Long = 0L
+    private val harvestMutex = Mutex()
 
     private var cachedClientToken: String? = null
     private var clientTokenExpiresAt: Long = 0L
@@ -95,17 +98,19 @@ class SpotifyCanvasRepository(
         )
     }
 
-    private suspend fun getAccessToken(spdc: String): String? {
-        if (System.currentTimeMillis() < accessTokenExpiresAt && !cachedAccessToken.isNullOrBlank()) {
-            return cachedAccessToken
+    private suspend fun getAccessToken(spdc: String): String? = harvestMutex.withLock {
+        if (System.currentTimeMillis() + TOKEN_REFRESH_MARGIN_MS < accessTokenExpiresAt &&
+            !cachedAccessToken.isNullOrBlank()
+        ) {
+            return@withLock cachedAccessToken
         }
 
-        val token = harvester.harvestAccessToken(spdc)
-        if (!token.isNullOrBlank()) {
-            cachedAccessToken = token
-            accessTokenExpiresAt = System.currentTimeMillis() + 3500_000L
+        val harvested = harvester.harvestAccessToken(spdc)
+        if (harvested != null) {
+            cachedAccessToken = harvested.token
+            accessTokenExpiresAt = harvested.expiresAt
         }
-        return token
+        harvested?.token
     }
 
     private fun getClientToken(): String? {
@@ -132,11 +137,17 @@ class SpotifyCanvasRepository(
                 .header("Accept", "application/json")
                 .header("Content-Type", "application/json")
                 .header("User-Agent", SpotifyTokenHarvester.BROWSER_USER_AGENT)
-                .post(jsonBody.toRequestBody("application/json".toMediaType()))
+                // Deliberately the ByteArray overload: the String overload rewrites the
+                // Content-Type to "application/json; charset=utf-8", which clienttoken
+                // rejects with a bare 400.
+                .post(jsonBody.toByteArray(Charsets.UTF_8).toRequestBody("application/json".toMediaType()))
                 .build()
 
             http.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return null
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "Spotify client token rejected: ${response.code} ${response.body.string().take(300)}")
+                    return null
+                }
                 val data = JSONObject(response.body.string())
                 val token = data.optJSONObject("granted_token")?.optString("token")
                 if (!token.isNullOrBlank()) {
@@ -145,7 +156,7 @@ class SpotifyCanvasRepository(
                     token
                 } else null
             }
-        }.getOrNull()
+        }.onFailure { Log.w(TAG, "Spotify client token failed: ${it.message}") }.getOrNull()
     }
 
     private fun searchSpotifyTrackId(accessToken: String, title: String, artist: String, clientToken: String): String? {
@@ -162,7 +173,10 @@ class SpotifyCanvasRepository(
                 .build()
 
             http.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return null
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "Spotify search rejected: ${response.code} ${response.body.string().take(200)}")
+                    return null
+                }
                 val data = JSONObject(response.body.string())
                 val items = data.optJSONObject("tracks")?.optJSONArray("items") ?: return null
                 if (items.length() == 0) return null
@@ -177,7 +191,7 @@ class SpotifyCanvasRepository(
                 }
                 items.optJSONObject(0)?.optString("id")
             }
-        }.getOrNull()
+        }.onFailure { Log.w(TAG, "Spotify search failed: ${it.message}") }.getOrNull()
     }
 
     private fun searchViaPathfinder(searchTerm: String, accessToken: String, clientToken: String): String? {
@@ -215,7 +229,10 @@ class SpotifyCanvasRepository(
                 .build()
 
             http.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return null
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "Spotify pathfinder rejected: ${response.code} ${response.body.string().take(200)}")
+                    return null
+                }
                 val root = JSONObject(response.body.string())
                 val items = root.optJSONObject("data")
                     ?.optJSONObject("searchV2")
@@ -229,7 +246,7 @@ class SpotifyCanvasRepository(
                 val uri = firstItem.optString("uri")
                 if (uri.isNotBlank()) uri.split(":").lastOrNull() else null
             }
-        }.getOrNull()
+        }.onFailure { Log.w(TAG, "Spotify pathfinder failed: ${it.message}") }.getOrNull()
     }
 
     private fun fetchSpotifyCanvasUrl(trackId: String, accessToken: String, clientToken: String): String? {
@@ -250,18 +267,25 @@ class SpotifyCanvasRepository(
                 .build()
 
             http.newCall(request).execute().use { response ->
-                if (!response.isSuccessful) return null
+                if (!response.isSuccessful) {
+                    Log.w(TAG, "Spotify canvaz rejected: ${response.code} ${response.body.string().take(200)}")
+                    return null
+                }
                 val bytes = response.body.bytes()
                 val text = String(bytes, Charsets.ISO_8859_1)
-                CANVAS_URL_REGEX.find(text)?.value
+                CANVAS_URL_REGEX.find(text)?.value.also {
+                    // An empty body is a legitimate answer: most tracks have no canvas.
+                    if (it == null) Log.i(TAG, "Spotify canvas: no video for $trackId (${bytes.size} byte response)")
+                }
             }
-        }.getOrNull()
+        }.onFailure { Log.w(TAG, "Spotify canvas fetch failed: ${it.message}") }.getOrNull()
     }
 
     companion object {
         const val CANVAS_USER_AGENT = "Spotify/9.0.34.593 iOS/18.4 (iPhone15,3)"
         private val CANVAS_URL_REGEX = Regex("https://[^\"'\\s\\x00-\\x1F]+\\.cnvs\\.mp4")
         private const val TAG = "SpotifyCanvasRepository"
+        private const val TOKEN_REFRESH_MARGIN_MS = 60_000L
 
         fun extractSpdc(cookieInput: String): String {
             val str = cookieInput.trim()

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/spotify/SpotifyTokenHarvester.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/spotify/SpotifyTokenHarvester.kt
@@ -23,30 +23,50 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.util.Log
 import android.webkit.CookieManager
+import android.webkit.JavascriptInterface
+import android.webkit.WebStorage
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 
+/** An access token as minted by the Spotify web player, with its own expiry. */
+data class HarvestedToken(val token: String, val expiresAt: Long)
+
 /**
  * Harvests Spotify Web Access Tokens using the logged-in sp_dc session cookie
- * via an offscreen WebView context on Android.
+ * via an offscreen WebView on Android.
+ *
+ * Spotify retired the old get_access_token endpoint, and its replacement
+ * (/api/token) rejects requests that are not signed the way its own web player
+ * signs them. So rather than forge that signature we load the real web player
+ * offscreen and read the token it obtains for itself, by hooking fetch/XHR in
+ * the page before its own scripts run. This mirrors what the desktop build does
+ * over CDP in electron/integrations/spotify.js.
  */
 class SpotifyTokenHarvester(private val context: Context) {
 
-    @SuppressLint("SetJavaScriptEnabled")
-    suspend fun harvestAccessToken(spdcToken: String): String? = withContext(Dispatchers.Main) {
+    @SuppressLint("SetJavaScriptEnabled", "AddJavascriptInterface")
+    suspend fun harvestAccessToken(spdcToken: String): HarvestedToken? = withContext(Dispatchers.Main) {
         if (spdcToken.isBlank()) return@withContext null
-        val deferred = CompletableDeferred<String?>()
+        val deferred = CompletableDeferred<HarvestedToken?>()
 
         val cookieManager = CookieManager.getInstance().apply {
             setAcceptCookie(true)
-            setCookie("https://.spotify.com", "sp_dc=$spdcToken; Domain=.spotify.com; Path=/; Secure; HttpOnly")
+            setCookie("https://open.spotify.com/", "sp_dc=$spdcToken; Domain=.spotify.com; Path=/; Secure")
+            setCookie("https://accounts.spotify.com/", "sp_dc=$spdcToken; Domain=.spotify.com; Path=/; Secure")
             flush()
         }
+
+        // The player caches its access token in web storage and will not re-request
+        // /api/token if a live one is already there — leaving the hook with nothing
+        // to observe. Wiping storage forces a fresh mint on every harvest.
+        runCatching { WebStorage.getInstance().deleteAllData() }
 
         var webView: WebView? = null
         try {
@@ -56,10 +76,37 @@ class SpotifyTokenHarvester(private val context: Context) {
                 settings.userAgentString = BROWSER_USER_AGENT
                 cookieManager.setAcceptThirdPartyCookies(this, true)
 
+                addJavascriptInterface(TokenBridge(deferred), BRIDGE_NAME)
+
+                // The hook has to be installed before the page's own bundle runs,
+                // otherwise the token request has already gone out by the time we
+                // patch fetch. addDocumentStartJavaScript guarantees that ordering;
+                // onPageStarted injection is the best-effort fallback without it.
+                val documentStartSupported =
+                    WebViewFeature.isFeatureSupported(WebViewFeature.DOCUMENT_START_SCRIPT)
+                if (documentStartSupported) {
+                    runCatching {
+                        WebViewCompat.addDocumentStartJavaScript(
+                            this,
+                            HOOK_SCRIPT,
+                            setOf("https://open.spotify.com"),
+                        )
+                    }
+                }
+
                 webViewClient = object : WebViewClient() {
+                    override fun onPageStarted(view: WebView, url: String?, favicon: android.graphics.Bitmap?) {
+                        super.onPageStarted(view, url, favicon)
+                        if (!documentStartSupported) {
+                            view.evaluateJavascript(HOOK_SCRIPT, null)
+                        }
+                    }
+
                     override fun onPageFinished(view: WebView, url: String?) {
                         super.onPageFinished(view, url)
-                        evaluateTokenFetch(view, deferred)
+                        // Re-assert the hook in case the player navigated client-side
+                        // after our document-start injection ran.
+                        view.evaluateJavascript(HOOK_SCRIPT, null)
                     }
                 }
 
@@ -68,32 +115,35 @@ class SpotifyTokenHarvester(private val context: Context) {
 
             withTimeoutOrNull(HARVEST_TIMEOUT_MS) {
                 deferred.await()
-            }
+            }.also { if (it == null) Log.w(TAG, "Spotify token harvest timed out") }
         } catch (e: Exception) {
             Log.w(TAG, "Spotify token harvest failed: ${e.message}")
             null
         } finally {
             runCatching {
+                webView?.removeJavascriptInterface(BRIDGE_NAME)
                 webView?.stopLoading()
                 webView?.destroy()
             }
         }
     }
 
-    private fun evaluateTokenFetch(view: WebView, deferred: CompletableDeferred<String?>) {
-        val script = "(function(){ fetch('/api/token').then(r=>r.json()).then(d=>JSON.stringify(d)).catch(e=>''); })()"
-        view.evaluateJavascript(script) { result ->
-            if (result.isNullOrBlank() || result == "null") return@evaluateJavascript
+    /** Receives raw /api/token response bodies from the hooked page. */
+    private class TokenBridge(private val deferred: CompletableDeferred<HarvestedToken?>) {
+        @JavascriptInterface
+        fun onTokenPayload(payload: String?) {
+            if (payload.isNullOrBlank()) return
             runCatching {
-                val jsonStr = if (result.startsWith("\"") && result.endsWith("\"")) {
-                    JSONObject("{\"val\":$result}").getString("val")
-                } else result
-                val json = JSONObject(jsonStr)
+                val json = JSONObject(payload)
                 val token = json.optString("accessToken")
-                val isAnon = json.optBoolean("isAnonymous", false)
-                if (token.isNotBlank() && !isAnon) {
-                    deferred.complete(token)
-                }
+                // The player also mints an anonymous token before the cookie is
+                // applied; that one cannot read canvases, so keep waiting for the
+                // logged-in one.
+                if (token.isBlank() || json.optBoolean("isAnonymous", false)) return
+                val expiresAt = json.optLong("accessTokenExpirationTimestampMs")
+                    .takeIf { it > System.currentTimeMillis() }
+                    ?: (System.currentTimeMillis() + DEFAULT_TOKEN_LIFETIME_MS)
+                deferred.complete(HarvestedToken(token, expiresAt))
             }
         }
     }
@@ -101,6 +151,53 @@ class SpotifyTokenHarvester(private val context: Context) {
     companion object {
         const val BROWSER_USER_AGENT = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36 Edg/135.0.0.0"
         private const val HARVEST_TIMEOUT_MS = 20_000L
+        private const val DEFAULT_TOKEN_LIFETIME_MS = 3_600_000L
+        private const val BRIDGE_NAME = "OrchardTokenBridge"
         private const val TAG = "SpotifyTokenHarvester"
+
+        private val HOOK_SCRIPT = """
+            (function () {
+              if (window.__orchardTokenHook) return;
+              window.__orchardTokenHook = true;
+              var report = function (body) {
+                try { $BRIDGE_NAME.onTokenPayload(body); } catch (e) {}
+              };
+              var isToken = function (u) {
+                try { return String(u).indexOf('/api/token') !== -1; } catch (e) { return false; }
+              };
+              var origFetch = window.fetch;
+              if (origFetch) {
+                window.fetch = function (input, init) {
+                  var url = (input && input.url) ? input.url : input;
+                  var result = origFetch.apply(this, arguments);
+                  if (isToken(url)) {
+                    try {
+                      result.then(function (res) {
+                        res.clone().text().then(report).catch(function () {});
+                      }).catch(function () {});
+                    } catch (e) {}
+                  }
+                  return result;
+                };
+              }
+              var origOpen = XMLHttpRequest.prototype.open;
+              XMLHttpRequest.prototype.open = function (method, url) {
+                this.__orchardUrl = url;
+                return origOpen.apply(this, arguments);
+              };
+              var origSend = XMLHttpRequest.prototype.send;
+              XMLHttpRequest.prototype.send = function () {
+                var xhr = this;
+                try {
+                  xhr.addEventListener('load', function () {
+                    if (isToken(xhr.__orchardUrl)) {
+                      try { report(xhr.responseText); } catch (e) {}
+                    }
+                  });
+                } catch (e) {}
+                return origSend.apply(this, arguments);
+              };
+            })();
+        """.trimIndent()
     }
 }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/ArtistSectionBottomSheet.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/ArtistSectionBottomSheet.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -129,7 +130,7 @@ fun ArtistSectionBottomSheet(
                 contentPadding = PaddingValues(bottom = 32.dp),
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                items(displayItems, key = { it.stableId }) { item ->
+                itemsIndexed(displayItems, key = { index, it -> "${it.stableId}_$index" }) { _, item ->
                     CatalogCard(
                         item = item,
                         onClick = {

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/PlayerChrome.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/PlayerChrome.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -131,6 +132,10 @@ fun OrchardBottomBar(currentRoute: String?, onSelect: (String) -> Unit) {
         NavigationBar(
             containerColor = Color.Transparent,
             tonalElevation = 0.dp,
+            // The Scaffold already insets the whole chrome column above the system navigation bar.
+            // Letting the bar apply that inset a second time would eat into its fixed 64dp height,
+            // which squashed the icons and labels under 3-button navigation.
+            windowInsets = WindowInsets(0),
             modifier = Modifier.height(64.dp)
         ) {
                 destinations.forEach { destination ->

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/UpdateDialog.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/components/UpdateDialog.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.ui.components
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import dev.sfg.orchard.mobile.MobileUpdateMetadata
+import dev.sfg.orchard.mobile.UpdateState
+import dev.sfg.orchard.mobile.ui.theme.CanopyColors
+import dev.sfg.orchard.mobile.ui.theme.LocalAccent
+
+/**
+ * In-app update prompt. The system package installer is only ever launched after the user
+ * has agreed here, so an update never arrives as an unexplained "install this package?".
+ */
+@Composable
+fun UpdateDialog(
+    state: UpdateState,
+    onInstall: (MobileUpdateMetadata) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    when (state) {
+        UpdateState.Idle, is UpdateState.ReadyToInstall -> Unit
+
+        is UpdateState.Available -> {
+            val metadata = state.metadata
+            val heading = buildString {
+                append("Orchard ")
+                append(metadata.version)
+                if (metadata.codename.isNotBlank()) append(" \"${metadata.codename}\"")
+            }
+            AlertDialog(
+                onDismissRequest = onDismiss,
+                title = { Text("Update available", color = CanopyColors.Text) },
+                text = {
+                    Column(Modifier.heightIn(max = 320.dp).verticalScroll(rememberScrollState())) {
+                        Text(
+                            heading,
+                            style = MaterialTheme.typography.titleSmall,
+                            color = CanopyColors.Text,
+                        )
+                        if (metadata.releaseNotes.isNotBlank()) {
+                            Spacer(Modifier.height(8.dp))
+                            Text(
+                                metadata.releaseNotes.stripMarkdown(),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = CanopyColors.Muted,
+                            )
+                        }
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { onInstall(metadata) }) {
+                        Text("Update", color = LocalAccent.current)
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = onDismiss) {
+                        Text("Not now", color = CanopyColors.Muted)
+                    }
+                },
+            )
+        }
+
+        is UpdateState.Downloading -> AlertDialog(
+            onDismissRequest = {},
+            title = { Text("Downloading update", color = CanopyColors.Text) },
+            text = {
+                Column {
+                    Text(
+                        "Fetching Orchard ${state.version}. You can keep using the app; " +
+                            "the installer opens when it finishes.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = CanopyColors.Muted,
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    LinearProgressIndicator(
+                        modifier = Modifier.heightIn(min = 4.dp),
+                        color = LocalAccent.current,
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = onDismiss) {
+                    Text("Hide", color = CanopyColors.Muted)
+                }
+            },
+        )
+
+        is UpdateState.Failed -> AlertDialog(
+            onDismissRequest = onDismiss,
+            title = { Text("Update failed", color = CanopyColors.Text) },
+            text = {
+                Text(
+                    "${state.reason} Orchard ${state.version} was not installed.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = CanopyColors.Muted,
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = onDismiss) {
+                    Text("OK", color = LocalAccent.current)
+                }
+            },
+        )
+    }
+}
+
+/** The release notes are authored as markdown for the web changelog; flatten the syntax. */
+private fun String.stripMarkdown(): String = lineSequence()
+    .map { line ->
+        line.trim()
+            .removePrefix("###").removePrefix("##").removePrefix("#")
+            .replace("**", "")
+            .replace(Regex("^- "), "• ")
+            .trim()
+    }
+    .filter { it.isNotBlank() }
+    .joinToString("\n")

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/DetailScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/DetailScreen.kt
@@ -257,7 +257,9 @@ private fun ArtistDetailContent(
                     } else null,
                 )
             }
-            itemsIndexed(displayedTracks, key = { _, track -> track.id }) { index, track ->
+            // A collection may legitimately list the same track twice, so the id alone is not
+            // a unique key and LazyColumn throws the moment the duplicate scrolls in.
+            itemsIndexed(displayedTracks, key = { index, track -> "${track.id}_$index" }) { index, track ->
                 val trackIndex = detail.tracks.indexOf(track).coerceAtLeast(index)
                 val isDownloaded = downloadedTrackIds.contains(track.id)
                 val isDownloading = downloadingTrackIds.contains(track.id)
@@ -304,7 +306,7 @@ private fun ArtistDetailContent(
                         contentPadding = PaddingValues(horizontal = 16.dp),
                         horizontalArrangement = Arrangement.spacedBy(14.dp),
                     ) {
-                        items(section.items, key = { it.stableId }) { item ->
+                        itemsIndexed(section.items, key = { index, it -> "${it.stableId}_$index" }) { _, item ->
                             CatalogCard(item, onClick = { onOpen(item.stableId) })
                         }
                     }
@@ -331,7 +333,7 @@ private fun ArtistDetailContent(
                     contentPadding = PaddingValues(horizontal = 16.dp),
                     horizontalArrangement = Arrangement.spacedBy(14.dp),
                 ) {
-                    items(detail.related, key = { it.stableId }) { item ->
+                    itemsIndexed(detail.related, key = { index, it -> "${it.stableId}_$index" }) { _, item ->
                         CatalogCard(item, onClick = { onOpen(item.stableId) })
                     }
                 }
@@ -406,7 +408,7 @@ private fun CollectionDetailContent(
                 )
             }
             if (detail.tracks.isNotEmpty()) {
-                itemsIndexed(detail.tracks, key = { _, track -> track.id }) { index, track ->
+                itemsIndexed(detail.tracks, key = { index, track -> "${track.id}_$index" }) { index, track ->
                     val isAlbum = detail.kind == CatalogKind.ALBUM
                     val isDownloaded = downloadedTrackIds.contains(track.id)
                     val isDownloading = downloadingTrackIds.contains(track.id)
@@ -485,7 +487,7 @@ private fun CollectionDetailContent(
                         contentPadding = PaddingValues(horizontal = 20.dp),
                         horizontalArrangement = Arrangement.spacedBy(14.dp),
                     ) {
-                        items(detail.related, key = { it.stableId }) { item ->
+                        itemsIndexed(detail.related, key = { index, it -> "${it.stableId}_$index" }) { _, item ->
                             CatalogCard(item, { onOpen(item.stableId) })
                         }
                     }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/LibraryScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/LibraryScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -247,7 +248,7 @@ private fun LazyListScope.songs(
         return
     }
     item { OrchardSectionHeader(title) }
-    items(values, key = Track::id) { track ->
+    itemsIndexed(values, key = { index, track -> "${track.id}_$index" }) { _, track ->
         TrackRow(
             track = track,
             onPlay = { onPlay(track) },
@@ -334,7 +335,7 @@ private fun LazyListScope.tracks(
         return
     }
     item { OrchardSectionHeader(title) }
-    items(values, key = Track::id) { track ->
+    itemsIndexed(values, key = { index, track -> "${track.id}_$index" }) { _, track ->
         val isDownloaded = downloadedTrackIds.contains(track.id)
         val isDownloading = downloadingTrackIds.contains(track.id)
         TrackRow(

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/NowPlayingScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/NowPlayingScreen.kt
@@ -111,6 +111,10 @@ fun NowPlayingScreen(
     onAddToPlaylist: ((Track) -> Unit)? = null,
     onShare: (() -> Unit)? = null,
     onOpenCollection: ((String) -> Unit)? = null,
+    autoplayEnabled: Boolean = true,
+    autoplayLoading: Boolean = false,
+    autoplayError: String = "",
+    onAutoplayEnabled: ((Boolean) -> Unit)? = null,
 ) {
     // Lyrics and the queue are modes of the player, not destinations, so their state lives here.
     // Only one can hold the panel at a time.
@@ -241,6 +245,10 @@ fun NowPlayingScreen(
                 onOpenCollection = onOpenCollection,
                 onLyricsPanel = { panel = if (lyricsOpen) PlayerPanel.NONE else PlayerPanel.LYRICS },
                 onQueuePanel = onQueue,
+                autoplayEnabled = autoplayEnabled,
+                autoplayLoading = autoplayLoading,
+                autoplayError = autoplayError,
+                onAutoplayEnabled = onAutoplayEnabled,
             )
             return@Box
         }
@@ -298,6 +306,10 @@ fun NowPlayingScreen(
                             onMove = onMoveQueueItem,
                             onClearUpcoming = onClearUpcoming,
                             onShuffleUpcoming = onShuffle,
+                            autoplayEnabled = autoplayEnabled,
+                            autoplayLoading = autoplayLoading,
+                            autoplayError = autoplayError,
+                            onAutoplayEnabled = onAutoplayEnabled,
                         )
                         return@Box
                     }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/PlayerQueue.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/PlayerQueue.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.AllInclusive
 import androidx.compose.material.icons.rounded.ClearAll
 import androidx.compose.material.icons.rounded.DeleteOutline
 import androidx.compose.material.icons.rounded.KeyboardArrowDown
@@ -42,6 +43,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -73,6 +76,10 @@ fun PlayerQueuePanel(
     onMove: (Int, Int) -> Unit,
     onClearUpcoming: () -> Unit,
     onShuffleUpcoming: (() -> Unit)? = null,
+    autoplayEnabled: Boolean = true,
+    autoplayLoading: Boolean = false,
+    autoplayError: String = "",
+    onAutoplayEnabled: ((Boolean) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val history = playback.history.takeLast(4)
@@ -83,8 +90,17 @@ fun PlayerQueuePanel(
         initialFirstVisibleItemIndex = remember { if (history.isEmpty()) 0 else history.size + 1 },
     )
     if (playback.queue.isEmpty()) {
-        Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            QueueNotice("Queue is empty", "Play an album, playlist, or song to get started.")
+        Box(modifier.fillMaxSize()) {
+            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                QueueNotice("Queue is empty", "Play an album, playlist, or song to get started.")
+            }
+            AutoplayFooter(
+                enabled = autoplayEnabled,
+                loading = autoplayLoading,
+                error = autoplayError,
+                onEnabled = onAutoplayEnabled,
+                modifier = Modifier.align(Alignment.BottomCenter),
+            )
         }
         return
     }
@@ -133,6 +149,73 @@ fun PlayerQueuePanel(
                 onPlay = { onPlayIndex(index) }, onRemove = onRemove, onMove = onMove,
             )
         }
+        item {
+            AutoplayFooter(
+                enabled = autoplayEnabled,
+                loading = autoplayLoading,
+                error = autoplayError,
+                onEnabled = onAutoplayEnabled,
+            )
+        }
+    }
+}
+
+/**
+ * Mirrors desktop's queue-panel footer: the same switch as Settings, plus whatever Autoplay is
+ * currently doing. The status line is the only place a listener finds out that recommendations are
+ * loading or that the radio ran out, so it stays visible even when the queue is empty.
+ */
+@Composable
+private fun AutoplayFooter(
+    enabled: Boolean,
+    loading: Boolean,
+    error: String,
+    onEnabled: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier
+            .fillMaxWidth()
+            .padding(start = 20.dp, end = 12.dp, top = 14.dp, bottom = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            Icons.Rounded.AllInclusive,
+            contentDescription = null,
+            tint = Color.White.copy(alpha = 0.7f),
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(Modifier.width(14.dp))
+        Column(Modifier.weight(1f)) {
+            Text(
+                "Autoplay",
+                style = MaterialTheme.typography.titleSmall.copy(fontWeight = FontWeight.SemiBold),
+                color = Color.White,
+            )
+            Text(
+                when {
+                    !enabled -> "Off"
+                    loading -> "Finding more music…"
+                    error.isNotBlank() -> error
+                    else -> "Keep the music going"
+                },
+                style = MaterialTheme.typography.bodySmall,
+                color = Color.White.copy(alpha = 0.6f),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+        Switch(
+            checked = enabled,
+            onCheckedChange = onEnabled,
+            enabled = onEnabled != null,
+            colors = SwitchDefaults.colors(
+                checkedThumbColor = Color.White,
+                checkedTrackColor = LocalAccent.current,
+                uncheckedThumbColor = Color.White.copy(alpha = 0.7f),
+                uncheckedTrackColor = Color.White.copy(alpha = 0.15f),
+            ),
+        )
     }
 }
 

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/SearchScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/SearchScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -189,7 +190,7 @@ private fun LazyListScope.results(
 ) {
     if (results.tracks.isNotEmpty()) {
         item { OrchardSectionHeader("Songs") }
-        items(results.tracks, key = { "track:${it.id}" }) { track ->
+        itemsIndexed(results.tracks, key = { index, it -> "track:${it.id}_$index" }) { _, track ->
             val isDownloaded = downloadedTrackIds.contains(track.id)
             val isDownloading = downloadingTrackIds.contains(track.id)
             TrackRow(
@@ -218,7 +219,7 @@ private fun LazyListScope.results(
         item { OrchardSectionHeader(title) }
         item {
             LazyRow(contentPadding = PaddingValues(horizontal = 16.dp), horizontalArrangement = Arrangement.spacedBy(14.dp)) {
-                items(values, key = { "$title:${it.stableId}" }) { item ->
+                itemsIndexed(values, key = { index, it -> "$title:${it.stableId}_$index" }) { _, item ->
                     CatalogCard(item, { onOpen(item.stableId) })
                 }
             }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/SettingsScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/SettingsScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.rounded.KeyboardArrowRight
+import androidx.compose.material.icons.rounded.AllInclusive
 import androidx.compose.material.icons.rounded.AutoAwesome
 import androidx.compose.material.icons.rounded.Devices
 import androidx.compose.material.icons.rounded.GraphicEq
@@ -92,6 +93,11 @@ fun SettingsScreen(
     onConnectSpotify: () -> Unit = {},
     onDevices: () -> Unit,
     onWelcome: () -> Unit = {},
+    /**
+     * Separate from [onSettings] because switching Autoplay off also strips the tracks it added,
+     * which only the view model can do.
+     */
+    onAutoplayEnabled: ((Boolean) -> Unit)? = null,
 ) {
     Column(
         Modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(horizontal = 16.dp),
@@ -125,6 +131,16 @@ fun SettingsScreen(
                 subtitle = "Even out volume differences between songs",
                 checked = settings.volumeNormalizationEnabled,
                 onChecked = { onSettings(settings.copy(volumeNormalizationEnabled = it)) },
+            )
+            PanelDivider()
+            ToggleRow(
+                icon = Icons.Rounded.AllInclusive,
+                title = "Autoplay",
+                subtitle = "Keep playing related music when the queue runs out",
+                checked = settings.autoplayEnabled,
+                onChecked = { enabled ->
+                    onAutoplayEnabled?.invoke(enabled) ?: onSettings(settings.copy(autoplayEnabled = enabled))
+                },
             )
             PanelDivider()
             CrossfadeRow(settings, onSettings)

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/SpotifyLoginScreen.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/SpotifyLoginScreen.kt
@@ -68,13 +68,15 @@ fun SpotifyLoginScreen(
 
     fun checkAndCaptureCookie(cookieManager: CookieManager) {
         if (captured) return
-        val cookieHeader = cookieManager.getCookie("https://.spotify.com")
-            ?: cookieManager.getCookie("https://open.spotify.com")
-            ?: cookieManager.getCookie("https://accounts.spotify.com")
-            .orEmpty()
+        // "https://.spotify.com" is not a valid URL for getCookie; ask for the real
+        // hosts and take the first jar that actually carries sp_dc.
+        val spdc = listOf("https://open.spotify.com", "https://accounts.spotify.com")
+            .firstNotNullOfOrNull { host ->
+                SpotifyCanvasRepository.extractSpdc(cookieManager.getCookie(host).orEmpty())
+                    .takeIf { it.isNotBlank() }
+            }
 
-        val spdc = SpotifyCanvasRepository.extractSpdc(cookieHeader)
-        if (spdc.isNotBlank()) {
+        if (spdc != null) {
             captured = true
             onSpdcCaptured(spdc)
         }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/TabletPlayer.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/ui/screens/TabletPlayer.kt
@@ -101,6 +101,10 @@ fun TabletPlayerBody(
     onOpenCollection: ((String) -> Unit)?,
     onLyricsPanel: () -> Unit,
     onQueuePanel: () -> Unit,
+    autoplayEnabled: Boolean = true,
+    autoplayLoading: Boolean = false,
+    autoplayError: String = "",
+    onAutoplayEnabled: ((Boolean) -> Unit)? = null,
 ) {
     Column(Modifier.fillMaxSize().systemBarsPadding()) {
         PlayerTopHandle(onDismiss = onBack, modifier = dragHandle)
@@ -192,6 +196,10 @@ fun TabletPlayerBody(
                                 onMove = onMoveQueueItem,
                                 onClearUpcoming = onClearUpcoming,
                                 onShuffleUpcoming = onShuffle,
+                                autoplayEnabled = autoplayEnabled,
+                                autoplayLoading = autoplayLoading,
+                                autoplayError = autoplayError,
+                                onAutoplayEnabled = onAutoplayEnabled,
                             )
                         } else {
                             val palette = rememberArtworkPalette(track.artworkUrl)

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/UpdateManagerTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/UpdateManagerTest.kt
@@ -54,4 +54,16 @@ class UpdateManagerTest {
         assertEquals(0, UpdateManager.compareVersions("1.0.0", "1.0.0"))
         assertEquals(-1, UpdateManager.compareVersions("1.0.0", "1.1.0"))
     }
+
+    /**
+     * Build-type suffixes used to make the trailing segment parse as 0, so "1.1.1-debug" read as
+     * 1.1.0 and every suffixed build believed it was one release behind.
+     */
+    @Test
+    fun ignoresBuildSuffixWhenComparing() {
+        assertEquals(0, UpdateManager.compareVersions("1.1.1", "1.1.1-debug"))
+        assertEquals(0, UpdateManager.compareVersions("1.1.1", "1.1.1-rc1"))
+        assertEquals(1, UpdateManager.compareVersions("1.1.2", "1.1.1-debug"))
+        assertEquals(-1, UpdateManager.compareVersions("1.1.0", "1.1.1-debug"))
+    }
 }

--- a/mobile/release-notes.md
+++ b/mobile/release-notes.md
@@ -1,4 +1,10 @@
-## Orchard Mobile 1.1.1 "Minuses Entangle"
+## Orchard Mobile 1.2.0 "Synopses Brusquely"
+
+### Features
+- **Autoplay**: When the queue runs dry, Orchard now keeps going with related tracks instead of falling silent. The continuation is pulled from the same radio feed the desktop app uses, appended to the queue as it plays so you can see what's coming and skip past anything you don't want. On by default, with a switch in Settings and a matching one in the queue footer, the way desktop does it, switching it off also clears the tracks it added.
 
 ### Fixes
-- **Crash on Track Analysis**: Fixed a native crash that killed the app a few seconds into playback on release builds. ONNX Runtime's JNI layer looks its Java classes up by name from native code, and R8 was renaming them away, so the first beat-tracking inference aborted the process. Added the required keep rules.
+- **Spotify Canvas on Android**: Canvas loops never loaded. The token harvester couldn't complete its handshake in Android's WebView, so every artwork request went out unauthenticated and came back empty. Reworked the harvester and pinned a modern `androidx.webkit`.
+- **Crash Scrolling Playlists**: Scrolling a playlist that contained the same track twice crashed the app. The lazy lists keyed their items by track ID, and Compose rejects duplicate keys outright. the affected lists now key by position as well.
+- **Update Prompt**: Updates used to download and launch the system installer on their own, which read as an app-wide hijack out of nowhere. Orchard now asks first and shows download progress, and the APK link it hands the installer actually resolves. Debug builds no longer check at all, since the published release can't install over them anyway. Thanks to **Julian-FF2000** for the fix.
+- **3-Button Navigation Layout**: The bottom bar applied the system navigation inset a second time on top of the one the app scaffold already added, squashing the tab icons and labels for anyone not using gesture navigation.

--- a/mobile/release-notes.md
+++ b/mobile/release-notes.md
@@ -1,16 +1,4 @@
-## Orchard Mobile 1.1.0 "Fiancee Batches"
+## Orchard Mobile 1.1.1 "Minuses Entangle"
 
-### Features
-- **Explicit Content & Badging**: Added parsing for explicit badges (`MUSIC_EXPLICIT_BADGE`), explicit track metadata support across models/UI, and JavaScript challenge solver integration for age-gated streams.
-- **Playlist Management**: Added mobile playlist add/create actions, `PlaylistPickerSheet`, and catalog mutation endpoints.
-- **Song Share & Links**: Enhanced song sharing sheet with direct Songlink integration and platform links.
-- **Orchard Connect & Cloud Sync**: Added remote track analysis request/response protocol (v3) over paired desktop connections, along with Supabase sync integration.
-- **Player UI Enhancements**: Rebuilt player components with tablet layout support (`TabletPlayer`), transition glow overlays, refined scrubber controls, and dedicated panel views.
-- **Offline Downloads & Catalog Sheets**: Full offline media caching system and paginated catalog section sheets.
-
-### Improvements & Fixes
-- **Volume Normalization Engine**: Wired volume normalization toggle into audio settings and added DSP level adjustments in `TransitionFilter`.
-- **Update Metadata & Codename**: Supported codename metadata field in update manager (`MobileUpdateMetadata`) and displayed codename in app settings.
-- **Stream Cache Reliability**: Improved stream cache handling and corrected YouTube quality warning logic during fallback playback.
-- **Smart Crossfade Tuning**: Integrated native WSOLA planner, best-mix track sorting, and refined transition planning/policy logic.
-- **Debug Build Flavor**: Added coexisting `.debug` build variant with distinct application ID and app name.
+### Fixes
+- **Crash on Track Analysis**: Fixed a native crash that killed the app a few seconds into playback on release builds. ONNX Runtime's JNI layer looks its Java classes up by name from native code, and R8 was renaming them away, so the first beat-tracking inference aborted the process. Added the required keep rules.


### PR DESCRIPTION
Rolls up the mobile fixes on `fix/mobile-bugs` plus autoplay, and bumps the app to 1.2.0.

Minor rather than patch because autoplay is a new user-facing feature.

## Features

- **Autoplay** (#51), when the queue runs out, playback continues with the
  `RDAMVM<videoId>` radio seed rather than stopping. Tracks are appended to the queue as
  they load, so they're visible and skippable. On by default, with a switch in Settings
  and a mirrored one in the queue footer, matching desktop. Turning it off clears the
  tracks it added.

## Fixes

- **Spotify Canvas on Android** (#44) - the token harvester couldn't complete its
  handshake in Android's WebView, so Canvas requests went out unauthenticated and came
  back empty. Reworked the harvester; adds `androidx.webkit:webkit:1.14.0`.
- **Crash scrolling playlists with duplicate tracks** (#47) - lazy lists keyed items by
  track ID, and Compose rejects duplicate keys. Affected lists now key by position too.
- **Update flow** - updates downloaded and fired the system installer unprompted; there's
  now a confirmation dialog with download progress, and the APK URL resolves. Debug builds
  skip the check entirely, since the release APK can't install over a different
  applicationId. Thanks to @Julian-FF2000.
- **3-button navigation layout** (#50) - the bottom bar applied the system nav inset a
  second time on top of the scaffold's, squashing icons and labels into the fixed 64dp
  height.