### PR TITLE
Backport 2.0.0 mobile Playback fix

### DIFF
--- a/mobile/android/app/build.gradle
+++ b/mobile/android/app/build.gradle
@@ -15,9 +15,9 @@ android {
         applicationId = 'dev.sfg.orchard.mobile'
         minSdk = 31
         targetSdk = 36
-        versionCode = 10900
-        versionName = '1.9.0'
-        buildConfigField 'String', 'CODENAME', '"Rustic Bipedal"'
+        versionCode = 10901
+        versionName = '1.9.1'
+        buildConfigField 'String', 'CODENAME', '"Journeyman Anthology"'
         // Only the build that is actually published may offer updates. Every other
         // build has its own applicationId, so the published APK is neither an
         // upgrade nor installable over it.

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/MobileChangelog.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/MobileChangelog.kt
@@ -28,11 +28,9 @@ object MobileChangelog {
 
     val CURRENT_RELEASE_NOTES =
         """
-        ### Added
-        - **Beta Channel**: Opt in to receive beta builds directly from GitHub releases with prerelease semver update checks and release notes.
-
-        ### Changed
-        - Updated markdown library to 0.7.9.
+        ### Fixed
+        - **Public Stream Playback**: Fixed public YouTube tracks failing with CDN errors by routing every quality tier through NewPipe while preserving the selected bitrate.
+        - **Public Stream Downloads**: Downloads now use the same quality-aware public resolver as playback, while account-only uploads retain the Innertube fallback.
         """
             .trimIndent()
 }

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/DownloadManager.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/DownloadManager.kt
@@ -237,7 +237,7 @@ class DownloadManager(
 
     companion object {
         private const val TAG = "DownloadManager"
-        // MAX-quality tracks may use four bounded range requests each. Three tracks keeps enough
+        // NewPipe-resolved tracks may use four bounded range requests each. Three tracks keeps enough
         // parallelism to beat per-connection throttling without creating a request storm.
         private const val MAX_CONCURRENT_DOWNLOADS = 3
         private const val MAX_DOWNLOAD_ATTEMPTS = 6

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/TrackDownloader.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/download/TrackDownloader.kt
@@ -43,8 +43,8 @@ import kotlin.coroutines.coroutineContext
 /**
  * Downloads audio tracks through the same client-profile resolver used for playback.
  *
- * NewPipe is intentionally absent from the retry path. [YouTubeStreamResolver] invokes it only
- * when the user explicitly selects [AudioQuality.MAX]; every other quality remains Innertube-only.
+ * Public tracks use NewPipe through [YouTubeStreamResolver], with Innertube retained for
+ * extraction failures and account-only uploads. The selected [AudioQuality] is preserved.
  */
 class TrackDownloader(
     private val http: OkHttpClient,

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/NewPipeStreamResolver.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/NewPipeStreamResolver.kt
@@ -20,6 +20,7 @@
 package dev.sfg.orchard.mobile.playback
 
 import android.util.Log
+import dev.sfg.orchard.mobile.model.AudioQuality
 import okhttp3.OkHttpClient
 import org.schabi.newpipe.extractor.NewPipe
 import org.schabi.newpipe.extractor.ServiceList
@@ -28,12 +29,12 @@ import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.util.concurrent.TimeUnit
 
 /**
- * Resolves the highest-bitrate audio stream for a YouTube video using NewPipeExtractor.
+ * Resolves an audio stream for a YouTube video using NewPipeExtractor.
  *
  * NewPipe extracts streams by parsing the YouTube web page directly, which often exposes
  * higher-bitrate Opus streams (up to ~320 kbps) that the innertube player API withholds.
  * This class is the sole consumer of NewPipeExtractor in the app; it lives behind
- * [YouTubeStreamResolver] and is called only when the user selects MAX quality.
+ * [YouTubeStreamResolver], which uses it for public tracks and keeps Innertube as the fallback.
  */
 class NewPipeStreamResolver(
     client: OkHttpClient,
@@ -50,27 +51,32 @@ class NewPipeStreamResolver(
     }
 
     /**
-     * Extracts the best audio stream for [videoId].
+     * Extracts the best audio stream for [videoId] within [quality]'s bitrate tier.
      *
      * @return a [ResolvedStream] with the CDN URL, or `null` when extraction fails.
      */
-    fun resolve(videoId: String): ResolvedStream? = runCatching {
+    fun resolve(
+        videoId: String,
+        quality: AudioQuality = AudioQuality.MAX,
+    ): ResolvedStream? = runCatching {
         val url = "https://www.youtube.com/watch?v=$videoId"
         val extractor = ServiceList.YouTube.getStreamExtractor(url)
         extractor.fetchPage()
         val streams: List<AudioStream> = extractor.audioStreams.orEmpty()
-        val best = streams
-            .filter { it.content.isNotBlank() }
-            .maxByOrNull { it.averageBitrate }
-            ?: return null
+        val playable = streams.filter { it.content.isNotBlank() }
+        val selectedIndex = selectNewPipeStreamIndex(
+            playable.map { it.averageBitrate },
+            quality,
+        ) ?: return null
+        val best = playable[selectedIndex]
         val format = runCatching { best.format }.getOrNull()
         val identity = YouTubeStreamRequestIdentity.fromUrl(
             best.content,
             YouTubeStreamRequestIdentity.WEB_USER_AGENT,
         )
+        val bitrateKbps = newPipeBitrateKbps(best.averageBitrate)
         Log.d(TAG, "NewPipe resolved ${format?.name ?: "?"} " +
-            "@${best.averageBitrate}kbps for $videoId")
-        val bitrateKbps = if (best.averageBitrate > 1000) best.averageBitrate / 1000 else best.averageBitrate
+            "@${bitrateKbps}kbps for $videoId (${quality.name})")
         val contentLength = best.itagItem?.contentLength?.takeIf { it > 0L }
             ?: best.content.toHttpUrlOrNull()?.queryParameter("clen")?.toLongOrNull()
             ?: 0L
@@ -98,3 +104,33 @@ class NewPipeStreamResolver(
         @Volatile private var initialized = false
     }
 }
+
+internal fun newPipeBitrateKbps(rawBitrate: Int): Int =
+    (if (rawBitrate > 1_000) rawBitrate / 1_000 else rawBitrate).coerceAtLeast(0)
+
+/** Returns the stream index that best preserves Orchard's four quality tiers. */
+internal fun selectNewPipeStreamIndex(
+    rawBitrates: List<Int>,
+    quality: AudioQuality,
+): Int? {
+    if (rawBitrates.isEmpty()) return null
+    val bitrates = rawBitrates.map(::newPipeBitrateKbps)
+    val known = bitrates.indices.filter { bitrates[it] > 0 }
+    val candidates = known.ifEmpty { bitrates.indices.toList() }
+    val capped = when (quality) {
+        AudioQuality.DATA_SAVER -> emptyList()
+        AudioQuality.NORMAL -> candidates.filter { bitrates[it] <= NORMAL_MAX_KBPS }
+        AudioQuality.HIGH -> candidates.filter { bitrates[it] <= HIGH_MAX_KBPS }
+        AudioQuality.MAX -> candidates
+    }
+    return when (quality) {
+        AudioQuality.DATA_SAVER -> candidates.minByOrNull { bitrates[it] }
+        AudioQuality.NORMAL, AudioQuality.HIGH ->
+            capped.maxByOrNull { bitrates[it] }
+                ?: candidates.minByOrNull { bitrates[it] }
+        AudioQuality.MAX -> candidates.maxByOrNull { bitrates[it] }
+    }
+}
+
+private const val NORMAL_MAX_KBPS = 140
+private const val HIGH_MAX_KBPS = 160

--- a/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeStreamResolver.kt
+++ b/mobile/android/app/src/main/java/dev/sfg/orchard/mobile/playback/YouTubeStreamResolver.kt
@@ -52,7 +52,7 @@ data class ResolvedStream(
     val referer: String? = null,
     /** Stable key used to avoid immediately retrying a CDN-rejected client profile. */
     val clientKey: String = "",
-    /** NewPipe/MAX URLs can safely be fetched as independent bounded ranges. */
+    /** NewPipe URLs can safely be fetched as independent bounded ranges. */
     val supportsParallelRanges: Boolean = false,
 ) {
     val requestHeaders: Map<String, String>
@@ -212,22 +212,29 @@ class YouTubeStreamResolver(
         val cacheKey = "$videoId:${quality.name}"
         cached(cacheKey)?.let { return it }
         var maxQualityFallback = false
-        // MAX uses NewPipe for the highest bitrate stream. NewPipe reads the public watch page,
-        // which does not exist for an upload, so that path is skipped rather than paid for.
-        if (quality == AudioQuality.MAX && videoId !in accountOnlyVideos) {
-            val newPipeStream = newPipeResolver.resolve(videoId)
+        // Public watch-page extraction is the primary path for every quality tier. The native
+        // Innertube clients can still mint plausible googlevideo URLs while the CDN rejects every
+        // byte with 403; NewPipe's WEB URL remains fetchable and also avoids waiting on a failed
+        // PO-token warm-up. Uploads have no public watch page, so they stay on signed-in Innertube.
+        if (videoId !in accountOnlyVideos) {
+            val newPipeStream = newPipeResolver.resolve(videoId, quality)
             if (newPipeStream != null) {
                 streams[cacheKey] = newPipeStream
                 return newPipeStream
             }
-            // NewPipe failed; fall back to HIGH. We only warn the user if HIGH resolution actually succeeds.
-            Log.w(TAG, "NewPipe extraction failed for $videoId; attempting fallback to HIGH quality")
-            maxQualityFallback = true
-            val fallbackKey = "$videoId:${AudioQuality.HIGH.name}"
-            cached(fallbackKey)?.let {
-                onWarning?.invoke("Max quality unavailable, using High")
-                streams[cacheKey] = it
-                return it
+            if (quality == AudioQuality.MAX) {
+                // MAX has no Innertube equivalent, so its fallback is HIGH. Warn only if that
+                // fallback resolves successfully rather than showing a misleading early toast.
+                Log.w(TAG, "NewPipe extraction failed for $videoId; attempting fallback to HIGH quality")
+                maxQualityFallback = true
+                val fallbackKey = "$videoId:${AudioQuality.HIGH.name}"
+                cached(fallbackKey)?.let {
+                    onWarning?.invoke("Max quality unavailable, using High")
+                    streams[cacheKey] = it
+                    return it
+                }
+            } else {
+                Log.w(TAG, "NewPipe extraction failed for $videoId; attempting Innertube fallback")
             }
         }
         // Only one caller resolves a given track; a prefetch already in flight is worth
@@ -315,8 +322,8 @@ class YouTubeStreamResolver(
                 }
             }
 
-            // Signed web playback remains the last normal fallback for account-only or
-            // age-gated music. It is never replaced with NewPipe; NewPipe belongs to MAX only.
+            // Signed web playback remains the last fallback for account-only or age-gated music.
+            // NewPipe cannot replace it because those tracks do not have a usable public page.
             // Deliberately outside the budget check: this is the only client that can play
             // account-only music, and dropping it because the guest attempts ran long turns a
             // playable upload into "Video unavailable".

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/playback/NewPipeStreamResolverTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/playback/NewPipeStreamResolverTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 SFG545
+ *
+ * This file is part of Orchard.
+ *
+ * Orchard is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option) any
+ * later version.
+ *
+ * Orchard is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Orchard. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package dev.sfg.orchard.mobile.playback
+
+import dev.sfg.orchard.mobile.model.AudioQuality
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class NewPipeStreamResolverTest {
+    private val bitrates = listOf(50, 128, 160, 251)
+
+    @Test
+    fun `quality tiers select the intended NewPipe bitrate`() {
+        assertEquals(50, selectedBitrate(AudioQuality.DATA_SAVER))
+        assertEquals(128, selectedBitrate(AudioQuality.NORMAL))
+        assertEquals(160, selectedBitrate(AudioQuality.HIGH))
+        assertEquals(251, selectedBitrate(AudioQuality.MAX))
+    }
+
+    @Test
+    fun `raw bitrates reported in bits per second are normalized`() {
+        val raw = listOf(50_000, 128_000, 160_000, 251_000)
+
+        val index = selectNewPipeStreamIndex(raw, AudioQuality.HIGH)
+
+        assertEquals(160_000, raw[index!!])
+        assertEquals(160, newPipeBitrateKbps(raw[index]))
+    }
+
+    @Test
+    fun `tier falls back to the lowest stream when every bitrate exceeds its cap`() {
+        val raw = listOf(251, 320)
+
+        assertEquals(0, selectNewPipeStreamIndex(raw, AudioQuality.NORMAL))
+    }
+
+    @Test
+    fun `empty stream list has no selection`() {
+        assertNull(selectNewPipeStreamIndex(emptyList(), AudioQuality.MAX))
+    }
+
+    private fun selectedBitrate(quality: AudioQuality): Int {
+        val index = selectNewPipeStreamIndex(bitrates, quality)
+        return bitrates[index!!]
+    }
+}

--- a/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/ui/components/UpdateDialogParserTest.kt
+++ b/mobile/android/app/src/test/java/dev/sfg/orchard/mobile/ui/components/UpdateDialogParserTest.kt
@@ -119,14 +119,18 @@ class UpdateDialogParserTest {
         val notes = dev.sfg.orchard.mobile.MobileChangelog.CURRENT_RELEASE_NOTES
         val sections = parseReleaseNoteSections(notes)
 
-        assertEquals(2, sections.size)
-        assertEquals("Added", sections[0].title)
-        assertEquals(ReleaseNoteCategory.NEW, sections[0].category)
-        assertEquals(1, sections[0].items.size)
-
-        assertEquals("Changed", sections[1].title)
-        assertEquals(ReleaseNoteCategory.CHANGED, sections[1].category)
-        assertEquals(1, sections[1].items.size)
+        assertEquals(1, sections.size)
+        assertEquals("Fixed", sections[0].title)
+        assertEquals(ReleaseNoteCategory.FIXED, sections[0].category)
+        assertEquals(2, sections[0].items.size)
+        assertEquals(
+            "**Public Stream Playback**: Fixed public YouTube tracks failing with CDN errors by routing every quality tier through NewPipe while preserving the selected bitrate.",
+            sections[0].items[0],
+        )
+        assertEquals(
+            "**Public Stream Downloads**: Downloads now use the same quality-aware public resolver as playback, while account-only uploads retain the Innertube fallback.",
+            sections[0].items[1],
+        )
     }
 
     @Test

--- a/mobile/release-notes.md
+++ b/mobile/release-notes.md
@@ -1,9 +1,6 @@
-## Orchard Mobile 1.9.0 "Rustic Bipedal"
+## Orchard Mobile 1.9.1 "Journeyman Anthology"
 
-### Added
-- **Beta Channel**: Opt in to receive beta builds directly from GitHub releases with prerelease semver update checks and release notes.
-
-### Maintenance
-- Updated markdown library to 0.7.9.
-
+### Fixed
+- **Public Stream Playback**: Fixed public YouTube tracks failing with CDN errors by routing every quality tier through NewPipe while preserving the selected bitrate.
+- **Public Stream Downloads**: Downloads now use the same quality-aware public resolver as playback, while account-only uploads retain the Innertube fallback.
 


### PR DESCRIPTION
### Overview
Backports mobile playback fixes from version 2.0.0 into stable mobile, routing public streams through NewPipe.

### Changes
* Routes public mobile streams through NewPipe to resolve playback issues.

### Testing
* Verified public stream playback works as expected on mobile.