### PR TITLE
fix(mobile): restore age-restricted playback and improve navigation stability

### DIFF
--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/auth/YouTubeSessionAuth.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/auth/YouTubeSessionAuth.kt
@@ -42,12 +42,28 @@ object YouTubeSessionAuth {
         origin: String = MUSIC_ORIGIN,
         epochSeconds: Long = System.currentTimeMillis() / 1_000,
     ): String? {
-        val loginCookie = loginCookieValue(cookieHeader) ?: return null
-        val source = "$epochSeconds $loginCookie $origin"
-        val digest = MessageDigest.getInstance("SHA-1").digest(source.toByteArray(Charsets.UTF_8))
-        val hash = digest.joinToString(separator = "") { byte -> "%02x".format(byte.toInt() and 0xff) }
-        return "SAPISIDHASH ${epochSeconds}_$hash"
+        val cookies = parseCookies(cookieHeader)
+        val sapisid = cookies["SAPISID"] ?: cookies["__Secure-3PAPISID"] ?: cookies["APISID"]
+        val signedCookies = listOfNotNull(
+            sapisid?.let { "SAPISIDHASH" to it },
+            cookies["__Secure-1PAPISID"]?.let { "SAPISID1PHASH" to it },
+            cookies["__Secure-3PAPISID"]?.let { "SAPISID3PHASH" to it },
+        )
+        if (signedCookies.isEmpty()) return null
+        return signedCookies.joinToString(" ") { (scheme, value) ->
+            val source = "$epochSeconds $value $origin"
+            val digest = MessageDigest.getInstance("SHA-1").digest(source.toByteArray(Charsets.UTF_8))
+            val hash = digest.joinToString(separator = "") { byte -> "%02x".format(byte.toInt() and 0xff) }
+            "$scheme ${epochSeconds}_$hash"
+        }
     }
+
+    private fun parseCookies(cookieHeader: String): Map<String, String> =
+        cookieHeader.split(';').mapNotNull { part ->
+            val separator = part.indexOf('=')
+            if (separator <= 0) return@mapNotNull null
+            part.substring(0, separator).trim() to part.substring(separator + 1).trim()
+        }.toMap()
 
     fun normalizeDataSyncId(value: String?): String {
         val decoded = value.orEmpty().trim().decodePercentEscapes()

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/CatalogParser.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/CatalogParser.kt
@@ -267,16 +267,15 @@ object CatalogParser {
         val title = JsonTraversal.text(shelf.optJSONObject("title"))
         if (title.isBlank()) return null
         val subtitle = JsonTraversal.text(shelf.optJSONObject("subtitle"))
-        val endpoint = titleRuns.firstOrNull()?.let(JsonTraversal::navigation)
-            ?: shelf.optJSONObject("onTap")?.let(JsonTraversal::navigation)
-            ?: JsonTraversal.navigation(shelf.optJSONObject("onTap"))
-            ?: JsonTraversal.navigation(shelf)
-        val videoId = JsonTraversal.videoId(endpoint)
-            .ifBlank { JsonTraversal.renderers(shelf.optJSONObject("onTap"), "watchEndpoint").firstOrNull()?.optString("videoId").orEmpty() }
-            .ifBlank { JsonTraversal.renderers(shelf.optJSONObject("title"), "watchEndpoint").firstOrNull()?.optString("videoId").orEmpty() }
+        val endpoint = cardEndpoint(shelf, titleRuns)
         val browseId = JsonTraversal.browseId(endpoint)
             .ifBlank { JsonTraversal.renderers(shelf.optJSONObject("onTap"), "browseEndpoint").firstOrNull()?.optString("browseId").orEmpty() }
             .ifBlank { JsonTraversal.renderers(shelf.optJSONObject("title"), "browseEndpoint").firstOrNull()?.optString("browseId").orEmpty() }
+        val videoId = if (browseId.isBlank()) {
+            JsonTraversal.videoId(endpoint)
+                .ifBlank { JsonTraversal.renderers(shelf.optJSONObject("onTap"), "watchEndpoint").firstOrNull()?.optString("videoId").orEmpty() }
+                .ifBlank { JsonTraversal.renderers(shelf.optJSONObject("title"), "watchEndpoint").firstOrNull()?.optString("videoId").orEmpty() }
+        } else ""
         val pageType = JsonTraversal.pageType(endpoint)
             .ifBlank {
                 JsonTraversal.renderers(shelf, "browseEndpointContextMusicConfig").firstOrNull()?.optString("pageType").orEmpty()
@@ -319,8 +318,9 @@ object CatalogParser {
         val title = JsonTraversal.text(renderer.optJSONObject("title"))
         if (title.isBlank()) return null
         val subtitle = JsonTraversal.text(renderer.optJSONObject("subtitle"))
-        val endpoint = titleRuns.firstOrNull()?.let(JsonTraversal::navigation) ?: JsonTraversal.navigation(renderer)
-        val playable = renderer.preferredPlayable(endpoint)
+        val endpoint = cardEndpoint(renderer, titleRuns)
+        val browseId = JsonTraversal.browseId(endpoint)
+        val playable = if (browseId.isBlank()) renderer.preferredPlayable(endpoint) else "" to ""
         val videoId = playable.first
         val art = JsonTraversal.largestThumbnail(renderer)
         if (videoId.isNotBlank()) {
@@ -328,7 +328,30 @@ object CatalogParser {
                 track(videoId, title, listOf(title, subtitle), art, renderer, musicVideoType = playable.second),
             )
         }
-        return browsable(JsonTraversal.browseId(endpoint), title, subtitle, art, JsonTraversal.pageType(endpoint), renderer)
+        return browsable(browseId, title, subtitle, art, JsonTraversal.pageType(endpoint), renderer)
+    }
+
+    /**
+     * Resolves the destination attached to a media card itself before considering its title.
+     *
+     * Artist album cards can carry a playable title endpoint as well as a direct album browse
+     * endpoint. Treating the title as authoritative turns the album into a song (or sends an
+     * unusable id to browse), even though tapping the card in YouTube Music opens the album. Menu
+     * endpoints are deliberately excluded: only direct card actions participate here.
+     */
+    private fun cardEndpoint(renderer: JSONObject, titleRuns: List<JSONObject>): JSONObject? {
+        val onTap = renderer.optJSONObject("onTap")
+        val candidates = buildList {
+            renderer.optJSONObject("navigationEndpoint")?.let(::add)
+            renderer.optJSONObject("endpoint")?.let(::add)
+            onTap?.takeIf { it.has("browseEndpoint") || it.has("watchEndpoint") }?.let(::add)
+            onTap?.optJSONObject("navigationEndpoint")?.let(::add)
+            onTap?.optJSONObject("endpoint")?.let(::add)
+            titleRuns.mapNotNullTo(this) { run -> run.optJSONObject("navigationEndpoint") }
+        }
+        return candidates.firstOrNull { JsonTraversal.browseId(it).isNotBlank() }
+            ?: candidates.firstOrNull { JsonTraversal.videoId(it).isNotBlank() }
+            ?: JsonTraversal.navigation(renderer)
     }
 
     /**

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/MediaItemMapper.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/MediaItemMapper.kt
@@ -23,6 +23,7 @@ import android.net.Uri
 import android.os.Bundle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.common.MimeTypes
 import dev.sfg.orchard.mobile.model.Track
 
 /** Converts provider-neutral tracks to Media3 items without persisting stream URLs. */
@@ -44,13 +45,22 @@ object MediaItemMapper {
             .setIsPlayable(true)
             .setExtras(extras)
             .build()
-        val uri = Uri.Builder().scheme(SCHEME).authority("stream").appendPath(track.id).build()
+        val uri = Uri.Builder()
+            .scheme(SCHEME)
+            .authority("stream")
+            .appendPath(track.id)
+            // Explicit tracks need the signed-in WEB_REMIX resolver. Its itag 18 is a
+            // normal progressive MP4, so it starts immediately instead of waiting for
+            // Safari HLS's pre-roll availability window.
+            .apply { if (track.explicit) appendQueryParameter(AUTHENTICATED_DIRECT, "1") }
+            .build()
         val requestMetadata = MediaItem.RequestMetadata.Builder()
             .setMediaUri(uri)
             .build()
         return MediaItem.Builder()
             .setMediaId(track.id)
             .setUri(uri)
+            .apply { if (track.explicit) setMimeType(MimeTypes.VIDEO_MP4) }
             .setRequestMetadata(requestMetadata)
             .setMediaMetadata(metadata)
             .build()
@@ -74,4 +84,28 @@ object MediaItemMapper {
     }
 
     fun isOrchardUri(uri: Uri): Boolean = uri.scheme == SCHEME && uri.host == "stream"
+
+    fun requiresAuthenticatedHls(uri: Uri): Boolean =
+        isOrchardUri(uri) && uri.getQueryParameter(AUTHENTICATED_HLS) == "1"
+
+    fun requiresAuthenticatedDirect(uri: Uri): Boolean =
+        isOrchardUri(uri) && uri.getQueryParameter(AUTHENTICATED_DIRECT) == "1"
+
+    /** Switches a failed direct authenticated stream to the slower, broadly compatible HLS path. */
+    fun asAuthenticatedHlsFallback(item: MediaItem): MediaItem {
+        val original = item.localConfiguration?.uri ?: return item
+        val uri =
+            original.buildUpon()
+                .clearQuery()
+                .appendQueryParameter(AUTHENTICATED_HLS, "1")
+                .build()
+        return item.buildUpon()
+            .setUri(uri)
+            .setMimeType(MimeTypes.APPLICATION_M3U8)
+            .setRequestMetadata(item.requestMetadata.buildUpon().setMediaUri(uri).build())
+            .build()
+    }
+
+    private const val AUTHENTICATED_DIRECT = "authenticated_direct"
+    private const val AUTHENTICATED_HLS = "authenticated_hls"
 }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/OrchardPlaybackService.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/OrchardPlaybackService.kt
@@ -40,7 +40,11 @@ import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.ShuffleOrder
+import androidx.media3.exoplayer.hls.HlsMediaSource
+import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.LibraryResult
@@ -327,7 +331,12 @@ class OrchardPlaybackService : MediaLibraryService() {
                 if (!MediaItemMapper.isOrchardUri(original.uri)) return@Factory original
                 val videoId = original.uri.lastPathSegment.orEmpty()
                 Log.d(TAG, "resolvingFactory: resolving videoId=$videoId")
-                val stream = streamResolver.resolve(videoId)
+                val stream =
+                    if (MediaItemMapper.requiresAuthenticatedDirect(original.uri)) {
+                        streamResolver.resolveAuthenticatedDirect(videoId)
+                    } else {
+                        streamResolver.resolve(videoId)
+                    }
                 if (stream.bitrateKbps > 0)
                     OrchardGraph.from(this@OrchardPlaybackService).activeBitrate.value =
                         stream.bitrateKbps
@@ -339,11 +348,63 @@ class OrchardPlaybackService : MediaLibraryService() {
                     .withUri(stream.url.toUri())
                     .withAdditionalHeaders(mapOf("User-Agent" to stream.userAgent))
             }
+        // HLS segment requests are created after the orchard manifest URI has been
+        // resolved, so they do not inherit that DataSpec's headers. Give the entire
+        // HLS data-source family Safari's identity to match the player response.
+        val hlsHttpFactory =
+            OkHttpDataSource.Factory(client)
+                .setDefaultRequestProperties(
+                    mapOf("User-Agent" to YouTubeStreamResolver.WEB_SAFARI_USER_AGENT),
+                )
+        val hlsUpstreamFactory = DefaultDataSource.Factory(this, hlsHttpFactory)
+        val hlsResolvingFactory =
+            ResolvingDataSource.Factory(hlsUpstreamFactory) { original ->
+                if (MediaItemMapper.requiresAuthenticatedHls(original.uri)) {
+                    val videoId = original.uri.lastPathSegment.orEmpty()
+                    val stream = streamResolver.resolveAuthenticatedHls(videoId)
+                    original
+                        .withUri(stream.url.toUri())
+                        .withAdditionalHeaders(mapOf("User-Agent" to stream.userAgent))
+                } else {
+                    original
+                }
+            }
         // Cache above resolution: it keys on the stable orchard:// URI, and a hit skips the
         // resolver entirely rather than re-resolving a CDN URL it does not need.
         val cachingFactory = streamCache.dataSourceFactory(resolvingFactory)
-        val mediaSourceFactory =
+        val progressiveMediaSourceFactory =
             DefaultMediaSourceFactory(this).setDataSourceFactory(cachingFactory)
+        val hlsMediaSourceFactory = HlsMediaSource.Factory(hlsResolvingFactory)
+        val mediaSourceFactory =
+            object : MediaSource.Factory {
+                override fun createMediaSource(mediaItem: MediaItem): MediaSource {
+                    val uri = mediaItem.localConfiguration?.uri
+                    return if (uri != null && MediaItemMapper.requiresAuthenticatedHls(uri)) {
+                        hlsMediaSourceFactory.createMediaSource(mediaItem)
+                    } else {
+                        progressiveMediaSourceFactory.createMediaSource(mediaItem)
+                    }
+                }
+
+                override fun getSupportedTypes(): IntArray =
+                    (progressiveMediaSourceFactory.supportedTypes.asIterable() + C.CONTENT_TYPE_HLS)
+                        .distinct()
+                        .toIntArray()
+
+                override fun setDrmSessionManagerProvider(
+                    drmSessionManagerProvider: DrmSessionManagerProvider,
+                ): MediaSource.Factory = apply {
+                    progressiveMediaSourceFactory.setDrmSessionManagerProvider(drmSessionManagerProvider)
+                    hlsMediaSourceFactory.setDrmSessionManagerProvider(drmSessionManagerProvider)
+                }
+
+                override fun setLoadErrorHandlingPolicy(
+                    loadErrorHandlingPolicy: LoadErrorHandlingPolicy,
+                ): MediaSource.Factory = apply {
+                    progressiveMediaSourceFactory.setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
+                    hlsMediaSourceFactory.setLoadErrorHandlingPolicy(loadErrorHandlingPolicy)
+                }
+            }
         val loadControl =
             DefaultLoadControl.Builder()
                 .setBufferDurationsMs(
@@ -624,6 +685,22 @@ class OrchardPlaybackService : MediaLibraryService() {
                 }
                 retriedMediaId = mediaId
                 streamResolver.invalidate(mediaId)
+                val failedItem = player.currentMediaItem
+                val failedUri = failedItem?.localConfiguration?.uri
+                if (
+                    failedItem != null &&
+                        failedUri != null &&
+                        MediaItemMapper.requiresAuthenticatedDirect(failedUri)
+                ) {
+                    val index = player.currentMediaItemIndex
+                    val position = player.currentPosition.coerceAtLeast(0)
+                    Log.w(TAG, "Direct authenticated stream failed; falling back to HLS", error)
+                    player.replaceMediaItem(index, MediaItemMapper.asAuthenticatedHlsFallback(failedItem))
+                    player.seekTo(index, position)
+                    player.prepare()
+                    player.play()
+                    return
+                }
                 Log.w(TAG, "Refreshing the failed stream once", error)
                 player.prepare()
                 player.play()
@@ -919,7 +996,18 @@ class OrchardPlaybackService : MediaLibraryService() {
         val current = player.currentMediaItemIndex
         for (index in current..current + 1) {
             if (index !in 0 until player.mediaItemCount) continue
-            streamResolver.prefetch(player.getMediaItemAt(index).mediaId)
+            val item = player.getMediaItemAt(index)
+            val uri = item.localConfiguration?.uri
+            // Authenticated progressive items are prefetched through StreamCache
+            // below, whose DataSource invokes their signed-in resolver. Running the
+            // ordinary resolver beside that would issue a competing guest fallback chain.
+            if (
+                uri == null ||
+                    (!MediaItemMapper.requiresAuthenticatedHls(uri) &&
+                        !MediaItemMapper.requiresAuthenticatedDirect(uri))
+            ) {
+                streamResolver.prefetch(item.mediaId)
+            }
         }
 
         val wanted =

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/QueueEditor.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/QueueEditor.kt
@@ -69,8 +69,13 @@ object QueueEditor {
     }
 
     fun replaceAndPlay(tracks: List<Track>, startIndex: Int = 0): Result {
+        val selectedId = tracks.getOrNull(startIndex)?.id.orEmpty()
         val playable = tracks.distinctBy { it.id }.filter { it.id.isNotBlank() }
-        return Result(playable, normalizedIndex(playable, startIndex))
+        val selectedIndex = playable.indexOfFirst { it.id == selectedId }
+        return Result(
+            playable,
+            if (selectedIndex >= 0) selectedIndex else normalizedIndex(playable, startIndex),
+        )
     }
 
     fun shuffle(tracks: List<Track>, random: kotlin.random.Random = kotlin.random.Random.Default): List<Track> {

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/StreamCache.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/StreamCache.kt
@@ -169,6 +169,10 @@ class StreamCache(
      */
     fun prefetch(uri: Uri) {
         if (!::readFactory.isInitialized || !::upstreamFactory.isInitialized) return
+        // HLS consists of a short-lived manifest and many segments. Treating the
+        // manifest as a progressive track marks a few KB as a fully cached song and
+        // later hands playlist text to the audio analyzer.
+        if (MediaItemMapper.requiresAuthenticatedHls(uri)) return
         val key = cacheKey(uri)
         if (inFlight.containsKey(key) || isFullyCached(uri)) return
         val writers = java.util.Collections.synchronizedList(mutableListOf<CacheWriter>())

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeChallengeSolver.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeChallengeSolver.kt
@@ -52,8 +52,21 @@ class YouTubeChallengeSolver(
     }
 
     private val playerCache = ConcurrentHashMap<String, String>()
+    private val nCache = ConcurrentHashMap<String, String>()
     private var webViewRef = AtomicReference<WebView?>()
     private val readyLatch = CountDownLatch(1)
+
+    /**
+     * A player build together with the signature timestamp baked into it.
+     *
+     * The player request and the decipher step must use this same build. Mixing the
+     * current timestamp with a pinned older script produces a plausible googlevideo
+     * URL whose signature the CDN rejects with HTTP 403.
+     */
+    data class PlayerScript(val url: String, val js: String, val signatureTimestamp: Int)
+
+    private val playerLock = Any()
+    @Volatile private var currentPlayer: PlayerScript? = null
 
     init {
         mainHandler.post {
@@ -96,6 +109,44 @@ class YouTubeChallengeSolver(
         }
     }
 
+    /** Returns the player build YouTube is serving now, with its matching timestamp. */
+    fun currentPlayer(): PlayerScript {
+        currentPlayer?.let { return it }
+        synchronized(playerLock) {
+            currentPlayer?.let { return it }
+            val url = runCatching { discoverPlayerUrl() }
+                .onFailure { Log.w(TAG, "Could not discover the live player build; using the pinned fallback", it) }
+                .getOrDefault(DEFAULT_PLAYER_URL)
+            val js = getPlayerJs(url)
+            val timestamp = extractSignatureTimestamp(js)
+                ?: error("Player JS at $url carried no signature timestamp")
+            Log.i(TAG, "Using player $url with signature timestamp $timestamp")
+            return PlayerScript(url, js, timestamp).also { currentPlayer = it }
+        }
+    }
+
+    fun signatureTimestamp(): Int = runCatching { currentPlayer().signatureTimestamp }
+        .onFailure { Log.w(TAG, "Falling back to the pinned signature timestamp", it) }
+        .getOrDefault(DEFAULT_SIGNATURE_TIMESTAMP)
+
+    /** Forces the next request and decipher operation to discover the live build again. */
+    fun invalidatePlayer() = synchronized(playerLock) {
+        currentPlayer?.let { playerCache.remove(it.url) }
+        currentPlayer = null
+    }
+
+    private fun discoverPlayerUrl(): String {
+        val req = Request.Builder()
+            .url("https://www.youtube.com/iframe_api")
+            .header("User-Agent", WEB_USER_AGENT)
+            .build()
+        client.newCall(req).execute().use { resp ->
+            check(resp.isSuccessful) { "iframe_api returned HTTP ${resp.code}" }
+            return extractPlayerUrl(resp.body.string())
+                ?: error("iframe_api carried no player build id")
+        }
+    }
+
     /**
      * Deciphers an encrypted signature and 'n' parameter for a given stream URL.
      */
@@ -103,13 +154,17 @@ class YouTubeChallengeSolver(
         streamUrl: String,
         encryptedSig: String?,
         sigParam: String = "sig",
-        playerUrl: String = DEFAULT_PLAYER_URL,
+        playerUrl: String? = null,
     ): String {
-        val playerJs = getPlayerJs(playerUrl)
+        val playerJs = if (playerUrl != null) getPlayerJs(playerUrl) else currentPlayer().js
         val uri = android.net.Uri.parse(streamUrl)
         val nVal = uri.getQueryParameter("n")
 
-        val (solvedSig, solvedN) = solve(playerJs, encryptedSig, nVal)
+        val cachedN = nVal?.let(nCache::get)
+        val (solvedSig, freshlySolvedN) = solve(playerJs, encryptedSig, nVal?.takeIf { cachedN == null })
+        val solvedN = cachedN ?: freshlySolvedN?.also { solved ->
+            nVal?.let { nCache[it] = solved }
+        }
 
         val uriBuilder = uri.buildUpon()
         if (solvedSig != null) {
@@ -138,6 +193,24 @@ class YouTubeChallengeSolver(
         }
 
         return uriBuilder.build().toString()
+    }
+
+    /**
+     * Solves the path-shaped `n` challenge used by YouTube's HLS manifests.
+     * Direct formats put this value in a query parameter, but manifests encode it
+     * as `/n/<challenge>/`; requesting that path unchanged lets the playlist load
+     * while its media chunks are rejected with HTTP 403.
+     */
+    fun decipherManifestUrl(manifestUrl: String): String {
+        val uri = android.net.Uri.parse(manifestUrl)
+        val path = uri.encodedPath.orEmpty()
+        val match = MANIFEST_N_PATTERN.find(path) ?: return manifestUrl
+        val challenge = match.groupValues[1]
+        val solved = nCache[challenge] ?: solve(currentPlayer().js, null, challenge).second
+            ?.also { nCache[challenge] = it }
+            ?: error("Failed to solve HLS manifest n challenge")
+        val solvedPath = path.replaceRange(match.range, "/n/$solved/")
+        return uri.buildUpon().encodedPath(solvedPath).build().toString()
     }
 
     /**
@@ -204,7 +277,26 @@ class YouTubeChallengeSolver(
     }
 
     companion object {
+        /** Only a network-failure fallback; normal playback discovers the live build. */
         const val DEFAULT_PLAYER_URL = "/s/player/854a788e/player_ias.vflset/en_US/base.js"
+        const val DEFAULT_SIGNATURE_TIMESTAMP = 20668
+        private val MANIFEST_N_PATTERN = Regex("/n/([^/]+)/")
+
+        internal fun extractPlayerUrl(iframeApi: String): String? {
+            val id = PLAYER_ID_PATTERN.find(iframeApi)?.groupValues?.getOrNull(1) ?: return null
+            return "/s/player/$id/player_ias.vflset/en_US/base.js"
+        }
+
+        internal fun extractSignatureTimestamp(playerJs: String): Int? =
+            STS_PATTERN.find(playerJs)?.groupValues?.getOrNull(1)?.toIntOrNull()
+
+        private const val WEB_USER_AGENT =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 " +
+                "(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+        // iframe_api escapes slashes in its JavaScript string, while fixtures and
+        // mirrors sometimes do not. The backslashes are therefore optional.
+        private val PLAYER_ID_PATTERN = Regex("""player\\?/([0-9a-zA-Z_-]{4,})\\?/""")
+        private val STS_PATTERN = Regex("""signatureTimestamp\s*[:=]\s*(\d+)""")
         private const val TAG = "YouTubeChallengeSolver"
     }
 }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeStreamResolver.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeStreamResolver.kt
@@ -250,6 +250,89 @@ class YouTubeStreamResolver(
         }
     }
 
+    /**
+     * Resolves a progressive stream through the signed-in Music client.
+     *
+     * Current YouTube requires a GVS proof token for most direct WEB formats, but
+     * deliberately exempts itag 18. Unlike Safari's HLS path, this URL is not held
+     * behind the account's pre-roll availability window, so playback can begin as
+     * soon as the player request and signature challenge finish.
+     */
+    fun resolveAuthenticatedDirect(videoId: String): ResolvedStream {
+        require(videoId.isNotBlank()) { "A YouTube video id is required" }
+        val cacheKey = "$videoId:AUTHENTICATED_DIRECT"
+        cached(cacheKey)?.let { return it }
+        val lock = locks.computeIfAbsent(cacheKey) { Any() }
+        synchronized(lock) {
+            cached(cacheKey)?.let { return it }
+            val account =
+                accountIdentity(videoId)
+                    ?: error("Sign in to YouTube to play age-restricted tracks")
+            val stream = chooseAuthenticatedItag18(webRemixPlayer(videoId, account))
+            streams[cacheKey] = stream
+            return stream
+        }
+    }
+
+    /** Slower fallback for sessions where the direct authenticated format is rejected. */
+    fun resolveAuthenticatedHls(videoId: String): ResolvedStream {
+        require(videoId.isNotBlank()) { "A YouTube video id is required" }
+        val cacheKey = "$videoId:AUTHENTICATED_HLS"
+        cached(cacheKey)?.let { return it }
+        val lock = locks.computeIfAbsent(cacheKey) { Any() }
+        synchronized(lock) {
+            cached(cacheKey)?.let { return it }
+            val account = accountIdentity(videoId)
+                ?: error("Sign in to YouTube to play age-restricted tracks")
+            val payload = webSafariPlayer(videoId, account)
+            val stream = chooseAudio(payload, qualityProvider())
+            check(stream.mimeType == HLS_MIME_TYPE) { "Safari did not return an HLS stream" }
+            streams[cacheKey] = stream
+            return stream
+        }
+    }
+
+    private fun chooseAuthenticatedItag18(payload: JSONObject): ResolvedStream {
+        val streaming = payload.optJSONObject("streamingData") ?: error("No streaming data returned")
+        val formats = streaming.optJSONArray("formats") ?: error("No muxed formats returned")
+        val format =
+            (0 until formats.length())
+                .mapNotNull(formats::optJSONObject)
+                .firstOrNull { it.optInt("itag") == AUTHENTICATED_DIRECT_ITAG }
+                ?: error("YouTube did not return authenticated itag $AUTHENTICATED_DIRECT_ITAG")
+        return resolvedFormat(payload, format)
+    }
+
+    private fun resolvedFormat(payload: JSONObject, format: JSONObject): ResolvedStream {
+        var rawUrl = format.optString("url")
+        if (rawUrl.isBlank()) {
+            val cipher = format.optString("signatureCipher").ifBlank { format.optString("cipher") }
+            val parsed = parseQuery(cipher)
+            val target =
+                parsed["url"]?.let { java.net.URLDecoder.decode(it, "UTF-8") }
+                    ?: error("No url in authenticated signatureCipher")
+            val signature = parsed["s"]?.let { java.net.URLDecoder.decode(it, "UTF-8") }
+            val signatureParameter =
+                parsed["sp"]?.let { java.net.URLDecoder.decode(it, "UTF-8") } ?: "sig"
+            rawUrl =
+                challengeSolver?.decipherUrl(target, signature, signatureParameter)
+                    ?: error("Challenge solver required for authenticated playback")
+        }
+        val expirySeconds = EXPIRY_PATTERN.find(rawUrl)?.groupValues?.getOrNull(1)?.toLongOrNull()
+        val expiry =
+            expirySeconds?.let { TimeUnit.SECONDS.toMillis(it) }
+                ?: System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(45)
+        val bitrateKbps = (format.optInt("bitrate") / 1000).coerceAtLeast(0)
+        Log.d(TAG, "Resolved authenticated itag ${format.optInt("itag")} @ ${bitrateKbps}kbps")
+        return ResolvedStream(
+            url = rawUrl,
+            mimeType = format.optString("mimeType"),
+            expiresAtMs = expiry,
+            bitrateKbps = bitrateKbps,
+            userAgent = payload.optString(REQUEST_USER_AGENT_KEY).ifBlank { WEB_USER_AGENT },
+        )
+    }
+
     private fun warmVisitor(videoId: String): Visitor {
         visitor?.let { return it }
         synchronized(visitorLock) {
@@ -323,7 +406,8 @@ class YouTubeStreamResolver(
     fun knownBitrateKbps(videoId: String): Int {
         if (videoId.isBlank()) return 0
         val quality = qualityProvider()
-        return streams["$videoId:${quality.name}"]?.bitrateKbps?.takeIf { it > 0 }
+        return streams["$videoId:AUTHENTICATED_DIRECT"]?.bitrateKbps?.takeIf { it > 0 }
+            ?: streams["$videoId:${quality.name}"]?.bitrateKbps?.takeIf { it > 0 }
             ?: streams["$videoId:${AudioQuality.HIGH.name}"]?.bitrateKbps?.takeIf { it > 0 }
             ?: 0
     }
@@ -498,7 +582,7 @@ class YouTubeStreamResolver(
         val playbackContext = JSONObject()
             .put(
                 "contentPlaybackContext",
-                JSONObject().put("signatureTimestamp", playerConfig.signatureTimestamp()),
+                JSONObject().put("signatureTimestamp", signatureTimestamp()),
             )
         val body = JSONObject()
             .put("context", JSONObject().put("client", clientContext).put("user", userContext))
@@ -524,8 +608,62 @@ class YouTubeStreamResolver(
                             header("Authorization", auth)
                         }
                         header("X-Goog-AuthUser", "0")
+                        header("X-Youtube-Bootstrap-Logged-In", "true")
                     } else if (it.id.isNotBlank()) {
                         header("X-Goog-Visitor-Id", it.id)
+                    }
+                }
+            }
+            .post(body.toString().toRequestBody(JSON_MEDIA_TYPE))
+            .build()
+        return executePlayer(request)
+    }
+
+    /**
+     * Safari's web player exposes HLS for signed-in non-Premium accounts. YouTube's
+     * direct WEB/WEB_REMIX URLs now require a GVS proof-of-origin token, while HLS
+     * remains playable without one.
+     */
+    private fun webSafariPlayer(videoId: String, visitor: Visitor?): JSONObject {
+        val clientContext = JSONObject()
+            .put("clientName", "WEB")
+            .put("clientVersion", WEB_CLIENT_VERSION)
+            .put("userAgent", WEB_SAFARI_USER_AGENT)
+            .put("hl", "en")
+            .put("gl", "US")
+            .apply { visitor?.id?.takeIf(String::isNotBlank)?.let { put("visitorData", it) } }
+        val body = JSONObject()
+            .put("context", JSONObject().put("client", clientContext))
+            .put("videoId", videoId)
+            .put("contentCheckOk", true)
+            .put("racyCheckOk", true)
+            .put(
+                "playbackContext",
+                JSONObject().put(
+                    "contentPlaybackContext",
+                    JSONObject()
+                        .put("html5Preference", "HTML5_PREF_WANTS")
+                        .put("signatureTimestamp", signatureTimestamp()),
+                ),
+            )
+        val request = Request.Builder()
+            .url("https://www.youtube.com/youtubei/v1/player?prettyPrint=false")
+            .header("Content-Type", "application/json")
+            .header("User-Agent", WEB_SAFARI_USER_AGENT)
+            .header("X-Youtube-Client-Name", "1")
+            .header("X-Youtube-Client-Version", WEB_CLIENT_VERSION)
+            .header("Origin", "https://www.youtube.com")
+            .apply {
+                visitor?.let {
+                    if (it.id.isNotBlank()) header("X-Goog-Visitor-Id", it.id)
+                    if (it.cookie.isNotBlank()) header("Cookie", it.cookie)
+                    if (it.signedIn) {
+                        YouTubeSessionAuth.authorization(it.cookie, origin = "https://www.youtube.com")?.let { auth ->
+                            header("Authorization", auth)
+                        }
+                        header("X-Goog-AuthUser", "0")
+                        header("X-Origin", "https://www.youtube.com")
+                        header("X-Youtube-Bootstrap-Logged-In", "true")
                     }
                 }
             }
@@ -545,7 +683,7 @@ class YouTubeStreamResolver(
         val playbackContext = JSONObject()
             .put("contentPlaybackContext", JSONObject()
                 .put("html5Preference", "HTML5_PREF_WANTS")
-                .put("signatureTimestamp", playerConfig.signatureTimestamp()))
+                .put("signatureTimestamp", signatureTimestamp()))
         val body = JSONObject()
             .put("context", JSONObject().put("client", clientContext))
             .put("videoId", videoId)
@@ -598,6 +736,7 @@ class YouTubeStreamResolver(
                 ) {
                     Log.w(TAG, "Player rejected the signature timestamp; refreshing it")
                     playerConfig.invalidate()
+                    challengeSolver?.invalidatePlayer()
                 }
                 // Distinguish age-gated refusals so the retry chain can
                 // route them to the web/music players instead of a guest retry.
@@ -619,8 +758,25 @@ class YouTubeStreamResolver(
         return AGE_GATE_PATTERN.containsMatchIn(text)
     }
 
+    /**
+     * Uses the timestamp from the same player script that will decipher returned
+     * signatures. [playerConfig] remains the fallback for resolver-only tests and
+     * callers that do not install the WebView challenge solver.
+     */
+    private fun signatureTimestamp(): Int =
+        challengeSolver?.signatureTimestamp() ?: playerConfig.signatureTimestamp()
+
     private fun chooseAudio(payload: JSONObject, quality: AudioQuality): ResolvedStream {
         val streaming = payload.optJSONObject("streamingData") ?: error("No streaming data returned")
+        val userAgent = payload.optString(REQUEST_USER_AGENT_KEY).ifBlank { CLIENT_USER_AGENT }
+        streaming.optString("hlsManifestUrl").takeIf(String::isNotBlank)?.let { rawHlsUrl ->
+            val hlsUrl = challengeSolver?.decipherManifestUrl(rawHlsUrl) ?: rawHlsUrl
+            val expirySeconds = EXPIRY_PATTERN.find(hlsUrl)?.groupValues?.getOrNull(1)?.toLongOrNull()
+            val expiry = expirySeconds?.let { TimeUnit.SECONDS.toMillis(it) }
+                ?: System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(45)
+            Log.d(TAG, "Resolved HLS manifest for authenticated web playback")
+            return ResolvedStream(hlsUrl, HLS_MIME_TYPE, expiry, 0, userAgent)
+        }
         val formats = streaming.optJSONArray("adaptiveFormats") ?: JSONArray()
         val candidates = buildList {
             for (index in 0 until formats.length()) {
@@ -664,7 +820,6 @@ class YouTubeStreamResolver(
         val expiry = expirySeconds?.let { TimeUnit.SECONDS.toMillis(it) }
             ?: System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(45)
         val bitrateKbps = (chosen.optInt("bitrate") / 1000).coerceAtLeast(0)
-        val userAgent = payload.optString(REQUEST_USER_AGENT_KEY).ifBlank { CLIENT_USER_AGENT }
         Log.d(TAG, "Resolved ${chosen.optString("mimeType").substringBefore(';')} audio @ ${bitrateKbps}kbps")
         return ResolvedStream(url, chosen.optString("mimeType"), expiry, bitrateKbps, userAgent)
     }
@@ -702,6 +857,10 @@ class YouTubeStreamResolver(
         private const val IOS_USER_AGENT =
             "com.google.ios.youtube/20.11.6 (iPhone10,4; U; CPU iOS 16_7_7 like Mac OS X)"
         private const val WEB_REMIX_VERSION = "1.20260213.01.00"
+        private const val WEB_CLIENT_VERSION = "2.20260708.00.00"
+        const val WEB_SAFARI_USER_AGENT =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 " +
+                "(KHTML, like Gecko) Version/15.5 Safari/605.1.15,gzip(gfe)"
         private const val PUBLIC_API_KEY = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
         private val FAILURE_BACKOFF_MS = TimeUnit.SECONDS.toMillis(20)
 
@@ -726,6 +885,8 @@ class YouTubeStreamResolver(
         private val AGE_GATE_PATTERN = Regex(
             """(?i)confirm[\s_-]*your[\s_-]*age|age[\s_-]*restrict|inappropriate for some users|LOGIN_REQUIRED""",
         )
+        private const val AUTHENTICATED_DIRECT_ITAG = 18
+        private const val HLS_MIME_TYPE = "application/x-mpegURL"
         private const val TAG = "YouTubeStreamResolver"
     }
 }

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/auth/YouTubeSessionAuthTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/auth/YouTubeSessionAuthTest.kt
@@ -46,6 +46,19 @@ class YouTubeSessionAuthTest {
     }
 
     @Test
+    fun authorizationIncludesSecureCookieSchemes() {
+        val authorization = YouTubeSessionAuth.authorization(
+            cookieHeader = "__Secure-1PAPISID=one; __Secure-3PAPISID=three",
+            epochSeconds = 1_700_000_000,
+        ).orEmpty()
+
+        assertEquals(3, authorization.split(' ').count { it.endsWith("HASH") })
+        assert(authorization.startsWith("SAPISIDHASH "))
+        assert(authorization.contains(" SAPISID1PHASH "))
+        assert(authorization.contains(" SAPISID3PHASH "))
+    }
+
+    @Test
     fun dataSyncIdNormalizesDelegationAndPercentEscapes() {
         assertEquals("channel-id", YouTubeSessionAuth.normalizeDataSyncId("account-id%7C%7Cchannel-id"))
         assertEquals("account-id", YouTubeSessionAuth.normalizeDataSyncId("account-id||"))

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/catalog/CatalogParserTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/catalog/CatalogParserTest.kt
@@ -70,6 +70,39 @@ class CatalogParserTest {
     }
 
     @Test
+    fun artistAlbumCardPrefersItsBrowseActionOverAPlayableTitle() {
+        val root = JSONObject(
+            """{
+              "header": {"musicImmersiveHeaderRenderer": {"title": {"runs": [{"text": "Ky."}]}}},
+              "contents": [{"musicCarouselShelfRenderer": {
+                "header": {"musicCarouselShelfBasicHeaderRenderer": {
+                  "title": {"runs": [{"text": "Albums"}]}
+                }},
+                "contents": [{"musicTwoRowItemRenderer": {
+                  "title": {"runs": [{
+                    "text": "Late Nights",
+                    "navigationEndpoint": {"watchEndpoint": {"videoId": "preview-video"}}
+                  }]},
+                  "subtitle": {"runs": [{"text": "Album • Ky. • 2026"}]},
+                  "navigationEndpoint": {"browseEndpoint": {
+                    "browseId": "MPRElate-nights",
+                    "browseEndpointContextSupportedConfigs": {
+                      "browseEndpointContextMusicConfig": {"pageType": "MUSIC_PAGE_TYPE_ALBUM"}
+                    }
+                  }}
+                }}]
+              }}]
+            }""".trimIndent(),
+        )
+
+        val detail = CatalogParser.detail("UCartist", root)
+        val album = detail.sections.single().items.single()
+
+        assertTrue(album is CatalogItem.Record)
+        assertEquals("MPRElate-nights", album.stableId)
+    }
+
+    @Test
     fun searchKeepsOfficialArtistChannelsAndDropsUserChannels() {
         fun channel(name: String, browseId: String, pageType: String) = """
             {"musicTwoRowItemRenderer": {
@@ -414,4 +447,3 @@ class CatalogParserTest {
         assertTrue(track.explicit)
     }
 }
-

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/playback/AgeGateTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/playback/AgeGateTest.kt
@@ -40,6 +40,17 @@ class AgeGateTest {
         assertEquals("sig", map["sp"])
         assertEquals("https%3A%2F%2Frr1---sn-oxun-xx.googlevideo.com%2Fvideoplayback%3Fexpire%3D12345", map["url"])
     }
-}
 
+    @Test
+    fun testLivePlayerConfigExtractionKeepsBuildAndTimestampTogether() {
+        val iframeApi = "var scriptUrl = 'https:\\/\\/www.youtube.com\\/s\\/player\\/8d2a370b\\/www-widgetapi.js';"
+        val playerJs = "const config={signatureTimestamp:20672};"
+
+        assertEquals(
+            "/s/player/8d2a370b/player_ias.vflset/en_US/base.js",
+            YouTubeChallengeSolver.extractPlayerUrl(iframeApi),
+        )
+        assertEquals(20672, YouTubeChallengeSolver.extractSignatureTimestamp(playerJs))
+    }
+}
 

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/playback/QueueEditorTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/playback/QueueEditorTest.kt
@@ -80,6 +80,18 @@ class QueueEditorTest {
     }
 
     @Test
+    fun replaceKeepsTheSelectedTrackAfterEarlierRowsAreDropped() {
+        val result = QueueEditor.replaceAndPlay(
+            listOf(a, a.copy(title = "Duplicate"), Track("", "Invalid", ""), b, c),
+            startIndex = 3,
+        )
+
+        assertEquals(listOf(a, b, c), result.tracks)
+        assertEquals(1, result.currentIndex)
+        assertEquals(b, result.tracks[result.currentIndex])
+    }
+
+    @Test
     fun removingOnlyTrackProducesEmptySelection() {
         val result = QueueEditor.remove(listOf(a), 0, 0)
 


### PR DESCRIPTION
## Summary

This PR resolves several Android stability issues affecting playback and navigation:

- restores age-restricted YouTube playback for signed-in users
- authenticates player requests with the complete YouTube session hash set
- keeps signature timestamps paired with the active player script
- deciphers signature and `n` challenges for progressive and HLS streams
- uses authenticated WEB_REMIX playback for fast startup
- falls back to Safari HLS when direct playback fails
- preserves album browse targets
- keeps the tapped playlist track selected

## Testing

- added coverage for YouTube session authentication
- added coverage for live player configuration extraction and age-gate handling
- verified Android tests and build

Fixes #3

Credit to @Julian-FF2000 for the age-restricted playback work.