### PR TITLE
Fix issues #80 through #85, and clipping in the default audio path

### DIFF
--- a/electron/catalog/musicText.js
+++ b/electron/catalog/musicText.js
@@ -75,11 +75,25 @@ export function hasExplicitBadge(value = {}) {
   return list.some((badge) => /explicit|music_explicit_badge/.test(explicitBadgeText(badge)));
 }
 
+// Loose comparison text for titles and artist names. Keeps letters and digits
+// in every script, because the class this used to reduce to, [a-z0-9], emptied
+// any title written without Latin characters. An empty key is not a harmless
+// near-miss here: callers treat it as "no identity" and drop the item, so a
+// Chinese or Japanese artist's releases disappeared from their own page while
+// the ones that happened to carry a Latin word survived.
+//
+// Latin combining marks are folded so an accented name still matches its plain
+// spelling. The fold is deliberately narrow: decomposing and recomposing around
+// U+0300-U+036F leaves Japanese voiced kana intact, where stripping every
+// combining mark would turn da into ta and match two different words.
 export function normalizedLooseText(value = '') {
   return String(value || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .normalize('NFC')
     .toLowerCase()
     .replace(/&/g, ' and ')
-    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
     .trim();
 }
 

--- a/electron/connect/orchardConnectPage.js
+++ b/electron/connect/orchardConnectPage.js
@@ -456,19 +456,25 @@ function readReply(response = {}) {
 }
 
 function requestPairing() {
+  const deviceToken = localStorage.getItem('orchard-connect-token') || '';
+  // Reaching this page without a token means the address was typed or copied
+  // without the ?token= part, which is not the same thing as an expired link.
+  if (!token && !deviceToken) {
+    els.status.textContent = 'This device is not paired. Scan the QR code in Orchard, or copy the camera link from Settings - it must include the token.';
+    return;
+  }
+
   els.status.textContent = 'Waiting for desktop approval';
-  socket.emit('connect:hello', {
-    token,
-    deviceToken: localStorage.getItem('orchard-connect-token') || '',
-    name: deviceName()
-  }, (response = {}) => {
+  socket.emit('connect:hello', { token, deviceToken, name: deviceName() }, (response = {}) => {
     const payload = readReply(response);
     if (payload.status === 'approved') {
       state.approved = true;
       els.status.textContent = 'Connected';
       renderState(payload.state || {});
     } else if (payload.status === 'expired') {
-      els.status.textContent = 'Pairing link expired. Refresh the QR code in Orchard.';
+      els.status.textContent = token
+        ? 'Pairing link expired. Refresh the QR code in Orchard.'
+        : 'This device is no longer paired. Scan a new QR code in Orchard.';
     } else if (payload.status === 'pending') {
       els.status.textContent = 'Approve this device in Orchard.';
     }

--- a/electron/connect/orchardConnectServer.js
+++ b/electron/connect/orchardConnectServer.js
@@ -37,13 +37,49 @@ function effectiveProtocolVersion(clientVersion = 1) {
   return Math.min(version, CONNECT_PROTOCOL_VERSION);
 }
 
-function localLanAddress() {
-  for (const entries of Object.values(networkInterfaces())) {
+// Windows boxes routinely enumerate Hyper-V, WSL, VPN and hypervisor adapters
+// ahead of the real NIC, so taking the first non-internal IPv4 hands the phone
+// an address nothing on the LAN can route to. Rank the candidates instead.
+const virtualAdapterPattern = /(vethernet|hyper-?v|vmware|vmnet|virtualbox|vboxnet|wsl|docker|tailscale|zerotier|npcap|loopback|bluetooth|tap-|tun\d|utun|ppp|radmin|hamachi|nordlynx|wireguard|proton)/i;
+
+// 192.168/16 and 10/8 are what home routers hand out. 172.16/12 is valid but is
+// also where Docker and WSL live, so it only wins when nothing better exists.
+function addressRangeScore(address = '') {
+  const [first, second] = address.split('.').map(Number);
+  if (first === 192 && second === 168) return 3;
+  if (first === 10) return 2;
+  if (first === 172 && second >= 16 && second <= 31) return 1;
+  return 0;
+}
+
+export function lanAddressCandidates(interfaces = {}) {
+  const candidates = [];
+  for (const [name, entries] of Object.entries(interfaces)) {
     for (const entry of entries || []) {
-      if (entry.family === 'IPv4' && !entry.internal) return entry.address;
+      const family = entry?.family;
+      if (family !== 'IPv4' && family !== 4) continue;
+      if (entry.internal) continue;
+      // Self-assigned APIPA addresses mean the interface never got a lease.
+      if (entry.address.startsWith('169.254.')) continue;
+      candidates.push({
+        address: entry.address,
+        name,
+        virtual: virtualAdapterPattern.test(name),
+        rangeScore: addressRangeScore(entry.address)
+      });
     }
   }
-  return '127.0.0.1';
+
+  return candidates
+    .sort((left, right) =>
+      Number(left.virtual) - Number(right.virtual) ||
+      right.rangeScore - left.rangeScore ||
+      left.address.localeCompare(right.address))
+    .map((candidate) => candidate.address);
+}
+
+function localLanAddress() {
+  return lanAddressCandidates(networkInterfaces())[0] || '127.0.0.1';
 }
 
 function jsonReply(reply, data) {
@@ -231,6 +267,16 @@ export async function createOrchardConnectServer({ Server, desktopIo, deviceStor
     return `http://${localLanAddress()}:${httpServer.address().port}`;
   }
 
+  // Ranking picks the address that works on most machines, but a host with two
+  // real NICs (wired plus wireless) can still be reachable only on the other
+  // one, so every candidate is offered as a fallback link.
+  function alternateWebUrls(token) {
+    const port = httpServer.address().port;
+    return lanAddressCandidates(networkInterfaces())
+      .slice(1)
+      .map((address) => `http://${address}:${port}/connect?token=${encodeURIComponent(token)}`);
+  }
+
   async function newPairing() {
     const token = randomBytes(18).toString('base64url');
     const serverUrl = baseUrl();
@@ -241,6 +287,7 @@ export async function createOrchardConnectServer({ Server, desktopIo, deviceStor
       url: appUrl,
       appUrl,
       webUrl,
+      altWebUrls: alternateWebUrls(token),
       qrSvg: await QRCode.toString(appUrl, { type: 'svg', margin: 1, width: 168 }),
       expiresAt: Date.now() + 10 * 60 * 1000
     };
@@ -255,6 +302,7 @@ export async function createOrchardConnectServer({ Server, desktopIo, deviceStor
       pairUrl: active.appUrl,
       appPairUrl: active.appUrl,
       webPairUrl: active.webUrl,
+      altWebPairUrls: active.altWebUrls || [],
       qrSvg: active.qrSvg,
       expiresAt: active.expiresAt,
       pending: publicPendingRequests(pending),

--- a/electron/integrations/updateErrors.js
+++ b/electron/integrations/updateErrors.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Turns an update failure into something the listener can act on.
+ *
+ * The update check runs on Electron's `net`, so its failures arrive as bare
+ * Chromium `net::ERR_*` codes. The proxy ones matter most: the same stack serves
+ * album art while playback runs on Node's, which ignores the proxy entirely, so
+ * an unreachable proxy presents as "updates and artwork are broken but music
+ * plays" with nothing on screen pointing at the machine's own settings.
+ */
+const PROXY_ERROR_PATTERN = /ERR_(?:TUNNEL_CONNECTION_FAILED|PROXY_CONNECTION_FAILED|PROXY_AUTH_UNSUPPORTED|MANDATORY_PROXY_CONFIGURATION_FAILED|PROXY_CERTIFICATE_INVALID)/i;
+
+export function errorText(error) {
+  if (!error) return '';
+  if (typeof error === 'string') return error.trim();
+  return String(error.message || error).trim();
+}
+
+export function isProxyUpdateError(error) {
+  return PROXY_ERROR_PATTERN.test(errorText(error));
+}
+
+export function updateErrorMessage(error) {
+  const text = errorText(error);
+  if (!text) return 'Update check failed.';
+  if (!isProxyUpdateError(text)) return text;
+
+  return `Orchard could not reach the update server through your system proxy (${text}). ` +
+    'Album art is served the same way and will also be missing. Check your proxy settings, or turn ' +
+    'on Settings > Network > "Ignore system proxy".';
+}

--- a/electron/integrations/updater.js
+++ b/electron/integrations/updater.js
@@ -25,6 +25,7 @@ import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { IPC_CHANNELS } from '../../shared/ipcChannels.js';
 import { createArtistPackService, readOfficialPackArchive } from './artistPackService.js';
+import { updateErrorMessage } from './updateErrors.js';
 
 const require = createRequire(import.meta.url);
 const { app, BrowserWindow, dialog, ipcMain } = require('electron');
@@ -62,11 +63,6 @@ function normalizeContentIndexUrl(value) {
   }
 }
 
-function updateErrorMessage(error) {
-  if (!error) return 'Update check failed.';
-  if (typeof error === 'string') return error;
-  return error.message || String(error);
-}
 
 function cleanProgress(progress) {
   if (!progress) return null;

--- a/electron/main/index.js
+++ b/electron/main/index.js
@@ -72,6 +72,7 @@ import { createMusicVideoFallback } from '../playback/musicVideoFallback.js';
 import { createPlaybackService } from '../playback/playbackService.js';
 import { registerAppHandlers } from '../platform/appHandlers.js';
 import { registerClipboardHandlers } from '../platform/clipboard.js';
+import { registerNetworkPreferences } from '../platform/networkPreferences.js';
 import { setupDesktopControls } from '../platform/desktopControls.js';
 import { registerScreenshotCapture } from '../platform/screenshotCapture.js';
 import { setupSystemMediaHandlers } from '../platform/systemMedia.js';
@@ -517,6 +518,10 @@ app.whenReady().then(async () => {
   });
   registerWindowControls({ BrowserWindow, ipcMain, screen });
   registerClipboardHandlers({ clipboard, ipcMain });
+  // Awaited here so the stored proxy mode is in force before any window requests
+  // its first image; applying it later would leave the opening screen's artwork
+  // going out through the proxy the listener asked Orchard to ignore.
+  await registerNetworkPreferences({ app, ipcMain, session }).restore();
   // Synchronous on purpose: the renderer seeds the queue and the last page from
   // this while it builds its initial state, and an async read would mean
   // starting on an empty queue and rewriting it a tick later.

--- a/electron/platform/networkPreferences.js
+++ b/electron/platform/networkPreferences.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Chooses whether Orchard's Chromium traffic follows the system proxy.
+ *
+ * Only part of the app ever sees a proxy: album art loads as ordinary renderer
+ * images and the update check runs through Electron's `net`, so both resolve the
+ * system proxy, while playback is fetched on Node's stack, which does not. A
+ * stale or unreachable proxy therefore breaks artwork and updates while music
+ * keeps playing, which reads as a bug in Orchard rather than a machine setting.
+ *
+ * The preference is owned by the main process and read before the first window
+ * loads: a renderer-side setting would arrive after the first images were
+ * already requested. It defaults to following the system, so a proxy an
+ * administrator configured is never bypassed unless the listener asks for it.
+ */
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { IPC_CHANNELS } from '../../shared/ipcChannels.js';
+
+export const PROXY_MODES = Object.freeze(['system', 'direct']);
+export const DEFAULT_PROXY_MODE = 'system';
+
+export function normalizeProxyMode(value) {
+  return PROXY_MODES.includes(value) ? value : DEFAULT_PROXY_MODE;
+}
+
+/**
+ * `direct` is Chromium's own name for "resolve nothing, connect straight out",
+ * which is the behaviour playback already has.
+ */
+export function proxyConfigForMode(mode) {
+  return normalizeProxyMode(mode) === 'direct' ? { mode: 'direct' } : { mode: 'system' };
+}
+
+export function registerNetworkPreferences({ app, ipcMain, session }) {
+  const preferencesPath = () => path.join(app.getPath('userData'), 'network-preferences.json');
+  let proxyMode = DEFAULT_PROXY_MODE;
+
+  async function read() {
+    try {
+      const parsed = JSON.parse(await readFile(preferencesPath(), 'utf8'));
+      return normalizeProxyMode(parsed?.proxyMode);
+    } catch {
+      return DEFAULT_PROXY_MODE;
+    }
+  }
+
+  async function apply(mode) {
+    proxyMode = normalizeProxyMode(mode);
+    await session.defaultSession.setProxy(proxyConfigForMode(proxyMode));
+    return proxyMode;
+  }
+
+  ipcMain.handle(IPC_CHANNELS.NETWORK.GET_PROXY_MODE, () => proxyMode);
+  ipcMain.handle(IPC_CHANNELS.NETWORK.SET_PROXY_MODE, async (_event, mode) => {
+    const applied = await apply(mode);
+    // Written after the session accepted it, so a rejected mode is never the one
+    // restored at the next launch.
+    await writeFile(preferencesPath(), `${JSON.stringify({ proxyMode: applied }, null, 2)}\n`);
+    return applied;
+  });
+
+  return {
+    /** Applies the stored mode. Awaited before the first window loads anything. */
+    async restore() {
+      return apply(await read());
+    },
+    mode: () => proxyMode
+  };
+}

--- a/electron/preload/index.cjs
+++ b/electron/preload/index.cjs
@@ -113,6 +113,14 @@ contextBridge.exposeInMainWorld('orchardClipboard', {
   writeText: (value) => ipcRenderer.invoke('clipboard:write-text', value)
 });
 
+// Album art and update checks resolve the system proxy; playback does not. This
+// lets the listener put the rest of the app on the same footing as playback when
+// the machine's proxy is unreachable.
+contextBridge.exposeInMainWorld('orchardNetwork', {
+  getProxyMode: () => ipcRenderer.invoke('network:get-proxy-mode'),
+  setProxyMode: (mode) => ipcRenderer.invoke('network:set-proxy-mode', mode)
+});
+
 contextBridge.exposeInMainWorld('orchardCrypto', {
   randomInt: (maxExclusive) => randomInt(Number(maxExclusive))
 });

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardViewModel.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/app/OrchardViewModel.kt
@@ -40,6 +40,7 @@ import dev.sfg.orchard.mobile.songlinks.LinkResolution
 import dev.sfg.orchard.mobile.songlinks.SongLinksCoordinator
 import dev.sfg.orchard.mobile.songlinks.SongShareState
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -220,6 +221,7 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
     private val mutableSleepTimerEndOfTrack = MutableStateFlow(false)
     val sleepTimerEndOfTrack: StateFlow<Boolean> = mutableSleepTimerEndOfTrack.asStateFlow()
     private var sleepTimerJob: Job? = null
+    private var detailJob: Job? = null
 
     val updateState: StateFlow<dev.sfg.orchard.mobile.UpdateState> = graph.updates.state
 
@@ -283,7 +285,10 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
 
     fun openDetail(id: String) {
         val seed = findCatalogItem(id, home.value, search.value, library.value, detail.value)
-        viewModelScope.launch {
+        // A collection now publishes several times as its pages land, so a load left running after
+        // the listener moved on would keep writing its pages over the collection they opened next.
+        detailJob?.cancel()
+        detailJob = viewModelScope.launch {
             mutableDetail.value = LoadState.Loading
 
             // When offline or if network is down, immediately synthesize from downloaded tracks
@@ -300,21 +305,27 @@ class OrchardViewModel(application: Application) : AndroidViewModel(application)
                 }
             }
 
-            val result = runCatching { graph.catalog.browse(id) }
-                .map { it.withSeed(seed) }
-                .recoverCatching { error ->
-                    dev.sfg.orchard.mobile.download.OfflineDetailSynthesizer.synthesize(
-                        id = id,
-                        seed = seed,
-                        downloadedItems = downloads.value.values.toList(),
-                        library = library.value,
-                    ) ?: throw error
+            // Each page replaces the last, so the collection appears as soon as its first page
+            // lands and grows underneath the listener instead of holding a spinner until an
+            // endless mix exhausts its continuation budget.
+            try {
+                graph.catalog.browsePages(id).collect { page ->
+                    mutableDetail.value = LoadState.Content(page.withSeed(seed))
                 }
-
-            mutableDetail.value = result.fold(
-                onSuccess = { LoadState.Content(it) },
-                onFailure = { LoadState.Error(it.message ?: "This collection could not be loaded.") },
-            )
+            } catch (cancelled: CancellationException) {
+                throw cancelled
+            } catch (error: Throwable) {
+                // Continuation failures are already absorbed by the repository, so reaching here
+                // means the first page never arrived and there is nothing on screen to keep.
+                val offline = dev.sfg.orchard.mobile.download.OfflineDetailSynthesizer.synthesize(
+                    id = id,
+                    seed = seed,
+                    downloadedItems = downloads.value.values.toList(),
+                    library = library.value,
+                )
+                mutableDetail.value = offline?.let { LoadState.Content(it) }
+                    ?: LoadState.Error(error.message ?: "This collection could not be loaded.")
+            }
         }
     }
 

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/CatalogRepository.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/CatalogRepository.kt
@@ -25,6 +25,10 @@ import dev.sfg.orchard.mobile.model.CatalogSection
 import dev.sfg.orchard.mobile.model.SearchResults
 import dev.sfg.orchard.mobile.model.Track
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.withContext
 
 /** Coroutine-friendly data boundary used by screen state holders. */
@@ -54,26 +58,40 @@ class CatalogRepository(private val client: InnerTubeClient) {
         if (query.isBlank()) SearchResults() else CatalogParser.search(client.search(query.trim()))
     }
 
-    suspend fun browse(id: String): BrowseDetail = withContext(Dispatchers.IO) {
+    suspend fun browse(id: String): BrowseDetail = browsePages(id).last()
+
+    /**
+     * The collection as it fills in: the first page as soon as it parses, then a fuller copy after
+     * each continuation.
+     *
+     * Paging used to complete before anything reached the screen, which is fine for a saved
+     * playlist that arrives whole but not for an endless mix, where the loop only stops at
+     * [MAX_TRACK_PAGES] and the listener waits out every round trip staring at a spinner.
+     */
+    fun browsePages(id: String): Flow<BrowseDetail> = flow {
         val root = client.browse(id)
         val detail = CatalogParser.detail(id, root)
         val tracks = detail.tracks.toMutableList()
+        emit(detail)
+
         // Playlists keep duplicate rows (see CatalogParser.collapseDuplicates); everything else
         // pulls one list from several shelves and must not repeat itself across pages.
         val seen = if (detail.kind == CatalogKind.PLAYLIST) null else tracks.mapTo(mutableSetOf(), Track::id)
+        val maxPages = pageBudget(id)
         var token = CatalogParser.continuationToken(root)
         var pages = 0
-        while (token.isNotBlank() && pages < MAX_TRACK_PAGES) {
+        while (token.isNotBlank() && pages < maxPages) {
             // A failed page is not worth losing the rows already parsed, so stop rather than throw.
             val page = runCatching { client.browseContinuation(token) }.getOrNull() ?: break
             CatalogParser.continuationTracks(detail, page).filterTo(tracks) { seen == null || seen.add(it.id) }
+            emit(detail.copy(tracks = tracks.toList()))
             val next = CatalogParser.continuationToken(page)
             if (next == token) break
             token = next
             pages++
         }
-        detail.copy(tracks = tracks)
-    }
+    }.flowOn(Dispatchers.IO)
+
 
     /** Radio continuation for a seed track, used to keep the queue from running dry. */
     suspend fun upNext(videoId: String): List<Track> = withContext(Dispatchers.IO) {
@@ -105,12 +123,27 @@ class CatalogRepository(private val client: InnerTubeClient) {
         CatalogParser.home(client.browse("FEmusic_library_landing"))
     }
 
-    private companion object {
+    internal companion object {
         /** Enough pages to match the long, personalized Music home without making it unbounded. */
         const val MAX_HOME_PAGES = 12
         /** Library grids are 25 items per page; this covers unusually large saved collections. */
         const val MAX_SECTION_PAGES = 40
         /** 100 rows per page, so this covers playlists up to 5000 tracks. */
         const val MAX_TRACK_PAGES = 50
+        /**
+         * A mix never runs out of continuations, so this is a queue-depth choice rather than a
+         * safety limit: enough to play for hours, few enough that the pages stop arriving early.
+         */
+        const val MAX_MIX_PAGES = 3
+
+        /**
+         * How many continuations a collection is worth.
+         *
+         * Radio and mix ids (`RD…`, optionally behind the `VL` playlist prefix) are the endless
+         * ones: "Mixed for you" entries continue forever, so a finite playlist's budget would have
+         * them page until the cap every single time they are opened.
+         */
+        internal fun pageBudget(id: String): Int =
+            if (id.removePrefix("VL").startsWith("RD")) MAX_MIX_PAGES else MAX_TRACK_PAGES
     }
 }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/InnerTubeClient.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/catalog/InnerTubeClient.kt
@@ -45,9 +45,15 @@ class InnerTubeClient(
 
     fun search(query: String): JSONObject = post("search", JSONObject().put("query", query))
 
-    /** Search restricted to songs, so music videos never come back as candidates. */
+    /**
+     * Search restricted to songs, so music videos never come back as candidates.
+     *
+     * Sent anonymously: this runs on the app's behalf while resolving a track the listener already
+     * picked, and an authenticated search writes the query into the account's YouTube search
+     * history. Only searches the listener actually typed belong there.
+     */
     fun searchSongs(query: String): JSONObject =
-        post("search", JSONObject().put("query", query).put("params", SONGS_FILTER))
+        post("search", JSONObject().put("query", query).put("params", SONGS_FILTER), anonymous = true)
 
     fun browse(browseId: String): JSONObject = post("browse", JSONObject().put("browseId", browseId))
 
@@ -122,9 +128,10 @@ class InnerTubeClient(
         return best?.optString("url").orEmpty()
     }
 
-    fun post(endpoint: String, payload: JSONObject): JSONObject {
+    /** [anonymous] drops the account session, keeping the call out of the listener's YouTube activity. */
+    fun post(endpoint: String, payload: JSONObject, anonymous: Boolean = false): JSONObject {
         val activeIdentity = identity ?: loadIdentity().also { identity = it }
-        val activeSession = sessionProvider.session()
+        val activeSession = if (anonymous) null else sessionProvider.session()
         val first = execute(endpoint, payload, activeIdentity, activeSession, includeDataSyncId = true)
         val firstMessage = errorMessage(first.body)
         val result = if (

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/OrchardPlaybackService.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/OrchardPlaybackService.kt
@@ -68,6 +68,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * Process-level owner of local phone playback.
@@ -106,6 +107,9 @@ class OrchardPlaybackService : MediaLibraryService() {
         )
     private var retriedMediaId = ""
     private var artworkHydrationId = ""
+
+    /** The exact client identity behind each stable Orchard URI's most recent media fetch. */
+    private val resolvedStreams = ConcurrentHashMap<String, ResolvedStream>()
 
     private val positionSaver =
         object : Runnable {
@@ -383,6 +387,7 @@ class OrchardPlaybackService : MediaLibraryService() {
                 if (stream.bitrateKbps > 0)
                     OrchardGraph.from(this@OrchardPlaybackService).activeBitrate.value =
                         stream.bitrateKbps
+                resolvedStreams[original.uri.toString()] = stream
                 Log.d(TAG, "resolvingFactory: resolved $videoId to url=${stream.url.take(60)}...")
                 // The CDN checks the URL against the client it was issued to, so the fetch
                 // has to claim the identity that resolved it rather than the factory's
@@ -405,6 +410,7 @@ class OrchardPlaybackService : MediaLibraryService() {
                 if (MediaItemMapper.requiresAuthenticatedHls(original.uri)) {
                     val videoId = original.uri.lastPathSegment.orEmpty()
                     val stream = streamResolver.resolveAuthenticatedHls(videoId)
+                    resolvedStreams[original.uri.toString()] = stream
                     original
                         .withUri(stream.url.toUri())
                         .withAdditionalHeaders(stream.requestHeaders)
@@ -734,7 +740,15 @@ class OrchardPlaybackService : MediaLibraryService() {
                     Log.e(TAG, "Playback failed without a recoverable media item", error)
                     return
                 }
-                streamResolver.invalidate(mediaId)
+                val resolvedStream = resolvedStreams.remove(failedUri.toString())
+                val responseCode = playbackHttpResponseCode(error)
+                val rejectedClient =
+                    if (resolvedStream != null && responseCode != null) {
+                        streamResolver.reject(mediaId, resolvedStream, responseCode)
+                    } else {
+                        false
+                    }
+                if (!rejectedClient) streamResolver.resetForRetry(mediaId)
                 if (
                     MediaItemMapper.requiresAuthenticatedDirect(failedUri)
                 ) {
@@ -762,6 +776,18 @@ class OrchardPlaybackService : MediaLibraryService() {
                     player.seekTo(index, position)
                     player.prepare()
                     player.play()
+                    return
+                }
+                // Resolution itself already walked the complete client catalog. Repeating that
+                // 25-second chain automatically only extends the spinner. Its failure backoff was
+                // cleared above, so an explicit Play tap makes one fresh attempt instead of
+                // reproducing the old exception instantly.
+                if (resolvedStream == null) {
+                    Log.e(TAG, "Playback stopped after stream resolution exhausted its fallbacks", error)
+                    return
+                }
+                if (isUnrecoverablePlaybackError(error)) {
+                    Log.e(TAG, "Playback error is not recoverable by refreshing the stream", error)
                     return
                 }
                 if (retriedMediaId == mediaId) {

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/PlaybackErrorMessages.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/PlaybackErrorMessages.kt
@@ -19,6 +19,9 @@
 
 package dev.sfg.orchard.mobile.playback
 
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.HttpDataSource
+
 /**
  * Turns a playback failure into something worth showing someone.
  *
@@ -60,6 +63,21 @@ internal fun playbackErrorMessage(error: Throwable): String {
     }
     val fallback = error.cause?.message ?: error.message
     return fallback?.takeIf { it.isNotBlank() } ?: "Playback failed."
+}
+
+/** Finds the CDN response code Media3 nests below its top-level playback exception. */
+@UnstableApi
+internal fun playbackHttpResponseCode(error: Throwable): Int? =
+    findCause(error, HttpDataSource.InvalidResponseCodeException::class.java)?.responseCode
+
+/** Cause chains are routinely two or three wrappers deep in Media3 source failures. */
+internal fun <T : Throwable> findCause(error: Throwable, type: Class<T>): T? {
+    var current: Throwable? = error
+    while (current != null) {
+        if (type.isInstance(current)) return type.cast(current)
+        current = current.cause
+    }
+    return null
 }
 
 private const val UNPLAYABLE_PREFIX = "YouTube could not play this track: "

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeStreamResolver.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeStreamResolver.kt
@@ -69,6 +69,15 @@ data class ResolvedStream(
  */
 private class AgeGateException(message: String) : RuntimeException(message)
 
+/**
+ * Thrown when YouTube refuses playback because the content belongs to an account rather than to
+ * the public catalog: a YouTube Music upload, or a video the owner set to private.
+ *
+ * No guest client can ever play these, so the retry chain treats one refusal as the answer for
+ * every anonymous profile and moves straight to the signed-in player.
+ */
+private class AccountOnlyException(message: String) : RuntimeException(message)
+
 /** A player/fetch identity kept together, following ArchiveTune's client catalog model. */
 private data class PlayerClientProfile(
     val key: String,
@@ -245,6 +254,13 @@ class YouTubeStreamResolver(
                 if (lastError is AgeGateException) ageGatedVideos += videoId
                 Log.w(TAG, "${profile.key} failed for $videoId", lastError)
 
+                // An upload or private video is refused identically by every anonymous client, so
+                // walking the rest of the catalog only burns the budget the signed-in player needs.
+                if (lastError is AccountOnlyException && account != null) {
+                    Log.d(TAG, "$videoId is account-only; skipping the remaining guest clients")
+                    break
+                }
+
                 // Refresh a persisted guest identity once. Repeating this for every profile
                 // creates exactly the burst of watch-page traffic that causes larger batches to
                 // fail after their first few tracks.
@@ -258,8 +274,10 @@ class YouTubeStreamResolver(
 
             // Signed web playback remains the last normal fallback for account-only or
             // age-gated music. It is never replaced with NewPipe; NewPipe belongs to MAX only.
+            // Deliberately outside the budget check: this is the only client that can play
+            // account-only music, and dropping it because the guest attempts ran long turns a
+            // playable upload into "Video unavailable".
             if (stream == null && account != null) {
-                withinBudget(lastError)
                 runCatching { chooseAudio(webRemixPlayer(videoId, account), quality) }
                     .onSuccess { stream = it }
                     .onFailure {
@@ -728,8 +746,20 @@ class YouTubeStreamResolver(
             .put("clientVersion", WEB_REMIX_VERSION)
             .put("hl", "en")
             .put("gl", "US")
+            // A signed-in player request without the account's own visitorData resolves against a
+            // different identity than the library page did, which reads as "video unavailable" for
+            // anything only that account can see, such as a YouTube Music upload.
+            .apply { visitor?.id?.takeIf(String::isNotBlank)?.let { put("visitorData", it) } }
         val userContext = JSONObject()
             .put("lockedSafetyMode", false)
+            // Uploads belong to a channel, not to the Google account, so the delegation id is what
+            // ties the request to the channel that owns them.
+            .apply {
+                if (visitor?.signedIn == true) {
+                    sessionProvider?.session()?.dataSyncId?.takeIf(String::isNotBlank)
+                        ?.let { put("onBehalfOfUser", it) }
+                }
+            }
         val playbackContext = JSONObject()
             .put(
                 "contentPlaybackContext",
@@ -889,6 +919,11 @@ class YouTubeStreamResolver(
                     playerConfig.invalidate()
                     challengeSolver?.invalidatePlayer()
                 }
+                // Checked before the age gate: an upload refusal also arrives as LOGIN_REQUIRED,
+                // and only the private/upload wording tells the two apart.
+                if (isAccountOnlyResponse(reason)) {
+                    throw AccountOnlyException("YouTube could not play this track: $reason")
+                }
                 // Distinguish age-gated refusals so the retry chain can
                 // route them to the web/music players instead of a guest retry.
                 if (isAgeGateResponse(statusCode, reason)) {
@@ -908,6 +943,8 @@ class YouTubeStreamResolver(
         val text = "$status $reason"
         return AGE_GATE_PATTERN.containsMatchIn(text)
     }
+
+    private fun isAccountOnlyResponse(reason: String): Boolean = ACCOUNT_ONLY_PATTERN.containsMatchIn(reason)
 
     /**
      * Uses the timestamp from the same player script that will decipher returned
@@ -1197,6 +1234,14 @@ class YouTubeStreamResolver(
         private val CONTENT_LENGTH_PATTERN = Regex("[?&]clen=(\\d+)")
         private val AGE_GATE_PATTERN = Regex(
             """(?i)confirm[\s_-]*your[\s_-]*age|age[\s_-]*restrict|inappropriate for some users|LOGIN_REQUIRED""",
+        )
+
+        /**
+         * Mirrors the desktop's private-playback detection so both clients route uploads the same
+         * way. YouTube Music uploads refuse guest players with the private-video wording.
+         */
+        internal val ACCOUNT_ONLY_PATTERN = Regex(
+            """(?i)(?:this )?video (?:is|has been set to) private|private video|only available to (?:the )?owner""",
         )
         private const val AUTHENTICATED_DIRECT_ITAG = 18
         private const val HLS_MIME_TYPE = "application/x-mpegURL"

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeStreamResolver.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeStreamResolver.kt
@@ -492,15 +492,29 @@ class YouTubeStreamResolver(
     }
 
     /**
+     * Drops both resolved URLs and the short failure backoff before a deliberate retry.
+     *
+     * A resolver failure is cached briefly to coalesce Media3 and prefetch requests. Once the
+     * player has surfaced that failure to the user, however, retaining it makes the next Play tap
+     * fail immediately without making a network request — the player appears to stop itself.
+     */
+    fun resetForRetry(videoId: String) {
+        invalidate(videoId)
+        failures.remove(videoId)
+    }
+
+    /**
      * Records a failed media fetch so the next resolve changes client instead of minting the same
      * rejected URL. Only response codes that indicate an expired/rejected CDN URL trigger this.
      */
-    fun reject(videoId: String, stream: ResolvedStream, responseCode: Int) {
-        if (responseCode !in RETRYABLE_STREAM_RESPONSE_CODES || stream.clientKey.isBlank()) return
+    fun reject(videoId: String, stream: ResolvedStream, responseCode: Int): Boolean {
+        if (responseCode !in RETRYABLE_STREAM_RESPONSE_CODES || stream.clientKey.isBlank()) {
+            return false
+        }
         rejectedClientsUntil["$videoId:${stream.clientKey}"] =
             System.currentTimeMillis() + REJECTED_CLIENT_BACKOFF_MS
-        invalidate(videoId)
-        failures.remove(videoId)
+        resetForRetry(videoId)
+        return true
     }
 
     /**

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/catalog/CatalogPagingTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/catalog/CatalogPagingTest.kt
@@ -1,0 +1,29 @@
+package dev.sfg.orchard.mobile.catalog
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * "Mixed for you" entries are radios: their continuations never run out, so a finite playlist's
+ * page budget means every open pages to the cap before the listener sees a full list.
+ */
+class CatalogPagingTest {
+
+    @Test
+    fun mixesAndRadiosPageFarLessThanSavedPlaylists() {
+        assertEquals(CatalogRepository.MAX_MIX_PAGES, CatalogRepository.pageBudget("RDCLAK5uy_examplemix"))
+        assertEquals(CatalogRepository.MAX_MIX_PAGES, CatalogRepository.pageBudget("VLRDTMAK5uy_supermix"))
+        assertEquals(CatalogRepository.MAX_MIX_PAGES, CatalogRepository.pageBudget("RDAMVMexamplevideo"))
+    }
+
+    @Test
+    fun finiteCollectionsKeepTheFullBudget() {
+        assertEquals(CatalogRepository.MAX_TRACK_PAGES, CatalogRepository.pageBudget("VLPLexampleplaylist"))
+        assertEquals(CatalogRepository.MAX_TRACK_PAGES, CatalogRepository.pageBudget("PLexampleplaylist"))
+        assertEquals(CatalogRepository.MAX_TRACK_PAGES, CatalogRepository.pageBudget("MPREb_examplealbum"))
+        assertEquals(CatalogRepository.MAX_TRACK_PAGES, CatalogRepository.pageBudget("FEmusic_liked_videos"))
+        // A saved playlist whose id merely opens with the prefix letters must not be mistaken for
+        // a radio once the VL prefix is gone.
+        assertEquals(CatalogRepository.MAX_TRACK_PAGES, CatalogRepository.pageBudget("VLPLRDsomething"))
+    }
+}

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/playback/AccountOnlyPlaybackTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/playback/AccountOnlyPlaybackTest.kt
@@ -1,0 +1,34 @@
+package dev.sfg.orchard.mobile.playback
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * A YouTube Music upload is refused by every anonymous player client. Recognising the refusal is
+ * what lets the resolver stop walking the guest catalog and hand the track to the signed-in
+ * player, which is the only one that can see it.
+ */
+class AccountOnlyPlaybackTest {
+
+    private val pattern = YouTubeStreamResolver.ACCOUNT_ONLY_PATTERN
+
+    @Test
+    fun uploadRefusalsAreRecognised() {
+        assertTrue(pattern.containsMatchIn("This video is private"))
+        assertTrue(pattern.containsMatchIn("Video unavailable. This video has been set to private."))
+        assertTrue(pattern.containsMatchIn("Private video"))
+        assertTrue(pattern.containsMatchIn("This content is only available to the owner"))
+    }
+
+    @Test
+    fun ageGatesAndOrdinaryFailuresAreNotTreatedAsAccountOnly() {
+        // These already route through the age-gate path, which keeps its own retry behaviour.
+        assertFalse(pattern.containsMatchIn("Sign in to confirm your age"))
+        assertFalse(pattern.containsMatchIn("The following content has been identified by the YouTube community as potentially inappropriate"))
+        // A genuinely gone video must keep costing the normal fallback chain, not a shortcut.
+        assertFalse(pattern.containsMatchIn("Video unavailable"))
+        assertFalse(pattern.containsMatchIn("This video is no longer available due to a copyright claim"))
+        assertFalse(pattern.containsMatchIn("HTTP 403"))
+    }
+}

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/playback/PlaybackErrorMessagesTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/playback/PlaybackErrorMessagesTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.playback
+
+import androidx.media3.common.util.UnstableApi
+import java.io.IOException
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Test
+
+@UnstableApi
+class PlaybackErrorMessagesTest {
+    @Test
+    fun `finds a matching exception nested below Media3 wrappers`() {
+        val expected = CdnFailure()
+        val playbackError = IllegalStateException("Source error", IOException(expected))
+
+        assertSame(expected, findCause(playbackError, CdnFailure::class.java))
+    }
+
+    @Test
+    fun `returns null when the failure did not reach the CDN`() {
+        val resolverError = IllegalStateException("No direct audio format was returned")
+
+        assertNull(playbackHttpResponseCode(resolverError))
+    }
+
+    private class CdnFailure : IOException()
+}

--- a/shared/ipcChannels.js
+++ b/shared/ipcChannels.js
@@ -75,6 +75,10 @@ export const IPC_CHANNELS = Object.freeze({
     GET_STATE: 'migration:get-state',
     REFRESH: 'migration:refresh'
   }),
+  NETWORK: Object.freeze({
+    GET_PROXY_MODE: 'network:get-proxy-mode',
+    SET_PROXY_MODE: 'network:set-proxy-mode'
+  }),
   SESSION_STATE: Object.freeze({
     GET: 'session-state:get',
     SET: 'session-state:set'

--- a/src/app/appearance/immersiveVeil.js
+++ b/src/app/appearance/immersiveVeil.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// The immersive backdrop used to sit under a veil of one fixed opacity, which
+// assumed every cover was dark. A pale one, greyscale especially, composited to
+// roughly the same lightness as the body text and the page turned into grey on
+// grey. Raising the background-intensity setting did not help, because that
+// scales the whole layer including the veil.
+//
+// So the veil is solved for instead of assumed: sample the artwork, work out
+// what the layer stack composites to, and pick the smallest opacity that still
+// clears a contrast target for both text colours. Dark covers land on the
+// existing default and look unchanged.
+
+// WCAG 2.1 relative luminance, and its contrast ratio.
+export function relativeLuminance([r, g, b]) {
+  const channel = (value) => {
+    const scaled = Math.min(255, Math.max(0, Number(value) || 0)) / 255;
+    return scaled <= 0.04045 ? scaled / 12.92 : ((scaled + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b);
+}
+
+export function contrastRatio(left, right) {
+  const a = relativeLuminance(left);
+  const b = relativeLuminance(right);
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+// Body text has to clear AA for normal text. Secondary text is held to the
+// large-text ratio: pinning it at 4.5 would force a veil so heavy that the
+// artwork stops reading as artwork at all, which is the feature.
+export const VEIL_TEXT_CONTRAST = 4.5;
+export const VEIL_MUTED_CONTRAST = 3;
+
+// The shipped default stays the floor, so nothing gets lighter than it was.
+export const VEIL_MIN_ALPHA = 0.34;
+// A ceiling short of 1, so even a white cover leaves the backdrop visible.
+export const VEIL_MAX_ALPHA = 0.82;
+
+/**
+ * What the viewer actually sees, in sRGB, for a given veil opacity.
+ *
+ * The stack is `page` at the bottom, then the artwork layer carrying the
+ * background-intensity opacity, and the veil painted inside that layer so it is
+ * scaled by the same opacity.
+ */
+export function compositeBackdrop({
+  artworkRgb,
+  veilRgb,
+  pageRgb,
+  backgroundOpacity = 0.82,
+  veilAlpha = VEIL_MIN_ALPHA
+}) {
+  return [0, 1, 2].map((channel) => {
+    const layer = artworkRgb[channel] * (1 - veilAlpha) + veilRgb[channel] * veilAlpha;
+    return pageRgb[channel] * (1 - backgroundOpacity) + layer * backgroundOpacity;
+  });
+}
+
+/**
+ * Smallest veil opacity that clears both contrast targets.
+ *
+ * Solved by bisection rather than algebraically, because contrast is not linear
+ * in the opacity and because this has to hold for the light theme too, where
+ * the veil is pale and the text is dark. Contrast rises monotonically with the
+ * opacity in both, since each theme's veil sits on the same side of the text as
+ * its page colour does.
+ *
+ * @returns {number} An opacity within [VEIL_MIN_ALPHA, VEIL_MAX_ALPHA]. The
+ * ceiling is returned when even that cannot reach the target, because a backdrop
+ * that is merely as good as possible beats one that has given up.
+ */
+export function solveVeilAlpha({
+  artworkRgb,
+  veilRgb,
+  pageRgb,
+  textRgb,
+  mutedRgb,
+  backgroundOpacity = 0.82,
+  minAlpha = VEIL_MIN_ALPHA,
+  maxAlpha = VEIL_MAX_ALPHA
+}) {
+  const clears = (veilAlpha) => {
+    const backdrop = compositeBackdrop({ artworkRgb, veilRgb, pageRgb, backgroundOpacity, veilAlpha });
+    return contrastRatio(textRgb, backdrop) >= VEIL_TEXT_CONTRAST &&
+      contrastRatio(mutedRgb, backdrop) >= VEIL_MUTED_CONTRAST;
+  };
+
+  if (clears(minAlpha)) return minAlpha;
+  if (!clears(maxAlpha)) return maxAlpha;
+
+  let low = minAlpha;
+  let high = maxAlpha;
+  for (let step = 0; step < 24; step += 1) {
+    const middle = (low + high) / 2;
+    if (clears(middle)) high = middle;
+    else low = middle;
+  }
+  return high;
+}

--- a/src/app/appearance/visualUtils.js
+++ b/src/app/appearance/visualUtils.js
@@ -17,7 +17,37 @@
  * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { hexColorToRgb } from './appearancePreferences.js';
+import { hexColorToRgb, immersiveBackgroundOpacity } from './appearancePreferences.js';
+import { VEIL_MIN_ALPHA, solveVeilAlpha } from './immersiveVeil.js';
+
+// What the veil composites against. The page colour and the two text colours
+// come from the theme tokens in base-shell.css and appearance-theme.css, and the
+// veil colours from immersive-background.css.
+// Each theme keeps the opacity it already shipped as its floor, so a cover that
+// never needed help looks exactly as it did.
+const VEIL_THEMES = {
+  dark: {
+    veilRgb: [3, 7, 4],
+    pageRgb: [0, 0, 0],
+    textRgb: [246, 246, 246],
+    mutedRgb: [141, 141, 141],
+    minAlpha: VEIL_MIN_ALPHA
+  },
+  light: {
+    veilRgb: [248, 250, 248],
+    pageRgb: [244, 246, 244],
+    textRgb: [20, 23, 20],
+    mutedRgb: [104, 112, 105],
+    minAlpha: 0.7
+  }
+};
+
+function veilTheme() {
+  const resolved = typeof document === 'undefined'
+    ? 'dark'
+    : document.documentElement?.dataset?.themeResolved;
+  return VEIL_THEMES[resolved === 'light' ? 'light' : 'dark'];
+}
 
 export function installVisualUtils(ctx) {
   function releaseTrackCount(value = '') {
@@ -35,11 +65,18 @@ export function installVisualUtils(ctx) {
     return /^[12][0-9]{3}$/.test(String(value || '').trim());
   };
 
+  // Mirrors normalizedLooseText in electron/catalog/musicText.js, and carries
+  // the same reason for keeping every script's letters: callers use the result
+  // as a dedupe key, and reducing a title to [a-z0-9] emptied anything written
+  // without Latin characters, so unrelated tracks collided on one blank key.
   ctx.normalizedLookupText = function normalizedLookupText(value = '') {
     return String(value)
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .normalize('NFC')
       .toLowerCase()
       .replace(/&/g, ' and ')
-      .replace(/[^a-z0-9]+/g, ' ')
+      .replace(/[^\p{L}\p{N}]+/gu, ' ')
       .trim();
   };
 
@@ -267,8 +304,63 @@ export function installVisualUtils(ctx) {
     ];
   };
 
-  ctx.loadPlayerBarAccent = async function loadPlayerBarAccent(imageUrl) {
+  // Average colour of the whole cover, opaque pixels only. The backdrop is a
+  // heavy blur of the artwork, so its mean is what the veil actually has to
+  // cover. Unlike the accent sampler this keeps greys, since a grey cover is
+  // exactly the case that needs a heavier veil.
+  ctx.meanArtworkColor = function meanArtworkColor(imageData) {
+    const data = imageData.data;
+    let r = 0;
+    let g = 0;
+    let b = 0;
+    let count = 0;
+
+    for (let index = 0; index < data.length; index += 16) {
+      if (data[index + 3] < 200) continue;
+      r += data[index];
+      g += data[index + 1];
+      b += data[index + 2];
+      count += 1;
+    }
+
+    return count ? [r / count, g / count, b / count] : null;
+  };
+
+  async function sampleArtworkImageData(imageUrl) {
+    if (!imageUrl || typeof Image === 'undefined' || typeof document === 'undefined') return null;
+
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.decoding = 'async';
+    image.referrerPolicy = 'no-referrer';
+
+    await new Promise((resolve, reject) => {
+      image.onload = resolve;
+      image.onerror = reject;
+      image.src = imageUrl;
+    });
+
+    const canvas = document.createElement('canvas');
+    const sampleWidth = 64;
+    const sampleHeight = Math.max(1, Math.round((image.naturalHeight / image.naturalWidth) * sampleWidth));
+    canvas.width = sampleWidth;
+    canvas.height = sampleHeight;
+
+    const context = canvas.getContext('2d', { willReadFrequently: true });
+    if (!context) throw new Error('Canvas is unavailable');
+
+    context.drawImage(image, 0, 0, sampleWidth, sampleHeight);
+    return context.getImageData(0, 0, sampleWidth, sampleHeight);
+  }
+
+  /**
+   * Reads the backdrop artwork once and derives both colours that depend on it:
+   * the accent, when the listener has asked for an artwork accent, and the veil
+   * opacity that keeps text legible over it. One decode serves both.
+   */
+  ctx.loadArtworkColors = async function loadArtworkColors(imageUrl) {
     const requestId = ++ctx.playerColorRequest;
+    const wantsArtworkAccent = ctx.accentColorSource?.value === 'artwork';
     const fallbackAccent = ctx.accentColorSource?.value === 'custom'
       ? hexColorToRgb(ctx.customAccentColor.value)
       : [47, 223, 147];
@@ -280,44 +372,44 @@ export function installVisualUtils(ctx) {
       document.documentElement.style.setProperty('--q-primary', `rgb(${ctx.rgbToken(accent.rgb)})`);
     }
 
-    if (ctx.accentColorSource?.value !== 'artwork') {
-      applyAccent(fallbackAccent);
-      return;
+    // No artwork to measure means nothing is covering the page, so the veil
+    // goes back to the shipped default rather than holding a previous cover's.
+    function applyVeil(artworkRgb) {
+      if (requestId !== ctx.playerColorRequest || !ctx.immersiveVeilAlpha) return;
+
+      const theme = veilTheme();
+      ctx.immersiveVeilAlpha.value = artworkRgb
+        ? solveVeilAlpha({
+          ...theme,
+          artworkRgb,
+          backgroundOpacity: immersiveBackgroundOpacity(ctx.immersiveBackgroundIntensity?.value)
+        })
+        : theme.minAlpha;
     }
 
-    if (!imageUrl || typeof Image === 'undefined' || typeof document === 'undefined') {
-      applyAccent(fallbackAccent);
-      return;
-    }
+    // A fixed accent does not depend on the artwork, so it lands immediately
+    // rather than waiting on a decode that only the veil needs.
+    if (!wantsArtworkAccent) applyAccent(fallbackAccent);
 
+    let imageData = null;
     try {
-      const image = new Image();
-      image.crossOrigin = 'anonymous';
-      image.decoding = 'async';
-      image.referrerPolicy = 'no-referrer';
-
-      await new Promise((resolve, reject) => {
-        image.onload = resolve;
-        image.onerror = reject;
-        image.src = imageUrl;
-      });
-
-      const canvas = document.createElement('canvas');
-      const sampleWidth = 64;
-      const sampleHeight = Math.max(1, Math.round((image.naturalHeight / image.naturalWidth) * sampleWidth));
-      canvas.width = sampleWidth;
-      canvas.height = sampleHeight;
-
-      const context = canvas.getContext('2d', { willReadFrequently: true });
-      if (!context) throw new Error('Canvas is unavailable');
-
-      context.drawImage(image, 0, 0, sampleWidth, sampleHeight);
-      const accent = ctx.pickArtworkAccent(context.getImageData(0, 0, sampleWidth, sampleHeight));
-
-      if (accent) applyAccent(accent);
+      imageData = await sampleArtworkImageData(imageUrl);
     } catch {
-      applyAccent(fallbackAccent);
+      imageData = null;
     }
+
+    if (requestId !== ctx.playerColorRequest) return;
+
+    applyVeil(imageData ? ctx.meanArtworkColor(imageData) : null);
+    if (!wantsArtworkAccent) return;
+
+    if (!imageData) {
+      applyAccent(fallbackAccent);
+      return;
+    }
+
+    const accent = ctx.pickArtworkAccent(imageData);
+    if (accent) applyAccent(accent);
   };
 
   ctx.playlistCardStyle = function playlistCardStyle(index) {

--- a/src/app/browse/browseActions.js
+++ b/src/app/browse/browseActions.js
@@ -18,6 +18,7 @@
  */
 
 import { openCollectionWithLoading } from './collectionNavigation.js';
+import { copyTextToClipboard } from '../platform/clipboardText.js';
 
 export function installBrowseActions(ctx) {
   ctx.cancelBrowseTrackPrefetch = function cancelBrowseTrackPrefetch() {
@@ -252,7 +253,7 @@ export function installBrowseActions(ctx) {
     if (!value) return;
 
     try {
-      await navigator.clipboard.writeText(value);
+      await copyTextToClipboard(value);
     } catch {
       ctx.errorMessage.value = `Copy failed. Use ${value}`;
     }

--- a/src/app/core/createOrchardApp.js
+++ b/src/app/core/createOrchardApp.js
@@ -62,6 +62,7 @@ import { installState } from './state.js';
 import { installSystemMediaActions } from '../platform/systemMediaActions.js';
 import { installSupportActions } from '../platform/supportActions.js';
 import { installUpdateActions } from '../platform/updateActions.js';
+import { installNetworkActions } from '../platform/networkActions.js';
 import { installVisualUtils } from '../appearance/visualUtils.js';
 import { installYouTubeHistoryActions } from '../browse/youtubeHistoryActions.js';
 import { installYouTubeLikesActions } from '../browse/youtubeLikesActions.js';
@@ -116,6 +117,7 @@ export function createOrchardApp() {
   installAutoplayActions(ctx);
   installMigrationActions(ctx);
   installUpdateActions(ctx);
+  installNetworkActions(ctx);
   installChangelogActions(ctx);
   installArtworkService(ctx);
   installMediaHandlers(ctx);

--- a/src/app/core/lifecycle.js
+++ b/src/app/core/lifecycle.js
@@ -112,7 +112,7 @@ export function installLifecycle(ctx) {
 
   watch(ctx.backdropArtworkImage, (imageUrl) => {
     if (imageUrl) ctx.lastImmersiveArtworkImage.value = imageUrl;
-    ctx.loadPlayerBarAccent(imageUrl);
+    ctx.loadArtworkColors(imageUrl);
   }, { immediate: true });
 
   watch(ctx.discordArtworkImage, () => {
@@ -328,8 +328,15 @@ export function installLifecycle(ctx) {
     ctx.syncSongCacheSettings();
   });
 
-  watch([ctx.accentColorSource, ctx.customAccentColor], () => {
-    ctx.loadPlayerBarAccent(ctx.backdropArtworkImage.value);
+  // The veil is solved against the theme's text colours and scaled by the
+  // background intensity, so both have to re-solve it, not just the accent.
+  watch([
+    ctx.accentColorSource,
+    ctx.customAccentColor,
+    ctx.themePreference,
+    ctx.immersiveBackgroundIntensity
+  ], () => {
+    ctx.loadArtworkColors(ctx.backdropArtworkImage.value);
   });
 
   watch(ctx.themePreference, () => {

--- a/src/app/core/lifecycle.js
+++ b/src/app/core/lifecycle.js
@@ -394,6 +394,7 @@ export function installLifecycle(ctx) {
     ctx.updateMediaSessionPlaybackState();
     ctx.updateMediaSessionPositionState();
     void ctx.loadMigrationNotice();
+    void ctx.loadProxyMode();
     void ctx.bindUpdateEvents().then((bound) => {
       if (bound && new URLSearchParams(window.location.search).get('welcome') !== '1') {
         void ctx.ensureOfficialArtistPages();

--- a/src/app/core/readinessActions.js
+++ b/src/app/core/readinessActions.js
@@ -19,6 +19,7 @@
 
 import { computed, ref } from 'vue';
 import { readPinnedTracks } from '../browse/pinsPersistence.js';
+import { copyTextToClipboard } from '../platform/clipboardText.js';
 import { readPlaybackState } from '../playback/queuePersistence.js';
 
 const SETUP_STORAGE_KEY = 'orchard:setup-state';
@@ -412,8 +413,12 @@ export function installReadinessActions(ctx) {
   ctx.copyDiagnostics = async function copyDiagnostics() {
     if (!ctx.diagnostics.value.report) await ctx.collectDiagnostics();
     const text = JSON.stringify(ctx.diagnostics.value.report, null, 2);
-    await navigator.clipboard?.writeText(text);
-    ctx.diagnosticsMessage.value = 'Diagnostic report copied.';
+    try {
+      await copyTextToClipboard(text);
+      ctx.diagnosticsMessage.value = 'Diagnostic report copied.';
+    } catch {
+      ctx.diagnosticsMessage.value = 'Copy failed. Export the report instead.';
+    }
   };
 
   ctx.exportOrchardBackup = async function exportOrchardBackup() {

--- a/src/app/core/state.js
+++ b/src/app/core/state.js
@@ -52,6 +52,7 @@ import {
   readPlaybackState,
   writePlaybackState
 } from '../playback/queuePersistence.js';
+import { VEIL_MIN_ALPHA } from '../appearance/immersiveVeil.js';
 import { SONG_CACHE_DEFAULTS, clampSongCacheMaxSizeMb } from '../playback/songCachePreferences.js';
 import { DEFAULT_QUEUE_LAYOUT, QUEUE_LAYOUT_OPTIONS, normalizeQueueLayout } from '../playback/queueLayout.js';
 
@@ -348,6 +349,7 @@ export function installState(ctx) {
   ctx.detailEnhancedArtwork = ref(null);
   ctx.playlistArtworkCollage = ref([]);
   ctx.playerBarAccent = ref(ctx.createPlayerBarAccent([47, 223, 147]));
+  ctx.immersiveVeilAlpha = ref(VEIL_MIN_ALPHA);
   ctx.lastImmersiveArtworkImage = ref('');
   ctx.nowArtworkVideoFailed = ref(false);
   ctx.detailArtworkVideoFailed = ref(false);

--- a/src/app/core/state.js
+++ b/src/app/core/state.js
@@ -187,6 +187,7 @@ export function installState(ctx) {
     pairUrl: '',
     appPairUrl: '',
     webPairUrl: '',
+    altWebPairUrls: [],
     qrSvg: '',
     expiresAt: 0,
     pending: [],

--- a/src/app/platform/clipboardText.js
+++ b/src/app/platform/clipboardText.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// The renderer's permission handler denies clipboard-sanitized-write, so
+// navigator.clipboard rejects with NotAllowedError inside the app window. The
+// main-process bridge is the only path that always works; the web APIs stay as
+// fallbacks for the browser-served surfaces that have no preload.
+export async function copyTextToClipboard(value) {
+  const text = String(value ?? '').trim();
+  if (!text) return false;
+
+  if (window.orchardClipboard?.writeText) {
+    await window.orchardClipboard.writeText(text);
+    return true;
+  }
+
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // Falls through to the execCommand path below.
+    }
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand('copy');
+  textarea.remove();
+  if (!copied) throw new Error('Clipboard access is unavailable.');
+  return true;
+}

--- a/src/app/platform/connectActions.js
+++ b/src/app/platform/connectActions.js
@@ -18,6 +18,7 @@
  */
 
 import { fetchBatchCloudAnalysis } from '../../services/cloudAnalysisSync.js';
+import { copyTextToClipboard } from './clipboardText.js';
 
 const CONNECT_SYNC_INTERVAL_MS = 500;
 
@@ -130,6 +131,7 @@ export function installConnectActions(ctx) {
         pairUrl: data.appUrl || data.url,
         appPairUrl: data.appUrl || data.url,
         webPairUrl: data.webUrl || '',
+        altWebPairUrls: data.altWebUrls || [],
         qrSvg: data.qrSvg,
         expiresAt: data.expiresAt
       }
@@ -156,16 +158,34 @@ export function installConnectActions(ctx) {
 
   ctx.copyOrchardConnectLink = async function copyOrchardConnectLink() {
     const url = ctx.orchardConnect.value.pairUrl;
-    if (!url || !navigator.clipboard) return;
-    await navigator.clipboard.writeText(url);
-    ctx.orchardConnectPairingMessage.value = 'App link copied.';
+    if (!url) return;
+    try {
+      await copyTextToClipboard(url);
+      ctx.orchardConnectPairingMessage.value = 'App link copied.';
+    } catch {
+      ctx.orchardConnectPairingMessage.value = `Copy failed. Use ${url}`;
+    }
   };
 
   ctx.copyOrchardConnectWebLink = async function copyOrchardConnectWebLink() {
     const url = ctx.orchardConnect.value.webPairUrl;
-    if (!url || !navigator.clipboard) return;
-    await navigator.clipboard.writeText(url);
-    ctx.orchardConnectPairingMessage.value = 'Camera link copied.';
+    if (!url) return;
+    try {
+      await copyTextToClipboard(url);
+      ctx.orchardConnectPairingMessage.value = 'Camera link copied.';
+    } catch {
+      ctx.orchardConnectPairingMessage.value = `Copy failed. Use ${url}`;
+    }
+  };
+
+  ctx.copyOrchardConnectAltLink = async function copyOrchardConnectAltLink(url) {
+    if (!url) return;
+    try {
+      await copyTextToClipboard(url);
+      ctx.orchardConnectPairingMessage.value = 'Alternate link copied.';
+    } catch {
+      ctx.orchardConnectPairingMessage.value = `Copy failed. Use ${url}`;
+    }
   };
 
   ctx.handleConnectCommand = function handleConnectCommand({ command = {} } = {}) {

--- a/src/app/platform/networkActions.js
+++ b/src/app/platform/networkActions.js
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+// The proxy mode is owned by the main process, which applies it to the session
+// before any window loads. The renderer only reads it back and asks for changes.
+import { computed, ref } from 'vue';
+
+export function installNetworkActions(ctx) {
+  ctx.proxyMode = ref('system');
+  ctx.proxyModeMessage = ref('');
+  ctx.proxyModeAvailable = Boolean(window.orchardNetwork?.setProxyMode);
+
+  ctx.loadProxyMode = async function loadProxyMode() {
+    if (!window.orchardNetwork?.getProxyMode) return;
+    const mode = await window.orchardNetwork.getProxyMode();
+    if (mode) ctx.proxyMode.value = mode;
+  };
+
+  ctx.setProxyMode = async function setProxyMode(mode) {
+    if (!window.orchardNetwork?.setProxyMode) return;
+    try {
+      ctx.proxyMode.value = await window.orchardNetwork.setProxyMode(mode);
+      // Images already refused by the dead proxy stay broken until they are
+      // requested again, so say so rather than leaving the listener staring at
+      // the same empty artwork wondering whether the setting took.
+      ctx.proxyModeMessage.value = ctx.proxyMode.value === 'direct'
+        ? 'Orchard now ignores the system proxy. Restart Orchard if album art is still missing.'
+        : 'Orchard now follows the system proxy.';
+    } catch (error) {
+      ctx.proxyModeMessage.value = `Could not change the proxy setting. ${error?.message || error}`;
+    }
+  };
+
+  ctx.proxyBypassToggle = computed({
+    get: () => ctx.proxyMode.value === 'direct',
+    set: (value) => { void ctx.setProxyMode(value ? 'direct' : 'system'); }
+  });
+}

--- a/src/app/social/listeningPartyActions.js
+++ b/src/app/social/listeningPartyActions.js
@@ -19,6 +19,7 @@
 
 import { computed, ref, watch } from 'vue';
 import { ListeningPartyClient } from './listeningPartyClient.js';
+import { copyTextToClipboard } from '../platform/clipboardText.js';
 
 const PARTY_SYNC_INTERVAL_MS = 2500;
 
@@ -26,29 +27,6 @@ function sameTrackOrder(left = [], right = []) {
   return left.length === right.length && left.every((track, index) => track?.id === right[index]?.id);
 }
 
-async function copyText(value) {
-  const text = String(value || '').trim();
-  if (!text) return false;
-  if (window.orchardClipboard?.writeText) {
-    await window.orchardClipboard.writeText(text);
-    return true;
-  }
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text);
-    return true;
-  }
-  const textarea = document.createElement('textarea');
-  textarea.value = text;
-  textarea.setAttribute('readonly', '');
-  textarea.style.position = 'fixed';
-  textarea.style.opacity = '0';
-  document.body.appendChild(textarea);
-  textarea.select();
-  const copied = document.execCommand('copy');
-  textarea.remove();
-  if (!copied) throw new Error('Clipboard access is unavailable.');
-  return true;
-}
 
 export function installListeningPartyActions(ctx) {
   ctx.listeningParty = ref({
@@ -153,7 +131,7 @@ export function installListeningPartyActions(ctx) {
 
   ctx.copyListeningPartyInviteUrl = async function copyListeningPartyInviteUrl() {
     if (!ctx.listeningPartyInviteUrl.value) return;
-    await copyText(ctx.listeningPartyInviteUrl.value);
+    await copyTextToClipboard(ctx.listeningPartyInviteUrl.value);
     ctx.listeningPartyInviteCopied.value = true;
     ctx.showShareMessage?.('Copied listening party invite link.');
     window.setTimeout(() => {

--- a/src/app/social/shareActions.js
+++ b/src/app/social/shareActions.js
@@ -18,6 +18,7 @@
  */
 
 import { ref } from 'vue';
+import { copyTextToClipboard } from '../platform/clipboardText.js';
 
 const songLinksOrigin = 'https://songlinks.sfg545.dev';
 
@@ -83,17 +84,7 @@ async function fetchSongLinksJson(path, payload) {
 }
 
 async function copyShareText(value) {
-  const text = cleanShareText(value);
-  if (!text) return false;
-  if (window.orchardClipboard?.writeText) {
-    await window.orchardClipboard.writeText(text);
-    return true;
-  }
-  if (navigator.clipboard?.writeText) {
-    await navigator.clipboard.writeText(text);
-    return true;
-  }
-  throw new Error('Clipboard access is unavailable.');
+  return copyTextToClipboard(cleanShareText(value));
 }
 
 export function installShareActions(ctx) {

--- a/src/audio/crossfade/crossfadeMixer.js
+++ b/src/audio/crossfade/crossfadeMixer.js
@@ -56,9 +56,28 @@ function equalPowerCurves(size = 64) {
 
 const CURVES = equalPowerCurves();
 
+// How fast a deck moves on or off the band-split network. The two paths are
+// magnitude-identical, so this swap has no level to fade -- it is only there to
+// keep the phase change from arriving as a step. Short enough to finish inside
+// the scheduler's lead time, so a deck is always fully on the intended path
+// before its curves start.
+const BAND_SPLIT_TIME_CONSTANT = 0.006;
+
 export function createCrossfadeMixer({ connectElement, currentTime }) {
   function mixParam(node) {
     return node.mixGain.gain;
+  }
+
+  // Only the DJ styles automate the crossover, and only they pay for it. See
+  // the allpass note in audioAnalyzer.js: leaving the split in circuit costs
+  // several dB of transient headroom for a response that is otherwise flat.
+  function setBandSplit(node, enabled) {
+    if (!node?.directBand || !node?.splitInput) return;
+    const now = currentTime();
+    node.directBand.gain.cancelScheduledValues(now);
+    node.splitInput.gain.cancelScheduledValues(now);
+    node.directBand.gain.setTargetAtTime(enabled ? 0 : 1, now, BAND_SPLIT_TIME_CONSTANT);
+    node.splitInput.gain.setTargetAtTime(enabled ? 1 : 0, now, BAND_SPLIT_TIME_CONSTANT);
   }
 
   function scheduleGain(node, curve, scale, startTime, duration, floor = 0) {
@@ -216,6 +235,10 @@ export function createCrossfadeMixer({ connectElement, currentTime }) {
     toGainParam.setValueAtTime(0, currentTime());
 
     const djStyle = ['dj_switch', 'dj_filter', 'dj_blend'].includes(transitionStyle);
+    // Arm both decks before anything is scheduled, so the crossover is settled
+    // and carrying signal by the time the first curve runs at `startTime`.
+    setBandSplit(fromNode, djStyle);
+    setBandSplit(toNode, djStyle);
     if (djStyle) {
       scheduleDjGains(
         fromNode,
@@ -257,6 +280,7 @@ export function createCrossfadeMixer({ connectElement, currentTime }) {
     const gain = mixParam(node);
     gain.cancelScheduledValues(now);
     gain.setTargetAtTime(1, now, 0.02);
+    setBandSplit(node, false);
     node.bassGain?.gain.cancelScheduledValues(now);
     node.bassGain?.gain.setTargetAtTime(1, now, 0.02);
     node.midDuck?.gain.cancelScheduledValues(now);

--- a/src/audio/engine/audioAnalyzer.js
+++ b/src/audio/engine/audioAnalyzer.js
@@ -85,8 +85,17 @@ export function createAudioAnalyzer(options = {}) {
   // `midDuck` is one peaking section rather than a second crossover: the
   // renderer can afford a three-way split offline, but here a single
   // automatable dip covers the same band without adding two more phase-shifted
-  // branches that would have to sum flat. At 0 dB it is transparent, so a
-  // non-DJ crossfade and ordinary playback run through an unchanged signal.
+  // branches that would have to sum flat. At 0 dB it is transparent.
+  //
+  // This network is switched *out* of circuit for ordinary playback, because
+  // "transparent" is only true of its magnitude response. An LR4 low/high pair
+  // sums to an allpass: dead flat within 0.03 dB, which is why it never showed
+  // up as a tone-balance problem, but it redistributes phase across the low
+  // mids and that grows transient peaks. Measured against real masters it adds
+  // 0.7-3.4 dB of peak with no change in level, so a track mastered near full
+  // scale -- which is most of them -- was driven past the destination's ceiling
+  // and hard-clipped on every transient, with EQ and every gain at unity. That
+  // was the "distorted even with the audio engine off" report.
   const BASS_CROSSOVER_HZ = 200;
   const MID_DUCK_HZ = 1200;
 
@@ -127,6 +136,9 @@ export function createAudioAnalyzer(options = {}) {
     const normalizedGain = ctx.createGain();
     const gain = ctx.createGain();
     const mixGain = ctx.createGain();
+    const directBand = ctx.createGain();
+    const splitInput = ctx.createGain();
+    const bandSum = ctx.createGain();
     const { lowPass, highPass } = outputFilters(ctx);
     const { bassLow, bassHigh, bassGain, midDuck } = mixBands(ctx);
     analyser.fftSize = config.fftSize;
@@ -140,6 +152,11 @@ export function createAudioAnalyzer(options = {}) {
     normalizedGain.gain.value = 0;
     gain.gain.value = clamp01(element.volume);
     mixGain.gain.value = 1;
+    // Playback starts on the unsplit path and stays there unless a transition
+    // that automates the bands asks for the split.
+    directBand.gain.value = 1;
+    splitInput.gain.value = 0;
+    bandSum.gain.value = 1;
 
     const processor = options.createProcessor?.({ context: ctx, source, element });
     if (processor?.output) processor.output.connect(analyser);
@@ -150,23 +167,34 @@ export function createAudioAnalyzer(options = {}) {
     normalizer.connect(normalizedGain);
     normalizedGain.connect(gain);
     gain.connect(mixGain);
-    // The sweep filters sit on the high branch only. Sweeping a low-pass down
+    // Ordinary playback: mix envelope straight to the output, no filters in
+    // the path at all. `splitInput` sits at zero, so the crossover branches
+    // below are silent and their filter state decays away until armed.
+    mixGain.connect(directBand);
+    directBand.connect(ctx.destination);
+    // The sweep filter sits on the high branch only. Sweeping a low-pass down
     // to 200 Hz across a band that starts at 200 Hz is meaningless, and running
     // it full-range is what made the outgoing track lose its body and its low
-    // end at the same time.
-    mixGain.connect(bassLow[0]);
-    mixGain.connect(bassHigh[0]);
-    bassGain.connect(ctx.destination);
+    // end at the same time. The static output pair is common to both branches
+    // and lives after the sum, so the crossover halves stay phase-matched.
+    mixGain.connect(splitInput);
+    splitInput.connect(bassLow[0]);
+    splitInput.connect(bassHigh[0]);
+    bassGain.connect(bandSum);
     midDuck.connect(lowPass);
-    lowPass.connect(highPass);
+    lowPass.connect(bandSum);
+    bandSum.connect(highPass);
     highPass.connect(ctx.destination);
     element.volume = 1;
 
     const node = {
       analyser,
+      bandSum,
       bassGain,
+      directBand,
       directGain,
       gain,
+      splitInput,
       highPass,
       lowPass,
       midDuck,

--- a/src/components/chrome/AppFrame.vue
+++ b/src/components/chrome/AppFrame.vue
@@ -119,6 +119,7 @@ export default {
     :style="{
       ...playerBarStyle,
       '--immersive-background-opacity': immersiveBackgroundOpacity(immersiveBackgroundIntensity),
+      '--immersive-veil-alpha': immersiveVeilAlpha,
       ...customArtistProfileCameraStyle
     }"
   >

--- a/src/components/chrome/RightPanel.vue
+++ b/src/components/chrome/RightPanel.vue
@@ -116,6 +116,21 @@ export default {
                 <strong>{{ continuousQueueEnabled ? 'Queue' : 'Up next' }}</strong>
               </div>
               <div class="right-queue-header__actions">
+                <!-- The full queue has always had a page of its own, but the
+                     only route to it was a sidebar entry filed under Library,
+                     which reads as saved content rather than what is playing.
+                     Anyone wanting more room for the queue is looking at the
+                     queue, so the way through is offered here. -->
+                <button
+                  type="button"
+                  class="right-queue-expand"
+                  title="Open the full queue"
+                  aria-label="Open the full queue"
+                  @click="selectView('queue')"
+                >
+                  <q-icon name="open_in_full" />
+                  <span>Open</span>
+                </button>
                 <button
                   v-if="queue.length > 1"
                   type="button"

--- a/src/components/settings/SettingsView.vue
+++ b/src/components/settings/SettingsView.vue
@@ -465,6 +465,23 @@ export default {
               </button>
             </div>
             <p v-if="orchardConnectPairingMessage" class="settings-connect__message">{{ orchardConnectPairingMessage }}</p>
+            <details v-if="orchardConnect.altWebPairUrls?.length" class="settings-connect__alternates">
+              <summary>Phone can't reach this address?</summary>
+              <p>
+                This machine has more than one network address. If the QR code does not connect, open one
+                of these on the phone instead.
+              </p>
+              <button
+                v-for="url in orchardConnect.altWebPairUrls"
+                :key="url"
+                type="button"
+                class="settings-button settings-connect__alternate"
+                @click="copyOrchardConnectAltLink(url)"
+              >
+                <q-icon name="content_copy" />
+                {{ url }}
+              </button>
+            </details>
           </div>
         </div>
 

--- a/src/components/settings/SettingsView.vue
+++ b/src/components/settings/SettingsView.vue
@@ -82,6 +82,10 @@ export default {
         <q-icon name="info_outline" />
         <span>Application</span>
       </a>
+      <a v-if="proxyModeAvailable" href="#settings-network">
+        <q-icon name="lan" />
+        <span>Network</span>
+      </a>
       <a href="#settings-diagnostics">
         <q-icon name="fact_check" />
         <span>Diagnostics</span>
@@ -569,6 +573,32 @@ export default {
             Restore defaults
           </button>
         </div>
+      </section>
+
+      <section
+        v-if="proxyModeAvailable"
+        id="settings-network"
+        class="settings-section"
+        aria-labelledby="settings-network-title"
+      >
+        <div class="settings-section__heading">
+          <h2 id="settings-network-title">Network</h2>
+          <p>How Orchard reaches the internet.</p>
+        </div>
+
+        <div class="settings-row">
+          <div class="settings-row__copy">
+            <label for="settings-proxy-bypass">Ignore system proxy</label>
+            <p>
+              Album art and update checks go through your computer's proxy settings; playback never
+              does. Turn this on if artwork is missing or updates fail with a tunnel or proxy error
+              while music still plays.
+            </p>
+          </div>
+          <q-toggle id="settings-proxy-bypass" v-model="proxyBypassToggle" color="primary" aria-label="Ignore system proxy" />
+        </div>
+
+        <p v-if="proxyModeMessage" class="settings-connect__message">{{ proxyModeMessage }}</p>
       </section>
 
       <DiagnosticsSection :app="app" />

--- a/src/styles/fullscreen-player.css
+++ b/src/styles/fullscreen-player.css
@@ -22,8 +22,12 @@
   z-index: 11000;
   inset: 0;
   display: grid;
-  min-width: 720px;
-  min-height: 520px;
+  /* The minimums keep the three-column stage honest on a small window, but the
+     panel is `overflow: hidden`, so anything past the viewport is clipped
+     outright rather than scrolled. Capping them at the viewport keeps the
+     transport row on screen on short displays such as 1920x480 bar monitors. */
+  min-width: min(720px, 100vw);
+  min-height: min(520px, 100vh);
   grid-template-rows: 76px minmax(0, 1fr) 150px;
   overflow: hidden;
   background: #070908;
@@ -229,7 +233,7 @@
 .fullscreen-player__lyrics {
   position: relative;
   height: min(58vh, 600px);
-  min-height: 300px;
+  min-height: min(300px, 58vh);
   overflow: hidden;
   -webkit-mask-image: linear-gradient(transparent, #000 13%, #000 82%, transparent);
   mask-image: linear-gradient(transparent, #000 13%, #000 82%, transparent);
@@ -484,6 +488,57 @@
 
   .fullscreen-player__transport {
     padding-bottom: 8px;
+  }
+}
+
+/* Ultra-short displays (bar monitors, half-height windows) cannot afford the
+   compact tier's 184px of chrome, so the rows tighten again and the artwork is
+   sized off what is left rather than off a fixed ceiling. */
+@media (max-height: 560px) {
+  .fullscreen-player {
+    grid-template-rows: 46px minmax(0, 1fr) 104px;
+  }
+
+  .fullscreen-player__header {
+    padding-block: 4px;
+  }
+
+  .fullscreen-player__left {
+    gap: 12px;
+  }
+
+  .fullscreen-player__artwork {
+    width: min(100%, 360px, calc(100vh - 236px));
+  }
+
+  .fullscreen-player__track-copy strong {
+    font-size: clamp(19px, 2vw, 26px);
+  }
+
+  .fullscreen-player__lyrics {
+    height: calc(100vh - 176px);
+  }
+
+  .fullscreen-player__lyrics .lyrics-line {
+    padding: 5px 0;
+    font-size: clamp(17px, 1.6vw, 26px);
+  }
+
+  .fullscreen-player__transport {
+    padding: 2px 44px 8px;
+  }
+
+  .fullscreen-player__buttons {
+    gap: 12px;
+  }
+
+  .fullscreen-player__buttons .q-btn:nth-child(3) {
+    width: 48px;
+    height: 48px;
+  }
+
+  .fullscreen-player__lyrics-label {
+    display: none;
   }
 }
 

--- a/src/styles/immersive-background.css
+++ b/src/styles/immersive-background.css
@@ -22,7 +22,7 @@
 .immersive-background::after {
   position: absolute;
   inset: 0;
-  background: rgba(3, 7, 4, 0.34);
+  background: rgba(3, 7, 4, var(--immersive-veil-alpha, 0.34));
   content: '';
 }
 
@@ -43,5 +43,5 @@
 }
 
 html[data-theme-resolved='light'] .immersive-background::after {
-  background: rgba(248, 250, 248, 0.7);
+  background: rgba(248, 250, 248, var(--immersive-veil-alpha, 0.7));
 }

--- a/src/styles/right-panel.css
+++ b/src/styles/right-panel.css
@@ -81,6 +81,7 @@
 .right-queue .queue-preview__item:focus-visible,
 .right-queue-remove:focus-visible,
 .right-queue-clear:focus-visible,
+.right-queue-expand:focus-visible,
 .right-queue-sort:focus-visible {
   outline: 1px solid rgba(47, 223, 147, 0.4);
   outline-offset: -1px;
@@ -219,7 +220,8 @@
   gap: 7px;
 }
 
-.right-queue-clear {
+.right-queue-clear,
+.right-queue-expand {
   justify-content: center;
 }
 
@@ -228,6 +230,7 @@
 }
 
 .right-queue-clear,
+.right-queue-expand,
 .right-queue-sort {
   display: inline-flex;
   min-height: 28px;
@@ -244,6 +247,7 @@
 }
 
 .right-queue-clear:hover,
+.right-queue-expand:hover,
 .right-queue-sort:hover {
   border-color: rgba(255, 255, 255, 0.16);
   background: rgba(255, 255, 255, 0.045);
@@ -251,6 +255,7 @@
 }
 
 .right-queue-clear .q-icon,
+.right-queue-expand .q-icon,
 .right-queue-sort .q-icon {
   font-size: 12px;
 }

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -348,6 +348,24 @@
   color: #b7c2bb;
 }
 
+.settings-connect__alternates {
+  display: grid;
+  gap: 8px;
+  justify-items: start;
+}
+
+.settings-connect__alternates summary {
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.settings-connect__alternate {
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+
 .settings-connect-list {
   display: grid;
 }

--- a/test/audioAnalyzerGraph.test.js
+++ b/test/audioAnalyzerGraph.test.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createAudioAnalyzer } from '../src/audio/engine/audioAnalyzer.js';
+
+function param(value = 0) {
+  return {
+    value,
+    cancelScheduledValues() {},
+    setValueAtTime(next) { this.value = next; },
+    setTargetAtTime(next) { this.value = next; },
+    linearRampToValueAtTime(next) { this.value = next; },
+    setValueCurveAtTime(values) { this.value = values.at(-1); }
+  };
+}
+
+function graphNode(kind) {
+  return {
+    kind,
+    outputs: [],
+    gain: param(1),
+    frequency: param(0),
+    Q: param(0),
+    threshold: param(0),
+    knee: param(0),
+    ratio: param(0),
+    attack: param(0),
+    release: param(0),
+    connect(target) { this.outputs.push(target); return target; }
+  };
+}
+
+function mockContext() {
+  const destination = graphNode('destination');
+  return {
+    sampleRate: 48000,
+    currentTime: 0,
+    destination,
+    createGain: () => graphNode('gain'),
+    createAnalyser: () => Object.assign(graphNode('analyser'), {
+      frequencyBinCount: 512,
+      getByteFrequencyData() {},
+      getByteTimeDomainData() {},
+      getFloatTimeDomainData() {}
+    }),
+    createBiquadFilter: () => graphNode('biquad'),
+    createStereoPanner: () => Object.assign(graphNode('panner'), { pan: param(0) }),
+    createDynamicsCompressor: () => graphNode('compressor'),
+    createMediaElementSource: () => graphNode('source')
+  };
+}
+
+// Every distinct route from `start` to the destination, as lists of nodes.
+function routes(start, destination, seen = new Set()) {
+  if (start === destination) return [[start]];
+  if (seen.has(start)) return [];
+  seen.add(start);
+  const found = [];
+  for (const output of start.outputs) {
+    for (const tail of routes(output, destination, new Set(seen))) found.push([start, ...tail]);
+  }
+  return found;
+}
+
+function connectedElement() {
+  const context = mockContext();
+  const analyzer = createAudioAnalyzer();
+  const element = { volume: 0.5 };
+  const previousWindow = globalThis.window;
+  globalThis.window = { AudioContext: function AudioContextStub() { return context; } };
+  try {
+    const node = analyzer.connectElement(element);
+    return { analyzer, context, element, node };
+  } finally {
+    if (previousWindow === undefined) delete globalThis.window;
+    else globalThis.window = previousWindow;
+  }
+}
+
+test('ordinary playback reaches the output without passing through the crossover', () => {
+  const { context, node } = connectedElement();
+
+  const live = routes(node.mixGain, context.destination)
+    .filter((route) => route.every((step) => step === node.mixGain ||
+      step === context.destination ||
+      step.gain.value !== 0 ||
+      step.kind === 'biquad'));
+
+  assert.equal(live.length, 1, 'exactly one audible path from the mix envelope');
+  assert.ok(
+    live[0].every((step) => step.kind !== 'biquad'),
+    'the audible path carries no filters, so untransitioned playback is transparent'
+  );
+});
+
+test('the crossover branches are wired but silent until a transition arms them', () => {
+  const { node } = connectedElement();
+
+  assert.equal(node.directBand.gain.value, 1);
+  assert.equal(node.splitInput.gain.value, 0);
+  assert.ok(node.splitInput.outputs.length >= 2, 'the split feeds both crossover branches');
+});
+
+test('the crossover halves stay phase-matched by sharing the post-sum output filters', () => {
+  const { context, node } = connectedElement();
+
+  const lowRoute = routes(node.bassGain, context.destination).at(0);
+  const highRoute = routes(node.midDuck, context.destination).at(0);
+
+  assert.ok(lowRoute?.includes(node.bandSum), 'the low branch sums before the output filters');
+  assert.ok(highRoute?.includes(node.bandSum), 'the high branch sums before the output filters');
+  assert.ok(
+    lowRoute.slice(lowRoute.indexOf(node.bandSum)).includes(node.highPass) &&
+      highRoute.slice(highRoute.indexOf(node.bandSum)).includes(node.highPass),
+    'both branches see the same static filtering after the sum'
+  );
+  // The sweep is the one deliberate asymmetry: it colours the high branch only.
+  assert.ok(!lowRoute.includes(node.lowPass) && highRoute.includes(node.lowPass));
+});
+
+test('the element hands its volume to the graph rather than attenuating itself', () => {
+  const { element, node } = connectedElement();
+
+  assert.equal(element.volume, 1);
+  assert.equal(node.gain.gain.value, 0.5);
+});

--- a/test/connectLanAddress.test.js
+++ b/test/connectLanAddress.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { lanAddressCandidates } from '../electron/connect/orchardConnectServer.js';
+
+test('a Hyper-V host advertises the real NIC, not the virtual switch', () => {
+  const candidates = lanAddressCandidates({
+    'vEthernet (Default Switch)': [{ family: 'IPv4', internal: false, address: '172.20.112.1' }],
+    'Wi-Fi': [{ family: 'IPv4', internal: false, address: '192.168.1.42' }]
+  });
+
+  assert.equal(candidates[0], '192.168.1.42');
+  assert.deepEqual(candidates, ['192.168.1.42', '172.20.112.1']);
+});
+
+test('loopback, IPv6 and unleased interfaces never reach the QR code', () => {
+  const candidates = lanAddressCandidates({
+    lo: [{ family: 'IPv4', internal: true, address: '127.0.0.1' }],
+    eth0: [
+      { family: 'IPv6', internal: false, address: 'fe80::1' },
+      { family: 'IPv4', internal: false, address: '10.0.0.5' }
+    ],
+    eth1: [{ family: 'IPv4', internal: false, address: '169.254.9.9' }]
+  });
+
+  assert.deepEqual(candidates, ['10.0.0.5']);
+});
+
+test('a router-assigned address outranks a Docker bridge in the same private space', () => {
+  const candidates = lanAddressCandidates({
+    'docker0': [{ family: 'IPv4', internal: false, address: '172.17.0.1' }],
+    'Ethernet': [{ family: 'IPv4', internal: false, address: '172.16.4.9' }],
+    'Wi-Fi': [{ family: 'IPv4', internal: false, address: '10.1.2.3' }]
+  });
+
+  assert.deepEqual(candidates, ['10.1.2.3', '172.16.4.9', '172.17.0.1']);
+});
+
+test('nothing routable leaves no candidates for the pairing URL', () => {
+  assert.deepEqual(lanAddressCandidates({ lo: [{ family: 'IPv4', internal: true, address: '127.0.0.1' }] }), []);
+  assert.deepEqual(lanAddressCandidates({}), []);
+});

--- a/test/crossfadeMixer.test.js
+++ b/test/crossfadeMixer.test.js
@@ -55,6 +55,8 @@ function mixNode() {
   return {
     gain: { gain: audioParam() },
     mixGain: { gain: audioParam() },
+    directBand: { gain: audioParam() },
+    splitInput: { gain: audioParam() },
     bassGain: { gain: audioParam() },
     midDuck: { gain: audioParam() },
     highPass: { context, frequency: audioParam() },
@@ -311,6 +313,68 @@ test('non-DJ styles stay a plain equal-power fade', () => {
   assert.deepEqual(fromNode.midDuck.gain.events, []);
   assert.deepEqual(fromNode.lowPass.frequency.events, []);
   assert.ok(lastCurve(toNode.mixGain.gain));
+});
+
+function splitTarget(node) {
+  return {
+    direct: node.directBand.gain.events.filter((event) => event.type === 'target').at(-1)?.value,
+    split: node.splitInput.gain.events.filter((event) => event.type === 'target').at(-1)?.value
+  };
+}
+
+// The crossover sums to an allpass, so leaving it in circuit costs transient
+// headroom without changing the response. A fade that never automates the
+// bands must not pay for it.
+test('a plain crossfade leaves both decks off the band split', () => {
+  const { fromAudio, toAudio, fromNode, toNode, mixer } = pair(0);
+
+  mixer.scheduleCrossfade({
+    fromAudio,
+    toAudio,
+    duration: 5,
+    transitionStyle: 'equal_power',
+    leadTime: 0
+  });
+
+  assert.deepEqual(splitTarget(fromNode), { direct: 1, split: 0 });
+  assert.deepEqual(splitTarget(toNode), { direct: 1, split: 0 });
+});
+
+test('a DJ transition engages the band split on both decks before its curves run', () => {
+  const now = 50;
+  const leadTime = 0.05;
+  const { fromAudio, toAudio, fromNode, toNode, mixer } = pair(now);
+
+  const timing = mixer.scheduleCrossfade({
+    fromAudio,
+    toAudio,
+    duration: 8,
+    transitionStyle: 'dj_blend',
+    bassSwap: true,
+    leadTime
+  });
+
+  assert.deepEqual(splitTarget(fromNode), { direct: 0, split: 1 });
+  assert.deepEqual(splitTarget(toNode), { direct: 0, split: 1 });
+
+  // Armed from now, and settled well inside the lead time -- five time
+  // constants is over 99% of the way across -- so neither deck is still
+  // straddling the two paths when the first scheduled value lands.
+  const arming = fromNode.splitInput.gain.events.at(-1);
+  assert.equal(arming.time, now);
+  assert.ok(arming.constant * 5 < timing.startTime - now);
+});
+
+test('resetting a mix returns the deck to the unsplit path', () => {
+  const element = {};
+  const node = mixNode();
+  const mixer = createCrossfadeMixer({ connectElement: () => node, currentTime: () => 7 });
+
+  node.directBand.gain.setTargetAtTime(0, 1, 0.006);
+  node.splitInput.gain.setTargetAtTime(1, 1, 0.006);
+  mixer.resetElement(element);
+
+  assert.deepEqual(splitTarget(node), { direct: 1, split: 0 });
 });
 
 test('resetting a mix cancels its envelope without changing the master volume', () => {

--- a/test/immersiveVeil.test.js
+++ b/test/immersiveVeil.test.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  VEIL_MAX_ALPHA,
+  VEIL_MIN_ALPHA,
+  VEIL_MUTED_CONTRAST,
+  VEIL_TEXT_CONTRAST,
+  compositeBackdrop,
+  contrastRatio,
+  solveVeilAlpha
+} from '../src/app/appearance/immersiveVeil.js';
+
+const DARK = {
+  veilRgb: [3, 7, 4],
+  pageRgb: [0, 0, 0],
+  textRgb: [246, 246, 246],
+  mutedRgb: [141, 141, 141]
+};
+
+const LIGHT = {
+  veilRgb: [248, 250, 248],
+  pageRgb: [244, 246, 244],
+  textRgb: [20, 23, 20],
+  mutedRgb: [104, 112, 105],
+  minAlpha: 0.7
+};
+
+function readable(theme, artworkRgb, veilAlpha) {
+  const backdrop = compositeBackdrop({ ...theme, artworkRgb, veilAlpha });
+  return {
+    text: contrastRatio(theme.textRgb, backdrop),
+    muted: contrastRatio(theme.mutedRgb, backdrop)
+  };
+}
+
+test('relative luminance matches the WCAG reference points', () => {
+  assert.equal(relativeLuminanceOf([255, 255, 255]).toFixed(4), '1.0000');
+  assert.equal(relativeLuminanceOf([0, 0, 0]).toFixed(4), '0.0000');
+  assert.equal(contrastRatio([255, 255, 255], [0, 0, 0]).toFixed(1), '21.0');
+});
+
+function relativeLuminanceOf(rgb) {
+  // Derived through the exported ratio so the test does not duplicate the table.
+  return (contrastRatio(rgb, [0, 0, 0]) * 0.05) - 0.05;
+}
+
+test('a dark cover keeps the veil it already had', () => {
+  const alpha = solveVeilAlpha({ ...DARK, artworkRgb: [18, 22, 19] });
+  assert.equal(alpha, VEIL_MIN_ALPHA);
+});
+
+// The reported case: a mid-grey cover under the old fixed veil composited to
+// roughly the lightness of the secondary text.
+test('a grey cover is unreadable at the old fixed veil and readable after solving', () => {
+  const grey = [150, 150, 150];
+
+  const before = readable(DARK, grey, VEIL_MIN_ALPHA);
+  assert.ok(before.muted < VEIL_MUTED_CONTRAST, `secondary text was already fine at ${before.muted.toFixed(2)}:1`);
+
+  const alpha = solveVeilAlpha({ ...DARK, artworkRgb: grey });
+  const after = readable(DARK, grey, alpha);
+  assert.ok(alpha > VEIL_MIN_ALPHA);
+  assert.ok(after.text >= VEIL_TEXT_CONTRAST, `body text at ${after.text.toFixed(2)}:1`);
+  assert.ok(after.muted >= VEIL_MUTED_CONTRAST, `secondary text at ${after.muted.toFixed(2)}:1`);
+});
+
+test('the solved veil is the smallest one that works, not the heaviest', () => {
+  const grey = [150, 150, 150];
+  const alpha = solveVeilAlpha({ ...DARK, artworkRgb: grey });
+  const lighter = readable(DARK, grey, alpha - 0.02);
+
+  assert.ok(alpha < VEIL_MAX_ALPHA);
+  assert.ok(
+    lighter.text < VEIL_TEXT_CONTRAST || lighter.muted < VEIL_MUTED_CONTRAST,
+    'a lighter veil would also have passed, so the solve is not minimal'
+  );
+});
+
+test('even a white cover is solved inside the ceiling, so artwork stays visible', () => {
+  const alpha = solveVeilAlpha({ ...DARK, artworkRgb: [255, 255, 255] });
+  const after = readable(DARK, [255, 255, 255], alpha);
+
+  assert.ok(alpha < VEIL_MAX_ALPHA, `the hardest case needed ${alpha.toFixed(3)}`);
+  assert.ok(after.text >= VEIL_TEXT_CONTRAST);
+  assert.ok(after.muted >= VEIL_MUTED_CONTRAST);
+});
+
+test('the light theme never drops below the opacity it shipped with', () => {
+  const alpha = solveVeilAlpha({ ...LIGHT, artworkRgb: [250, 250, 250], minAlpha: LIGHT.minAlpha });
+  assert.ok(alpha >= LIGHT.minAlpha);
+});
+
+test('a dark cover under the light theme is pushed lighter, not darker', () => {
+  const dark = [12, 14, 12];
+  const alpha = solveVeilAlpha({ ...LIGHT, artworkRgb: dark, minAlpha: LIGHT.minAlpha });
+  const after = readable({ ...LIGHT }, dark, alpha);
+
+  assert.ok(alpha > LIGHT.minAlpha, 'the floor alone cannot carry a near-black cover');
+  assert.ok(after.text >= VEIL_TEXT_CONTRAST, `body text at ${after.text.toFixed(2)}:1`);
+});
+
+test('a heavier background intensity is accounted for rather than ignored', () => {
+  const grey = [150, 150, 150];
+  const light = solveVeilAlpha({ ...DARK, artworkRgb: grey, backgroundOpacity: 0.5 });
+  const heavy = solveVeilAlpha({ ...DARK, artworkRgb: grey, backgroundOpacity: 1 });
+
+  assert.ok(heavy > light, 'a more opaque artwork layer needs a heavier veil');
+});

--- a/test/musicTextNormalization.test.js
+++ b/test/musicTextNormalization.test.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { normalizedLooseText, textMatchesArtist, textMatchesTitle } from '../electron/catalog/musicText.js';
+import { createArtistCatalog } from '../electron/catalog/artistCatalog.js';
+
+test('loose text keeps an identity for titles written in any script', () => {
+  for (const title of ['梦醒时分', '小幸运', '夜長夢多', '告五人', 'ロード', 'Пыяла', '아이유']) {
+    assert.notEqual(normalizedLooseText(title), '', `${title} lost its identity`);
+  }
+
+  // Distinct titles must stay distinct. Collapsing them to one key is the other
+  // half of the same bug: it deduplicates a whole catalogue down to one release.
+  assert.notEqual(normalizedLooseText('夜長夢多'), normalizedLooseText('小幸運'));
+  assert.ok(textMatchesArtist('梦梦', '梦梦'));
+  assert.ok(textMatchesTitle('漂浮', '漂浮'));
+});
+
+test('loose text still folds punctuation, case, and ampersands the way it did', () => {
+  assert.equal(normalizedLooseText('AC/DC'), 'ac dc');
+  assert.equal(normalizedLooseText('Tom & Jerry'), 'tom and jerry');
+  assert.equal(normalizedLooseText('  Hello!!  '), 'hello');
+  assert.equal(normalizedLooseText('Waa Wei'), 'waa wei');
+});
+
+test('loose text folds Latin accents without folding Japanese voiced kana', () => {
+  assert.equal(normalizedLooseText('Sigur Rós'), 'sigur ros');
+  assert.ok(textMatchesTitle('Beyonce', 'Beyoncé'));
+  // Stripping every combining mark would turn "da" into "ta" and match two
+  // different words, so the fold is limited to the Latin range.
+  assert.notEqual(normalizedLooseText('ただ'), normalizedLooseText('たた'));
+});
+
+function artistCatalog() {
+  return createArtistCatalog({
+    asText: (value) => String(value || ''),
+    artistBrowseSectionItemMatches: () => true,
+    browseContinuationTokenFromData: () => '',
+    dedupeMediaItems: (items) => [...new Map(items.map((item) => [item.id || item.browseId, item])).values()],
+    isSingleOrEpRelease: (item) => item.kind === 'single',
+    itemMatchesReleaseSection: () => true,
+    mergeTrackMetadata: (track) => track,
+    normalizeAlbum: (album, browseId) => ({ ...album, browseId }),
+    normalizeBrowseSection: (section) => section,
+    normalizeRawBrowseItem: (item) => item,
+    // The real one, because this regression lives entirely in what it returns.
+    normalizedLooseText,
+    rawBrowseDescription: () => '',
+    rawBrowseItemsFromData: () => [],
+    rawBrowseThumbnail: () => '',
+    rawHeader: (artist) => artist.header,
+    rawMicroformat: () => ({}),
+    rawSectionList: (artist) => artist.sections,
+    searchArtistShelfFallback: async () => [],
+    searchTrackAlbumMetadata: async () => null
+  });
+}
+
+test('an artist keeps every release whose title carries no Latin characters', async () => {
+  const collection = {
+    browseId: 'mengmeng',
+    data: {
+      header: { title: '梦梦' },
+      sections: [{
+        title: 'Albums',
+        items: [
+          { browseId: 'a1', title: '梦醒时分', kind: 'album' },
+          { browseId: 'a2', title: '小幸运', kind: 'album' },
+          { browseId: 'a3', title: '漂浮', kind: 'album' },
+          { browseId: 'a4', title: 'Waa Wei', kind: 'album' }
+        ]
+      }]
+    }
+  };
+
+  const detail = await artistCatalog().normalizeArtist(collection);
+
+  assert.deepEqual(
+    detail.sections[0].items.map((item) => item.title),
+    ['梦醒时分', '小幸运', '漂浮', 'Waa Wei'],
+    'releases were dropped or collapsed by an empty identity key'
+  );
+});

--- a/test/networkPreferences.test.js
+++ b/test/networkPreferences.test.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import {
+  DEFAULT_PROXY_MODE,
+  normalizeProxyMode,
+  proxyConfigForMode,
+  registerNetworkPreferences
+} from '../electron/platform/networkPreferences.js';
+import { IPC_CHANNELS } from '../shared/ipcChannels.js';
+
+function harness(userDataPath) {
+  const handlers = new Map();
+  const applied = [];
+  return {
+    applied,
+    invoke: (channel, ...args) => handlers.get(channel)(null, ...args),
+    deps: {
+      app: { getPath: () => userDataPath },
+      ipcMain: { handle: (channel, handler) => handlers.set(channel, handler) },
+      session: {
+        defaultSession: {
+          setProxy: async (config) => { applied.push(config); }
+        }
+      }
+    }
+  };
+}
+
+test('an unknown or missing proxy mode follows the system', () => {
+  assert.equal(normalizeProxyMode(undefined), 'system');
+  assert.equal(normalizeProxyMode('socks5://somewhere'), 'system');
+  assert.equal(normalizeProxyMode(''), 'system');
+  assert.equal(DEFAULT_PROXY_MODE, 'system');
+  assert.deepEqual(proxyConfigForMode('direct'), { mode: 'direct' });
+  assert.deepEqual(proxyConfigForMode('system'), { mode: 'system' });
+});
+
+test('a fresh install leaves the system proxy in charge', async () => {
+  const userData = await mkdtemp(path.join(tmpdir(), 'orchard-network-'));
+  const { deps, applied } = harness(userData);
+
+  const preferences = registerNetworkPreferences(deps);
+  assert.equal(await preferences.restore(), 'system');
+  assert.deepEqual(applied, [{ mode: 'system' }]);
+});
+
+test('a stored bypass is applied before anything asks for a window', async () => {
+  const userData = await mkdtemp(path.join(tmpdir(), 'orchard-network-'));
+  const first = harness(userData);
+  const preferences = registerNetworkPreferences(first.deps);
+  await preferences.restore();
+
+  assert.equal(await first.invoke(IPC_CHANNELS.NETWORK.SET_PROXY_MODE, 'direct'), 'direct');
+  assert.deepEqual(first.applied.at(-1), { mode: 'direct' });
+  assert.equal(await first.invoke(IPC_CHANNELS.NETWORK.GET_PROXY_MODE), 'direct');
+
+  const stored = JSON.parse(await readFile(path.join(userData, 'network-preferences.json'), 'utf8'));
+  assert.deepEqual(stored, { proxyMode: 'direct' });
+
+  // The next launch reads the same file, so artwork requested by the opening
+  // window already skips the proxy.
+  const second = harness(userData);
+  assert.equal(await registerNetworkPreferences(second.deps).restore(), 'direct');
+  assert.deepEqual(second.applied, [{ mode: 'direct' }]);
+});
+
+test('a junk proxy mode is never written back to disk', async () => {
+  const userData = await mkdtemp(path.join(tmpdir(), 'orchard-network-'));
+  const { deps, invoke, applied } = harness(userData);
+  registerNetworkPreferences(deps);
+
+  assert.equal(await invoke(IPC_CHANNELS.NETWORK.SET_PROXY_MODE, 'http://evil.example'), 'system');
+  assert.deepEqual(applied.at(-1), { mode: 'system' });
+
+  const stored = JSON.parse(await readFile(path.join(userData, 'network-preferences.json'), 'utf8'));
+  assert.deepEqual(stored, { proxyMode: 'system' });
+});

--- a/test/updateErrors.test.js
+++ b/test/updateErrors.test.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isProxyUpdateError, updateErrorMessage } from '../electron/integrations/updateErrors.js';
+
+test('a dead system proxy is named as the cause, not left as a net:: code', () => {
+  const message = updateErrorMessage(new Error('net::ERR_TUNNEL_CONNECTION_FAILED'));
+
+  assert.match(message, /system proxy/);
+  assert.match(message, /net::ERR_TUNNEL_CONNECTION_FAILED/);
+  // Artwork fails through the same stack, so the report explains both at once.
+  assert.match(message, /Album art/);
+  assert.match(message, /Ignore system proxy/);
+});
+
+test('every Chromium proxy failure routes to the proxy explanation', () => {
+  for (const code of [
+    'net::ERR_TUNNEL_CONNECTION_FAILED',
+    'net::ERR_PROXY_CONNECTION_FAILED',
+    'net::ERR_PROXY_AUTH_UNSUPPORTED',
+    'net::ERR_MANDATORY_PROXY_CONFIGURATION_FAILED',
+    'net::ERR_PROXY_CERTIFICATE_INVALID'
+  ]) {
+    assert.equal(isProxyUpdateError(code), true, code);
+  }
+});
+
+test('ordinary failures are reported verbatim', () => {
+  assert.equal(isProxyUpdateError(new Error('net::ERR_INTERNET_DISCONNECTED')), false);
+  assert.equal(updateErrorMessage(new Error('net::ERR_INTERNET_DISCONNECTED')), 'net::ERR_INTERNET_DISCONNECTED');
+  assert.equal(updateErrorMessage('HTTP 404'), 'HTTP 404');
+  assert.equal(updateErrorMessage(null), 'Update check failed.');
+  assert.equal(updateErrorMessage(''), 'Update check failed.');
+});


### PR DESCRIPTION
Six reported issues, plus one audio bug found while looking into #77.

### Reported issues

- **Fixes #80** ,Play uploaded library tracks on Android.
- **Fixes #81** ,Keep internal track lookups out of YouTube search history.
- **Fixes #82** ,Show a collection as its pages arrive on Android, rather than after the last page.
- **Fixes #83** ,Let Orchard ignore an unreachable system proxy. Artwork and update checks resolve the system proxy while playback does not, so a dead proxy broke images and updates while music kept playing.
- **Fixes #84** ,Advertise a reachable LAN address for Orchard Connect.
- **Fixes #85** ,Keep the fullscreen transport on screen on short displays.

### Audio path

**Refs #77.** The gain complaint in that thread was fixed separately, but the muffling and distortion reported underneath it were a second bug.

Orchard splits the signal at 200 Hz so a DJ-style transition can hand the low end over exclusively. Only three transition styles automate that network, yet it was wired into every element unconditionally, so ordinary playback ran through it on every track.

An LR4 low/high pair sums to an allpass. Magnitude stays flat within 0.03 dB, which is why this never read as a tone balance problem and why checking the EQ and the gains found nothing. It does shift phase across the low mids, and that grows transient peaks at unchanged level. Measured through the filters' own coefficients on real audio it added 0.7 to 3.4 dB of peak. On one master already sitting at +0.25 dBFS it pushed 1017 samples past full scale. Anything mastered near 0 dBFS was clipping on transients with the audio engine off and every gain at unity.

The mix envelope now has a direct path to the output carrying no filters at all, and the crossover sits behind a gain the mixer opens only for the styles that use it. The static output pair moved after the branch sum so the two halves stay phase matched. The sweep filter stays on the high branch by design.

### Also

- Route renderer clipboard writes through the main process.

### Testing

444 tests pass. The audio graph had no coverage, so this adds some, and the mixer's node stub was missing the new gains, which would have let the arming assertions pass without testing anything.

The audio fix is verified by measurement and tests rather than by ear. Worth a listen on a loud master with the engine off before release. The allpass headroom cost still applies during DJ transitions where the split is genuinely in use, bounded there by the mid duck and the equal-power fade, so I left that alone.